### PR TITLE
Feature/test ci ytt templates

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -10,7 +10,7 @@ name: Cheks
   - push
 
 jobs:
-  js-search-test: #@ test_job("JS-Search Tests", "pkg/js-search")
+  js-search-test: #@ test_job("JS-Search Tests", "pkg/js-search", "jest-junit")
 
   ui-test: #@ test_job("UI Tests", "pkg/ui")
 

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -2,6 +2,7 @@
 #@ load("rush.lib.yml", "rush_add_path")
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
+#@ load("test-job.lib.yml", "test_job")
 
 name: Cheks
 
@@ -9,47 +10,10 @@ name: Cheks
   - push
 
 jobs:
-  js-search-test:
-    name: JS-Search tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      id-token: write
-      contents: read
-      checks: write
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      -  #@ cache_node()
-      -  #@ rush_add_path()
-      -  #@ rush_install()
-      - name: Run tests
-        run: cd pkg/js-search/ && rushx test:ci
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: JS-Search Tests
-          path: pkg/js-search/junit.xml
-          reporter: jest-junit
-      - name: Build js-search
-        run: cd pkg/js-search/ && rushx build
-  ui-test:
-    name: UI tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      -  #@ cache_node()
-      -  #@ rush_add_path()
-      -  #@ rush_install()
-      -  #@ rush_build()
-      - name: Run tests
-        run: cd pkg/ui && rushx test:ci
+  js-search-test: #@ test_job("JS-Search Tests", "pkg/js-search")
+
+  ui-test: #@ test_job("UI Tests", "pkg/ui")
+
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflow.templates/test-job.lib.yml
+++ b/.github/workflow.templates/test-job.lib.yml
@@ -1,0 +1,36 @@
+#@ load("cache.lib.yml", "cache_node")
+#@ load("rush.lib.yml", "rush_add_path")
+#@ load("rush.lib.yml", "rush_install")
+#@ load("rush.lib.yml", "rush_build")
+
+#@ def test_script(workdir):
+#@  return "cd "+workdir+" && rushx test:ci"
+#@ end
+
+#@ def test_job(name, workdir, node="16", needs_build=True):
+name: #@ name
+runs-on: ubuntu-latest
+timeout-minutes: 10
+permissions:
+  id-token: write
+  contents: read
+  checks: write
+steps:
+  - uses: actions/checkout@v2
+  - uses: actions/setup-node@v2
+    with:
+      node-version: #@ node
+  -  #@ cache_node()
+  -  #@ rush_add_path()
+  -  #@ rush_install()
+  -  #@ rush_build()
+  - name: Run tests
+    run: #@ test_script(workdir)
+  - name: Test Report
+    uses: dorny/test-reporter@v1
+    if: success() || failure()
+    with:
+      name: #@ name
+      path: #@ workdir+"/junit.xml"
+      reporter: jest-junit
+#@ end

--- a/.github/workflow.templates/test-job.lib.yml
+++ b/.github/workflow.templates/test-job.lib.yml
@@ -7,7 +7,7 @@
 #@  return "cd "+workdir+" && rushx test:ci"
 #@ end
 
-#@ def test_job(name, workdir, node="16", needs_build=True):
+#@ def test_job(name, workdir, reporter=None):
 name: #@ name
 runs-on: ubuntu-latest
 timeout-minutes: 10
@@ -19,18 +19,20 @@ steps:
   - uses: actions/checkout@v2
   - uses: actions/setup-node@v2
     with:
-      node-version: #@ node
+      node-version: "16"
   -  #@ cache_node()
   -  #@ rush_add_path()
   -  #@ rush_install()
   -  #@ rush_build()
   - name: Run tests
     run: #@ test_script(workdir)
+  #@ if reporter!=None:
   - name: Test Report
     uses: dorny/test-reporter@v1
     if: success() || failure()
     with:
       name: #@ name
       path: #@ workdir+"/junit.xml"
-      reporter: jest-junit
+      reporter: #@ reporter
+  #@ end
 #@ end

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -69,13 +69,6 @@ jobs:
       run: rush build
     - name: Run tests
       run: cd pkg/ui && rushx test:ci
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
-      with:
-        name: UI Tests
-        path: pkg/ui/junit.xml
-        reporter: jest-junit
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -3,7 +3,7 @@ name: Cheks
 - push
 jobs:
   js-search-test:
-    name: JS-Search tests
+    name: JS-Search Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -28,8 +28,10 @@ jobs:
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
       run: rush update
+    - name: Build packages
+      run: rush build
     - name: Run tests
-      run: cd pkg/js-search/ && rushx test:ci
+      run: cd pkg/js-search && rushx test:ci
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()
@@ -37,11 +39,14 @@ jobs:
         name: JS-Search Tests
         path: pkg/js-search/junit.xml
         reporter: jest-junit
-    - name: Build js-search
-      run: cd pkg/js-search/ && rushx build
   ui-test:
-    name: UI tests
+    name: UI Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
@@ -64,6 +69,13 @@ jobs:
       run: rush build
     - name: Run tests
       run: cd pkg/ui && rushx test:ci
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: UI Tests
+        path: pkg/ui/junit.xml
+        reporter: jest-junit
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@
 **/build
 **/.svelte-kit
 
+# Test reports
+**/junit.xml
+
 # -------Ignored contents of the root of the repo------- #
 
 # Rush temporary files

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -11,7 +11,7 @@
 		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
 		"format": "prettier --write --plugin-search-dir=. .",
 		"test": "vitest",
-		"test:ci": "CI=true vitest run",
+		"test:ci": "CI=true vitest run --reporter=junit --outputFile=./junit.xml",
 		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook",
 		"postinstall": "svelte-kit sync"


### PR DESCRIPTION
I've created workflow template for an entire test job. 
I've included the `rush build` step in all test jobs generated by a template as `js-search` already does a build check, and build with rush gets parallelised as it is, so I don't think there's too much of an overhead. 
I believe that using a conditional `needs_build` step is doable, but didn't find it necessary atm, @silviot let me know what you think.