### PR TITLE
Lock sveltekit to version 1.0.0-next.573 (for Histoire)

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@librocco/ui": "workspace:*",
 		"@sveltejs/adapter-auto": "next",
-		"@sveltejs/kit": "1.0.0-next.578",
+		"@sveltejs/kit": "1.0.0-next.573",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",
 		"eslint": "^8.16.0",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
       '@librocco/ui': workspace:*
       '@sveltejs/adapter-auto': next
       '@sveltejs/adapter-static': ~1.0.0-next.39
-      '@sveltejs/kit': 1.0.0-next.578
+      '@sveltejs/kit': 1.0.0-next.573
       '@typescript-eslint/eslint-plugin': ^5.27.0
       '@typescript-eslint/parser': ^5.27.0
       eslint: ^8.16.0
@@ -34,7 +34,7 @@ importers:
       '@librocco/ui': link:../../pkg/ui
       '@sveltejs/adapter-auto': 1.0.0-next.90
       '@sveltejs/adapter-static': 1.0.0-next.49
-      '@sveltejs/kit': 1.0.0-next.578_svelte@3.54.0+vite@3.2.5
+      '@sveltejs/kit': 1.0.0-next.573_svelte@3.54.0+vite@3.2.5
       '@typescript-eslint/eslint-plugin': 5.46.0_eb164fa24d514c9644c76b459446be46
       '@typescript-eslint/parser': 5.46.0_eslint@8.29.0+typescript@4.9.4
       eslint: 8.29.0
@@ -141,7 +141,7 @@ importers:
       '@histoire/plugin-svelte': ~0.11.2
       '@rgossiaux/svelte-headlessui': ~1.0.2
       '@sveltejs/adapter-auto': next
-      '@sveltejs/kit': 1.0.0-next.578
+      '@sveltejs/kit': 1.0.0-next.573
       '@sveltejs/package': ~1.0.0-next.1
       '@tailwindcss/forms': ~0.5.3
       '@testing-library/svelte': ~3.1.3
@@ -175,7 +175,7 @@ importers:
       '@histoire/plugin-svelte': 0.11.9_62c15e85ec1650db4ca3ee182b19c971
       '@rgossiaux/svelte-headlessui': 1.0.2_svelte@3.54.0
       '@sveltejs/adapter-auto': 1.0.0-next.90
-      '@sveltejs/kit': 1.0.0-next.578_svelte@3.54.0+vite@3.2.5
+      '@sveltejs/kit': 1.0.0-next.573_svelte@3.54.0+vite@3.2.5
       '@sveltejs/package': 1.0.0-next.6_svelte@3.54.0+typescript@4.9.4
       '@tailwindcss/forms': 0.5.3_tailwindcss@3.0.24
       '@testing-library/svelte': 3.1.3_svelte@3.54.0
@@ -1951,8 +1951,8 @@ packages:
     resolution: {integrity: sha512-tPMnqzFpFDWbeRsSkTUUIvjSHv66uEilQvk9shupsVRDycBb7ZACEnfA/T1HyEZKaMZYfFafyKb2dCTDGks0nA==}
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.578_svelte@3.54.0+vite@3.2.5:
-    resolution: {integrity: sha512-6/970BYgQvKYN+H8N4bgSWYCYpfkxmDe85xmxexVdVtrI0VVyV59gbP+dOXyF7k4Ivodge3dsbPjvPg/YaCITA==}
+  /@sveltejs/kit/1.0.0-next.573_svelte@3.54.0+vite@3.2.5:
+    resolution: {integrity: sha512-3qizgkX7oO1rt+wq3EvJHDNBtnW2EEqen6m7PbOfrXK7idhCrPsVUkJWT7+ooGu8zs/kkvHxa7ZdQPp6ltrN+g==}
     engines: {node: '>=16.14'}
     hasBin: true
     requiresBuild: true
@@ -1972,7 +1972,7 @@ packages:
       sirv: 2.0.2
       svelte: 3.54.0
       tiny-glob: 0.2.9
-      undici: 5.14.0
+      undici: 5.13.0
       vite: 3.2.5
     transitivePeerDependencies:
       - supports-color
@@ -8280,8 +8280,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici/5.14.0:
-    resolution: {integrity: sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==}
+  /undici/5.13.0:
+    resolution: {integrity: sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "87c224cb87ba70dd89c38af60485a13bf6bc821c",
+  "pnpmShrinkwrapHash": "e9fbd49763ad38197ce673880820dfec307a18da",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -17,7 +17,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "next",
-		"@sveltejs/kit": "1.0.0-next.578",
+		"@sveltejs/kit": "1.0.0-next.573",
 		"@sveltejs/package": "~1.0.0-next.1",
 		"@tailwindcss/forms": "~0.5.3",
 		"@testing-library/svelte": "~3.1.3",


### PR DESCRIPTION
Histoire is currently failing after svelte `1.0.0-next.573` so we're currently locked to that version, but should update later, as mentioned in #138 as soon as possible