### PR TITLE
Fix/vitest setup deprecated config

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -143,7 +143,6 @@ importers:
       typescript: ^4.7.4
       vite: ^3.0.0
       vitest: ~0.21.1
-      vitest-svelte-kit: 0.0.6
     devDependencies:
       '@storybook/addon-actions': 6.4.22
       '@storybook/addon-essentials': 6.4.22_e54289f66234f332516dcff0a32fdf63
@@ -172,7 +171,6 @@ importers:
       typescript: 4.7.4
       vite: 3.0.4
       vitest: 0.21.1
-      vitest-svelte-kit: 0.0.6
 
   ../../pkg/ui-react:
     specifiers:
@@ -16951,11 +16949,6 @@ packages:
       rollup: 2.77.2
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /vitest-svelte-kit/0.0.6:
-    resolution: {integrity: sha512-bQ1GcCAk600YV1xOiJBhltGE/HO/j6FozNY2BFq2GP1mHh3pj0KrGZlyx0kVlXx+BSKDXQHuYZtwlHwNlvv0fQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: true
 
   /vitest/0.21.1:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6d3e7b40c8e5a9d5c1edc0432dcb4977422aa4fa",
+  "pnpmShrinkwrapHash": "6029e5ccb7fb78bc3098b215bbab54f69ea60b0c",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -42,7 +42,6 @@
 		"typescript": "^4.7.4",
 		"vite": "^3.0.0",
 		"vitest": "~0.21.1",
-		"vitest-svelte-kit": "0.0.6",
 		"svelte2tsx": "~0.5.13"
 	},
 	"type": "module"

--- a/pkg/ui/vitest.config.js
+++ b/pkg/ui/vitest.config.js
@@ -1,3 +1,0 @@
-import { extractFromSvelteConfig } from 'vitest-svelte-kit';
-
-export default extractFromSvelteConfig();

--- a/pkg/ui/vitest.config.ts
+++ b/pkg/ui/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	test: {
+		globals: true,
+		environment: 'jsdom',
+		deps: { inline: true }
+	}
+});


### PR DESCRIPTION
- use `vitest.config.ts` instead of `vitest.config.js`
- use vite config with `sveltekit` plugin instead of (deprecated) `vitest-svelte-kit` for vitest config
- allow 3rd party `.svelte` files in tests by inlining them (setting `deps: { inline: true }` in `vitest.config.ts`)