### PR TITLE
Create filterPositionClass helper for the ui

### DIFF
--- a/pkg/ui/.storybook/main.js
+++ b/pkg/ui/.storybook/main.js
@@ -24,7 +24,7 @@ module.exports = {
   webpackFinal: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      "@": path.join(__dirname, "..", "src"),
+      "@assets": path.join(__dirname, "..", "src", "assets"),
     };
 
     const fileLoaderRule = config.module.rules.find(

--- a/pkg/ui/src/__tests__/utils.test.ts
+++ b/pkg/ui/src/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import { filterPositionClass } from "../utils/styles";
+
+describe("UI utils", () => {
+  describe("filterPositionClass", () => {
+    test("should filter the position class from 'baseClasses' array", () => {
+      const baseClasses = ["mx-4", "w-2", "relative"];
+      const res = filterPositionClass("absolute mx-2", baseClasses);
+      expect(res).toEqual(["mx-4", "w-2"]);
+    });
+  });
+});

--- a/pkg/ui/src/components/SideNavButton/SideNavButton.tsx
+++ b/pkg/ui/src/components/SideNavButton/SideNavButton.tsx
@@ -1,5 +1,7 @@
 import React, { HTMLAttributes } from "react";
 
+import { filterPositionClass } from "../../utils/styles";
+
 interface SideNavButtonProps extends HTMLAttributes<HTMLButtonElement> {
   /**
    * A boolean flag used to switch styles for a selected button.
@@ -20,7 +22,7 @@ const onClickFallback = (e: React.SyntheticEvent) => {
  */
 const SideNavButton: React.FC<SideNavButtonProps> = ({
   children,
-  className: classes,
+  className: classes = "",
   selected,
   as: htmlTag = "button", // 'as' used to be reserved for TS, better to be safe
   onClick = onClickFallback,
@@ -39,10 +41,13 @@ const SideNavButton: React.FC<SideNavButtonProps> = ({
   const bgColor = selected ? "bg-gray-900" : "bg-none";
   const iconColor = selected ? "text-white" : "text-gray-400 hover:text-white";
 
-  const className = [...baseClasses, bgColor, iconColor, classes]
-    .join(" ")
-    .trim()
-    .replace(/%s%s/g, " ");
+  const filteredBaseClasses = filterPositionClass(classes, [
+    ...baseClasses,
+    bgColor,
+    iconColor,
+  ]);
+
+  const className = [...filteredBaseClasses, classes].join(" ").trim();
 
   // Icon box container with icon component passed as 'children'
   const iconBox = <div className="center-absolute w-4 h-4">{children}</div>;

--- a/pkg/ui/src/utils/styles.ts
+++ b/pkg/ui/src/utils/styles.ts
@@ -1,0 +1,22 @@
+const positionClasses = ["static", "relative", "absolute", "fixed", "sticky"];
+
+/**
+ * Checks input classes for position class, if provided, filters the position class from
+ * the base classes.
+ * @param {string} inputClasses CSS classes provided as 'className' prop to the component
+ * @param {Array<string>} baseClasses Array of tailwind classes used as component base
+ * @returns base classes with position class filtered out (if needed)
+ */
+export const filterPositionClass = (
+  inputClasses: string,
+  baseClasses: string[]
+): string[] => {
+  inputClasses.split(" ").forEach((className) => {
+    if (positionClasses.includes(className)) {
+      baseClasses = baseClasses.filter(
+        (baseClass) => !positionClasses.includes(baseClass)
+      );
+    }
+  });
+  return baseClasses;
+};


### PR DESCRIPTION
After hard think, complication and almost implementing a tree with classnames and a recursive merge of final classes into the final string, I've decided to go with the YAGNI principle and just created a `filterPositionClass` function which filters a position class ("absolute", "relative", etc.) from the base classes of the component, only if the position class is provided through `"className"` prop to the component itself.