### PR TITLE
Component test example

### DIFF
--- a/pkg/ui/src/Button/__tests__/Button.spec.ts
+++ b/pkg/ui/src/Button/__tests__/Button.spec.ts
@@ -5,7 +5,7 @@
 import { describe, test, vi, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/svelte';
 
-import Button from './Button.svelte';
+import TestComponent from './TestComponent.svelte';
 
 describe('Button', () => {
 	describe('smoke test', () => {
@@ -15,9 +15,9 @@ describe('Button', () => {
 
 		test('should propagate click event', () => {
 			const mockClick = vi.fn();
-			const { component } = render(Button);
+			const { component } = render(TestComponent, { slot: 'Button text' });
 			component.$on('click', mockClick);
-			screen.getByRole('button').click();
+			screen.getByText('Button text').click();
 
 			expect(mockClick).toHaveBeenCalled();
 		});

--- a/pkg/ui/src/Button/__tests__/TestComponent.svelte
+++ b/pkg/ui/src/Button/__tests__/TestComponent.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	/**
+	 * This is an example component used to test svelte components requiring the testing of <slot /> getting
+	 * passed to them.
+	 *
+	 * All the props are passed as 'props' (in svelte testing lobrary if would look something like this):
+	 * ```
+	 * render(Button, { props: { disabled: true } })
+	 * ```
+	 *
+	 * additionally, slot can be passed as 'slot' the render funciton, like so:
+	 * ```
+	 * render(Button, { props: { disabled: true }, slot: "Click me" })
+	 * ```
+	 *
+	 * The slot will get passed a an html child to the component (if text), or get rendered as
+	 * a svelte component using `<svelte:component this={slot}>`
+	 *
+	 * The events also get forwarded up, but one caveat is: each event needs to manually be forwarded.
+	 * There is a duscussion on the matter (a feature request) to forward all events, but it isn't in yet (as far as I'm aware).
+	 * You can track progress on this issue:
+	 *
+	 * https://github.com/sveltejs/svelte/issues/2837
+	 *
+	 */
+
+	import type { SvelteComponent } from 'svelte';
+
+	import Button from './Button.svelte';
+
+	export let props = {};
+	export let slot: SvelteComponent | string;
+</script>
+
+<Button {...props} on:click>
+	{#if !slot}
+		{null}
+	{:else if typeof slot === 'string'}
+		{slot}
+	{:else}
+		<svelte:component this={slot} />
+	{/if}
+</Button>

--- a/pkg/ui/svelte.config.js
+++ b/pkg/ui/svelte.config.js
@@ -1,6 +1,13 @@
 import adapter from '@sveltejs/adapter-auto';
 import preprocess from 'svelte-preprocess';
 
+const ignorePatterns = [
+	// Ignore stories files
+	'.stories',
+	// Ignore __tests__, __testUtils__, __testData__, etc.
+	'__test*'
+];
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://github.com/sveltejs/svelte-preprocess
@@ -15,8 +22,7 @@ const config = {
 		},
 		package: {
 			dir: 'dist',
-			// Exclude stories files from built package
-			files: (fp) => !/stories/.test(fp)
+			files: (fp) => ignorePatterns.every((p) => !new RegExp(p).test(fp))
 		}
 	}
 };


### PR DESCRIPTION
Svelte testing library is a bit limited when it comes to passing of "children" (or `<slot />` in svelte parlance) to the component. I've found a "good enough" way for unit testing (by writing a `TestComponent.svelte` next to the unit tests for the component). I believe this to be convenient enough as well as good folder architecture approach:
```
/Button
+-- __tests__
| +-- Button.spec.ts
| +-- TestComponent.svelte
+-- Button.svelte
+-- index.ts
```

Also, the test files are now excluded from the `package` build in `pkg/ui`