### PR TITLE
Feature/book detail form

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -208,6 +208,7 @@ importers:
       eslint: ^8.16.0
       eslint-config-prettier: ^8.3.0
       eslint-plugin-svelte3: ^4.0.0
+      felte: ~1.2.7
       histoire: ~0.11.2
       jsdom: 20.0.0
       lucide-svelte: ~0.91.0
@@ -243,6 +244,7 @@ importers:
       eslint: 8.32.0
       eslint-config-prettier: 8.6.0_eslint@8.32.0
       eslint-plugin-svelte3: 4.0.0_eslint@8.32.0+svelte@3.55.1
+      felte: 1.2.7_svelte@3.55.1
       histoire: 0.11.9_vite@3.2.5
       jsdom: 20.0.0
       lucide-svelte: 0.91.0_svelte2tsx@0.5.23+svelte@3.55.1
@@ -1591,6 +1593,18 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@felte/common/1.1.4:
+    resolution: {integrity: sha512-4jNB4EwRpaGZppwV/YqbGF7SVRwehWw+hyTGmw2N+pL86LuqVTTSrgVOGXwPaLTju1BxAptcoAXjxZbBf0XB4Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /@felte/core/1.3.7:
+    resolution: {integrity: sha512-/AkIEZu/Yg/K+YEdnup5c3Bb0xyr9ONdZnS0us6V/b9DgfiEqbcm1xgglD/mtwh+IH7KOhIuQecjBdPQfpNViQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      '@felte/common': 1.1.4
     dev: true
 
   /@histoire/app/0.11.9_vite@3.2.5:
@@ -4668,6 +4682,16 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
+    dev: true
+
+  /felte/1.2.7_svelte@3.55.1:
+    resolution: {integrity: sha512-VfCkYBODReCUrYeRMmJ9lRs7O/pC4PYKMTT7E2K6m9UzmTGpm3Ql3C518J3gUVVG5ZeEeSEifUaqmrAcaWB89w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      svelte: ^3.31.0
+    dependencies:
+      '@felte/core': 1.3.7
+      svelte: 3.55.1
     dev: true
 
   /fetch-cookie/0.11.0:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -222,9 +222,11 @@ importers:
       svelte: ^3.44.0
       svelte-check: ^2.7.1
       svelte-fragment-component: ~1.2.0
+      svelte-headlessui: ~0.0.14
       svelte-htm: ~1.2.0
       svelte-loader: ^3.1.2
       svelte-preprocess: ^4.10.6
+      svelte-transition: ~0.0.7
       svelte2tsx: ~0.5.13
       tailwindcss: ~3.0.24
       tslib: ^2.3.1
@@ -264,9 +266,11 @@ importers:
       svelte: 3.55.1
       svelte-check: 2.10.3_postcss@8.4.21+svelte@3.55.1
       svelte-fragment-component: 1.2.0_svelte@3.55.1
+      svelte-headlessui: 0.0.14
       svelte-htm: 1.2.0_svelte@3.55.1
       svelte-loader: 3.1.5_svelte@3.55.1
       svelte-preprocess: 4.10.7_720a9953ae0478bce00e7bc3a3de2065
+      svelte-transition: 0.0.7
       svelte2tsx: 0.5.23_svelte@3.55.1+typescript@4.9.4
       tailwindcss: 3.0.24
       tslib: 2.4.1
@@ -8326,6 +8330,12 @@ packages:
       svelte: 3.55.1
     dev: true
 
+  /svelte-headlessui/0.0.14:
+    resolution: {integrity: sha512-w2Sqj/xqmrUi5XtVXUeSh3lJUAUgpVSpA5ApnmLmFE+S16nk8XRsQof6Inj0Lrc+Qe91AnaDXGQxijuKZg4Vfg==}
+    dependencies:
+      svelte-transition: 0.0.7
+    dev: true
+
   /svelte-hmr/0.14.12_svelte@3.55.1:
     resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
@@ -8430,6 +8440,10 @@ packages:
       strip-indent: 3.0.0
       svelte: 3.55.1
       typescript: 4.9.4
+    dev: true
+
+  /svelte-transition/0.0.7:
+    resolution: {integrity: sha512-YMbl+eIkzeYKBz6E/I8KI8RMezhqB38t2B/Mx8BotmtiN+5wnKath7CWDc+8U9zKGJ/iUYHmx4MwQjIzo05nVg==}
     dev: true
 
   /svelte/3.55.1:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -200,7 +200,11 @@ importers:
       '@sveltejs/kit': 1.0.0-next.573
       '@sveltejs/package': ~1.0.0-next.1
       '@tailwindcss/forms': ~0.5.3
+      '@testing-library/dom': ~8.20.0
+      '@testing-library/jest-dom': ~5.16.5
       '@testing-library/svelte': ~3.1.3
+      '@testing-library/user-event': ~14.4.3
+      '@types/testing-library__jest-dom': ~5.14.5
       '@types/uuid': ~8.3.4
       '@typescript-eslint/eslint-plugin': ^5.27.0
       '@typescript-eslint/parser': ^5.27.0
@@ -217,6 +221,8 @@ importers:
       prettier-plugin-svelte: ^2.7.0
       svelte: ^3.44.0
       svelte-check: ^2.7.1
+      svelte-fragment-component: ~1.2.0
+      svelte-htm: ~1.2.0
       svelte-loader: ^3.1.2
       svelte-preprocess: ^4.10.6
       svelte2tsx: ~0.5.13
@@ -236,7 +242,11 @@ importers:
       '@sveltejs/kit': 1.0.0-next.573_svelte@3.55.1+vite@3.2.5
       '@sveltejs/package': 1.0.2_svelte@3.55.1+typescript@4.9.4
       '@tailwindcss/forms': 0.5.3_tailwindcss@3.0.24
+      '@testing-library/dom': 8.20.0
+      '@testing-library/jest-dom': 5.16.5
       '@testing-library/svelte': 3.1.3_svelte@3.55.1
+      '@testing-library/user-event': 14.4.3_@testing-library+dom@8.20.0
+      '@types/testing-library__jest-dom': 5.14.5
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.48.2_101cdf21de94ccf8fd79d46613915786
       '@typescript-eslint/parser': 5.48.2_eslint@8.32.0+typescript@4.9.4
@@ -253,6 +263,8 @@ importers:
       prettier-plugin-svelte: 2.9.0_prettier@2.8.3+svelte@3.55.1
       svelte: 3.55.1
       svelte-check: 2.10.3_postcss@8.4.21+svelte@3.55.1
+      svelte-fragment-component: 1.2.0_svelte@3.55.1
+      svelte-htm: 1.2.0_svelte@3.55.1
       svelte-loader: 3.1.5_svelte@3.55.1
       svelte-preprocess: 4.10.7_720a9953ae0478bce00e7bc3a3de2065
       svelte2tsx: 0.5.23_svelte@3.55.1+typescript@4.9.4
@@ -263,6 +275,10 @@ importers:
       vitest: 0.21.1_jsdom@20.0.0
 
 packages:
+
+  /@adobe/css-tools/4.1.0:
+    resolution: {integrity: sha512-mMVJ/j/GbZ/De4ZHWbQAQO1J6iVnjtZLc9WEdkUQb8S/Bu2cAF2bETXUgMAdvMG3/ngtKmcNBe+Zms9bg6jnQQ==}
+    dev: true
 
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -1424,6 +1440,14 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/runtime-corejs3/7.20.13:
+    resolution: {integrity: sha512-p39/6rmY9uvlzRiLZBIB3G9/EBr66LBMcYm7fIDeSBNdRjF2AGD3rFZucUyAgGHC2N+7DdLvVi33uTjSE44FIw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.28.0
+      regenerator-runtime: 0.13.11
+    dev: true
+
   /@babel/runtime/7.20.7:
     resolution: {integrity: sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==}
     engines: {node: '>=6.9.0'}
@@ -2142,6 +2166,21 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@testing-library/jest-dom/5.16.5:
+    resolution: {integrity: sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==}
+    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
+    dependencies:
+      '@adobe/css-tools': 4.1.0
+      '@babel/runtime': 7.20.7
+      '@types/testing-library__jest-dom': 5.14.5
+      aria-query: 5.1.3
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.5.16
+      lodash: 4.17.21
+      redent: 3.0.0
+    dev: true
+
   /@testing-library/svelte/3.1.3_svelte@3.55.1:
     resolution: {integrity: sha512-pyed3yMnTu7wG9Z4XKoIxdrx52hSEFDC8qUaiSsiSh8tBVj3ZjqEKnV2Nfc0IF2llEkT0B7QOXnOVTLJ3O5RCw==}
     engines: {node: '>= 10'}
@@ -2150,6 +2189,15 @@ packages:
     dependencies:
       '@testing-library/dom': 8.20.0
       svelte: 3.55.1
+    dev: true
+
+  /@testing-library/user-event/14.4.3_@testing-library+dom@8.20.0:
+    resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 8.20.0
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -2441,6 +2489,12 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/testing-library__jest-dom/5.14.5:
+    resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
+    dependencies:
+      '@types/jest': 27.5.2
     dev: true
 
   /@types/uuid/8.3.4:
@@ -3410,6 +3464,16 @@ packages:
       browserslist: 4.21.4
     dev: true
 
+  /core-js-pure/3.28.0:
+    resolution: {integrity: sha512-DSOVleA9/v3LNj/vFxAPfUHttKTzrB2RXhAPvR5TPXn4vrra3Z2ssytvRyt8eruJwAfwAiFADEbrjcRdcvPLQQ==}
+    requiresBuild: true
+    dev: true
+
+  /core-js/3.28.0:
+    resolution: {integrity: sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==}
+    requiresBuild: true
+    dev: true
+
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -3435,6 +3499,10 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
+
+  /css.escape/1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
     dev: true
 
   /cssesc/3.0.0:
@@ -5135,6 +5203,10 @@ packages:
       - utf-8-validate
     dev: true
 
+  /htm/3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
+    dev: true
+
   /html-encoding-sniffer/2.0.1:
     resolution: {integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==}
     engines: {node: '>=10'}
@@ -5239,6 +5311,11 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+    dev: true
+
+  /indent-string/4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
     dev: true
 
   /inflight/1.0.6:
@@ -7491,6 +7568,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /redent/3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    dev: true
+
   /regenerate-unicode-properties/10.1.0:
     resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
     engines: {node: '>=4'}
@@ -8232,6 +8317,15 @@ packages:
     resolution: {integrity: sha512-oU+Xv7Dl4kRU2kdFjsoPLfJfnt5hUhsFUZtuzI3Ku/f2iAFZqBoEuXOqK3N9ngD4dxQOmN4OKWPHVi3NeAeAfQ==}
     dev: true
 
+  /svelte-fragment-component/1.2.0_svelte@3.55.1:
+    resolution: {integrity: sha512-rRstmz2oAy2Y/7X57tRaIAJdMYsa2K/MOx/YJN/ETb7Bj9U3vjgioz27dMG1hl2vAKFTtQpxDhC31ur7ECwpog==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      svelte: 3.x
+    dependencies:
+      svelte: 3.55.1
+    dev: true
+
   /svelte-hmr/0.14.12_svelte@3.55.1:
     resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
@@ -8247,6 +8341,31 @@ packages:
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
+      svelte: 3.55.1
+    dev: true
+
+  /svelte-htm/1.2.0_svelte@3.55.1:
+    resolution: {integrity: sha512-6YFNncbyXbCa3PSoMQc/JR6O/Yg1OgNioH5rMgE88RVPzU8714y2Urfenlqs+ryRS+Inv+m6TJ9jH3W7wDCS1A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      svelte: 3.x
+    dependencies:
+      '@babel/runtime-corejs3': 7.20.13
+      core-js: 3.28.0
+      htm: 3.1.1
+      svelte: 3.55.1
+      svelte-fragment-component: 1.2.0_svelte@3.55.1
+      svelte-hyperscript: 1.2.1_svelte@3.55.1
+    dev: true
+
+  /svelte-hyperscript/1.2.1_svelte@3.55.1:
+    resolution: {integrity: sha512-IVk91VDSOrhOUe0KI+Jfu7yCruUTOXgr4WysrK7hBNbFMDjeBOcPhk+LMYjUjdWxJx3+QSt3bUXj09YrUfRkjg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      svelte: 3.x
+    dependencies:
+      '@babel/runtime-corejs3': 7.20.13
+      core-js: 3.28.0
       svelte: 3.55.1
     dev: true
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "49bff34a3baf5f7e0d1de7fcc80a1dc4d1d4c48c",
+  "pnpmShrinkwrapHash": "9dbfc4f2fff2a0450ddc208c67b73380c90d6661",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c906a821dcda8635cd4e66f56064d0758f15f545",
+  "pnpmShrinkwrapHash": "49bff34a3baf5f7e0d1de7fcc80a1dc4d1d4c48c",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9dbfc4f2fff2a0450ddc208c67b73380c90d6661",
+  "pnpmShrinkwrapHash": "33a854d0a344ba9cf057cbc9fe0d2d21dc1ad2b7",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-000.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-000.json
@@ -1,83 +1,71 @@
 {
-  "id": "note-000",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 10,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 5,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 12,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-000",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 10,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 5,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 12,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-001.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-001.json
@@ -1,83 +1,71 @@
 {
-  "id": "note-001",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 19,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 12,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 27,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-001",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 19,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 12,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 27,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-002.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-002.json
@@ -1,83 +1,71 @@
 {
-  "id": "note-002",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 2,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 9,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 18,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-002",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 2,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 9,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 18,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-003.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-003.json
@@ -1,109 +1,93 @@
 {
-  "id": "note-003",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 2,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 16,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 30,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 14,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-003",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 2,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 16,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 30,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 14,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-004.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-004.json
@@ -1,109 +1,93 @@
 {
-  "id": "note-004",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 14,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 15,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-004",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 14,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 15,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-005.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-005.json
@@ -1,187 +1,159 @@
 {
-  "id": "note-005",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "Saving Darwin",
-        "authors": [
-          "Karl Giberson"
-        ],
-        "publisher": "Harper Collins",
-        "publishedDate": "2009-10-06",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780061983412"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0061983411"
-          }
-        ],
-        "categories": [
-          "Religion"
-        ],
-        "language": "en"
-      },
-      "quantity": 8,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 15,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 14,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "What Went Wrong?",
-        "authors": [
-          "Trevor Kletz"
-        ],
-        "publisher": "Elsevier",
-        "publishedDate": "1998-06-23",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0080524230"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780080524238"
-          }
-        ],
-        "categories": [
-          "Technology & Engineering"
-        ],
-        "language": "en"
-      },
-      "quantity": 5,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Age of Wonder",
-        "authors": [
-          "Richard Holmes"
-        ],
-        "publisher": "HarperCollins UK",
-        "publishedDate": "2008",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780007149520"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0007149522"
-          }
-        ],
-        "categories": [
-          "Biographers"
-        ],
-        "language": "en"
-      },
-      "quantity": 13,
-      "warehouseId": "science"
-    }
-  ]
+	"id": "note-005",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "Saving Darwin",
+				"authors": ["Karl Giberson"],
+				"publisher": "Harper Collins",
+				"publishedDate": "2009-10-06",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780061983412"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0061983411"
+					}
+				],
+				"categories": ["Religion"],
+				"language": "en"
+			},
+			"quantity": 8,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 15,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 14,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "What Went Wrong?",
+				"authors": ["Trevor Kletz"],
+				"publisher": "Elsevier",
+				"publishedDate": "1998-06-23",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0080524230"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780080524238"
+					}
+				],
+				"categories": ["Technology & Engineering"],
+				"language": "en"
+			},
+			"quantity": 5,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Age of Wonder",
+				"authors": ["Richard Holmes"],
+				"publisher": "HarperCollins UK",
+				"publishedDate": "2008",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780007149520"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0007149522"
+					}
+				],
+				"categories": ["Biographers"],
+				"language": "en"
+			},
+			"quantity": 13,
+			"warehouseId": "science"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-006.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-006.json
@@ -1,187 +1,159 @@
 {
-  "id": "note-006",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "Saving Darwin",
-        "authors": [
-          "Karl Giberson"
-        ],
-        "publisher": "Harper Collins",
-        "publishedDate": "2009-10-06",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780061983412"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0061983411"
-          }
-        ],
-        "categories": [
-          "Religion"
-        ],
-        "language": "en"
-      },
-      "quantity": 8,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 13,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 13,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "What Went Wrong?",
-        "authors": [
-          "Trevor Kletz"
-        ],
-        "publisher": "Elsevier",
-        "publishedDate": "1998-06-23",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0080524230"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780080524238"
-          }
-        ],
-        "categories": [
-          "Technology & Engineering"
-        ],
-        "language": "en"
-      },
-      "quantity": 1,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Age of Wonder",
-        "authors": [
-          "Richard Holmes"
-        ],
-        "publisher": "HarperCollins UK",
-        "publishedDate": "2008",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780007149520"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0007149522"
-          }
-        ],
-        "categories": [
-          "Biographers"
-        ],
-        "language": "en"
-      },
-      "quantity": 13,
-      "warehouseId": "science"
-    }
-  ]
+	"id": "note-006",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "Saving Darwin",
+				"authors": ["Karl Giberson"],
+				"publisher": "Harper Collins",
+				"publishedDate": "2009-10-06",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780061983412"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0061983411"
+					}
+				],
+				"categories": ["Religion"],
+				"language": "en"
+			},
+			"quantity": 8,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 13,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 13,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "What Went Wrong?",
+				"authors": ["Trevor Kletz"],
+				"publisher": "Elsevier",
+				"publishedDate": "1998-06-23",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0080524230"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780080524238"
+					}
+				],
+				"categories": ["Technology & Engineering"],
+				"language": "en"
+			},
+			"quantity": 1,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Age of Wonder",
+				"authors": ["Richard Holmes"],
+				"publisher": "HarperCollins UK",
+				"publishedDate": "2008",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780007149520"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0007149522"
+					}
+				],
+				"categories": ["Biographers"],
+				"language": "en"
+			},
+			"quantity": 13,
+			"warehouseId": "science"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-007.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-007.json
@@ -1,187 +1,159 @@
 {
-  "id": "note-007",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 25,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "What Went Wrong?",
-        "authors": [
-          "Trevor Kletz"
-        ],
-        "publisher": "Elsevier",
-        "publishedDate": "1998-06-23",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0080524230"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780080524238"
-          }
-        ],
-        "categories": [
-          "Technology & Engineering"
-        ],
-        "language": "en"
-      },
-      "quantity": 1,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Age of Wonder",
-        "authors": [
-          "Richard Holmes"
-        ],
-        "publisher": "HarperCollins UK",
-        "publishedDate": "2008",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780007149520"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0007149522"
-          }
-        ],
-        "categories": [
-          "Biographers"
-        ],
-        "language": "en"
-      },
-      "quantity": 13,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "Saving Darwin",
-        "authors": [
-          "Karl Giberson"
-        ],
-        "publisher": "Harper Collins",
-        "publishedDate": "2009-10-06",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780061983412"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0061983411"
-          }
-        ],
-        "categories": [
-          "Religion"
-        ],
-        "language": "en"
-      },
-      "quantity": 8,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 9,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 33,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-007",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 25,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "What Went Wrong?",
+				"authors": ["Trevor Kletz"],
+				"publisher": "Elsevier",
+				"publishedDate": "1998-06-23",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0080524230"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780080524238"
+					}
+				],
+				"categories": ["Technology & Engineering"],
+				"language": "en"
+			},
+			"quantity": 1,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Age of Wonder",
+				"authors": ["Richard Holmes"],
+				"publisher": "HarperCollins UK",
+				"publishedDate": "2008",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780007149520"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0007149522"
+					}
+				],
+				"categories": ["Biographers"],
+				"language": "en"
+			},
+			"quantity": 13,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "Saving Darwin",
+				"authors": ["Karl Giberson"],
+				"publisher": "Harper Collins",
+				"publishedDate": "2009-10-06",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780061983412"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0061983411"
+					}
+				],
+				"categories": ["Religion"],
+				"language": "en"
+			},
+			"quantity": 8,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 9,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 33,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-008.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-008.json
@@ -1,187 +1,159 @@
 {
-  "id": "note-008",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 18,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 25,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "What Went Wrong?",
-        "authors": [
-          "Trevor Kletz"
-        ],
-        "publisher": "Elsevier",
-        "publishedDate": "1998-06-23",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0080524230"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780080524238"
-          }
-        ],
-        "categories": [
-          "Technology & Engineering"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Age of Wonder",
-        "authors": [
-          "Richard Holmes"
-        ],
-        "publisher": "HarperCollins UK",
-        "publishedDate": "2008",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780007149520"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0007149522"
-          }
-        ],
-        "categories": [
-          "Biographers"
-        ],
-        "language": "en"
-      },
-      "quantity": 7,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "Saving Darwin",
-        "authors": [
-          "Karl Giberson"
-        ],
-        "publisher": "Harper Collins",
-        "publishedDate": "2009-10-06",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780061983412"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0061983411"
-          }
-        ],
-        "categories": [
-          "Religion"
-        ],
-        "language": "en"
-      },
-      "quantity": 8,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 9,
-      "warehouseId": "jazz"
-    }
-  ]
+	"id": "note-008",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 18,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 25,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "What Went Wrong?",
+				"authors": ["Trevor Kletz"],
+				"publisher": "Elsevier",
+				"publishedDate": "1998-06-23",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0080524230"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780080524238"
+					}
+				],
+				"categories": ["Technology & Engineering"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Age of Wonder",
+				"authors": ["Richard Holmes"],
+				"publisher": "HarperCollins UK",
+				"publishedDate": "2008",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780007149520"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0007149522"
+					}
+				],
+				"categories": ["Biographers"],
+				"language": "en"
+			},
+			"quantity": 7,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "Saving Darwin",
+				"authors": ["Karl Giberson"],
+				"publisher": "Harper Collins",
+				"publishedDate": "2009-10-06",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780061983412"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0061983411"
+					}
+				],
+				"categories": ["Religion"],
+				"language": "en"
+			},
+			"quantity": 8,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 9,
+			"warehouseId": "jazz"
+		}
+	]
 }

--- a/pkg/datamodel-tests/src/runner/__testData__/snaps/note-009.json
+++ b/pkg/datamodel-tests/src/runner/__testData__/snaps/note-009.json
@@ -1,187 +1,159 @@
 {
-  "id": "note-009",
-  "books": [
-    {
-      "volumeInfo": {
-        "title": "Saving Darwin",
-        "authors": [
-          "Karl Giberson"
-        ],
-        "publisher": "Harper Collins",
-        "publishedDate": "2009-10-06",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780061983412"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0061983411"
-          }
-        ],
-        "categories": [
-          "Religion"
-        ],
-        "language": "en"
-      },
-      "quantity": 16,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Jazz Standards",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "",
-        "publishedDate": "2012",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780199769155"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "019976915X"
-          }
-        ],
-        "categories": [
-          "African Americans"
-        ],
-        "language": "en"
-      },
-      "quantity": 9,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Swing Era",
-        "authors": [
-          "Gunther Schuller"
-        ],
-        "publisher": "History of Jazz",
-        "publishedDate": "1989",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0195071409"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195071405"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 18,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "The History of Jazz",
-        "authors": [
-          "Ted Gioia"
-        ],
-        "publisher": "Oxford University Press",
-        "publishedDate": "2011-05-09",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780195399707"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0195399706"
-          }
-        ],
-        "categories": [
-          "History"
-        ],
-        "language": "en"
-      },
-      "quantity": 0,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "Holiday Jazz Chants",
-        "authors": [
-          "Carolyn Graham"
-        ],
-        "publisher": "Oxford",
-        "publishedDate": "1999-01-01",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0194349276"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780194349277"
-          }
-        ],
-        "categories": [
-          "Foreign Language Study"
-        ],
-        "language": "en"
-      },
-      "quantity": 25,
-      "warehouseId": "jazz"
-    },
-    {
-      "volumeInfo": {
-        "title": "What Went Wrong?",
-        "authors": [
-          "Trevor Kletz"
-        ],
-        "publisher": "Elsevier",
-        "publishedDate": "1998-06-23",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_10",
-            "identifier": "0080524230"
-          },
-          {
-            "type": "ISBN_13",
-            "identifier": "9780080524238"
-          }
-        ],
-        "categories": [
-          "Technology & Engineering"
-        ],
-        "language": "en"
-      },
-      "quantity": 10,
-      "warehouseId": "science"
-    },
-    {
-      "volumeInfo": {
-        "title": "The Age of Wonder",
-        "authors": [
-          "Richard Holmes"
-        ],
-        "publisher": "HarperCollins UK",
-        "publishedDate": "2008",
-        "industryIdentifiers": [
-          {
-            "type": "ISBN_13",
-            "identifier": "9780007149520"
-          },
-          {
-            "type": "ISBN_10",
-            "identifier": "0007149522"
-          }
-        ],
-        "categories": [
-          "Biographers"
-        ],
-        "language": "en"
-      },
-      "quantity": 25,
-      "warehouseId": "science"
-    }
-  ]
+	"id": "note-009",
+	"books": [
+		{
+			"volumeInfo": {
+				"title": "Saving Darwin",
+				"authors": ["Karl Giberson"],
+				"publisher": "Harper Collins",
+				"publishedDate": "2009-10-06",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780061983412"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0061983411"
+					}
+				],
+				"categories": ["Religion"],
+				"language": "en"
+			},
+			"quantity": 16,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Jazz Standards",
+				"authors": ["Ted Gioia"],
+				"publisher": "",
+				"publishedDate": "2012",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780199769155"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "019976915X"
+					}
+				],
+				"categories": ["African Americans"],
+				"language": "en"
+			},
+			"quantity": 9,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Swing Era",
+				"authors": ["Gunther Schuller"],
+				"publisher": "History of Jazz",
+				"publishedDate": "1989",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0195071409"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195071405"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 18,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "The History of Jazz",
+				"authors": ["Ted Gioia"],
+				"publisher": "Oxford University Press",
+				"publishedDate": "2011-05-09",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780195399707"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0195399706"
+					}
+				],
+				"categories": ["History"],
+				"language": "en"
+			},
+			"quantity": 0,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "Holiday Jazz Chants",
+				"authors": ["Carolyn Graham"],
+				"publisher": "Oxford",
+				"publishedDate": "1999-01-01",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0194349276"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780194349277"
+					}
+				],
+				"categories": ["Foreign Language Study"],
+				"language": "en"
+			},
+			"quantity": 25,
+			"warehouseId": "jazz"
+		},
+		{
+			"volumeInfo": {
+				"title": "What Went Wrong?",
+				"authors": ["Trevor Kletz"],
+				"publisher": "Elsevier",
+				"publishedDate": "1998-06-23",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_10",
+						"identifier": "0080524230"
+					},
+					{
+						"type": "ISBN_13",
+						"identifier": "9780080524238"
+					}
+				],
+				"categories": ["Technology & Engineering"],
+				"language": "en"
+			},
+			"quantity": 10,
+			"warehouseId": "science"
+		},
+		{
+			"volumeInfo": {
+				"title": "The Age of Wonder",
+				"authors": ["Richard Holmes"],
+				"publisher": "HarperCollins UK",
+				"publishedDate": "2008",
+				"industryIdentifiers": [
+					{
+						"type": "ISBN_13",
+						"identifier": "9780007149520"
+					},
+					{
+						"type": "ISBN_10",
+						"identifier": "0007149522"
+					}
+				],
+				"categories": ["Biographers"],
+				"language": "en"
+			},
+			"quantity": 25,
+			"warehouseId": "science"
+		}
+	]
 }

--- a/pkg/ui/.eslintrc.cjs
+++ b/pkg/ui/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = useTSConfig(
 		parser: '@typescript-eslint/parser',
 		extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
 		plugins: ['svelte3', '@typescript-eslint'],
-		ignorePatterns: ['*.cjs', '*.config.js'],
+		ignorePatterns: ['*.cjs', '*.config.js', '*.setup.*'],
 		overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 		settings: {
 			'svelte3/typescript': () => require('typescript')

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -46,11 +46,13 @@
 		"autoprefixer": "~10.4.12",
 		"lucide-svelte": "~0.91.0",
 		"@rgossiaux/svelte-headlessui": "~1.0.2",
-		"jsdom": "20.0.0"
+		"jsdom": "20.0.0",
+		"felte": "~1.2.7"
 	},
 	"peerDependencies": {
 		"lucide-svelte": "~0.91.0",
-		"svelte": "^3.44.0"
+		"svelte": "^3.44.0",
+		"felte": "~1.2.7"
 	},
 	"dependencies": {
 		"uuid": "~9.0.0"

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -47,7 +47,13 @@
 		"lucide-svelte": "~0.91.0",
 		"@rgossiaux/svelte-headlessui": "~1.0.2",
 		"jsdom": "20.0.0",
-		"felte": "~1.2.7"
+		"felte": "~1.2.7",
+		"@testing-library/dom": "~8.20.0",
+		"@testing-library/jest-dom": "~5.16.5",
+		"@testing-library/user-event": "~14.4.3",
+		"@types/testing-library__jest-dom": "~5.14.5",
+		"svelte-fragment-component": "~1.2.0",
+		"svelte-htm": "~1.2.0"
 	},
 	"peerDependencies": {
 		"lucide-svelte": "~0.91.0",

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -53,7 +53,9 @@
 		"@testing-library/user-event": "~14.4.3",
 		"@types/testing-library__jest-dom": "~5.14.5",
 		"svelte-fragment-component": "~1.2.0",
-		"svelte-htm": "~1.2.0"
+		"svelte-htm": "~1.2.0",
+		"svelte-headlessui": "~0.0.14",
+		"svelte-transition": "~0.0.7"
 	},
 	"peerDependencies": {
 		"lucide-svelte": "~0.91.0",

--- a/pkg/ui/src/Button/Button.svelte
+++ b/pkg/ui/src/Button/Button.svelte
@@ -78,10 +78,6 @@
 	 * ```
 	 */
 	export let color: ButtonColor = ButtonColor.Primary;
-	/**
-	 * A custom html tag we want to render the element as (defaults to "button")
-	 */
-	export let as: string = 'button';
 
 	$: shapeClass = shape === ButtonShape.Circular ? 'rounded-full' : shapeRadiusLookup[shape][size];
 	$: textClasses = textSizeLookup[size];
@@ -92,8 +88,7 @@
 	$: containerClasses = [sizeClasses, shapeClass, colorClasses, focusClasses, className].join(' ');
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<svelte:element this={as} class={containerClasses} on:click>
+<button class={containerClasses} on:click>
 	<span class="flex items-center gap-x-2">
 		{#if $$slots.startAdornment && shape !== ButtonShape.Circular}
 			<slot name="startAdornment" />
@@ -105,4 +100,4 @@
 			<slot name="endAdornment" />
 		{/if}
 	</span>
-</svelte:element>
+</button>

--- a/pkg/ui/src/Button/Button.svelte
+++ b/pkg/ui/src/Button/Button.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+	import type { HTMLButtonAttributes } from 'svelte/elements';
 	import { ButtonColor, ButtonShape, ButtonSize } from './enums';
 	import { shapeRadiusLookup, textSizeLookup, shapeSpacingLookup, colorClassesLookup } from './styles';
+
+	interface $$Props extends HTMLButtonAttributes {
+		class?: string;
+		size?: ButtonSize;
+		shape?: ButtonShape;
+		color?: ButtonColor;
+	}
 
 	let className = '';
 	export { className as class };
@@ -88,7 +96,7 @@
 	$: containerClasses = [sizeClasses, shapeClass, colorClasses, focusClasses, className].join(' ');
 </script>
 
-<button class={containerClasses} on:click>
+<button class={containerClasses} on:click type="button" {...$$restProps}>
 	<span class="flex items-center gap-x-2">
 		{#if $$slots.startAdornment && shape !== ButtonShape.Circular}
 			<slot name="startAdornment" />

--- a/pkg/ui/src/FormFields/Checkbox/Checkbox.svelte
+++ b/pkg/ui/src/FormFields/Checkbox/Checkbox.svelte
@@ -32,6 +32,7 @@
 		<input
 			type="checkbox"
 			{id}
+			{name}
 			aria-describedby={`${name}-description`}
 			class={inputBaseClasses}
 			{...$$restProps}

--- a/pkg/ui/src/FormFields/Checkbox/Checkbox.svelte
+++ b/pkg/ui/src/FormFields/Checkbox/Checkbox.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
 	import { v4 as uuid } from 'uuid';
-	export let name: string;
+	import type { HTMLInputAttributes } from 'svelte/elements';
 
+	interface $$Props extends HTMLInputAttributes {
+		name: string;
+		label?: string;
+		helpText?: string;
+	}
+
+	export let name: string;
 	export let label = '';
 	export let helpText = '';
-	export let checked = false;
-	export let disabled = false;
 
 	const id = uuid();
 
-	const labelBaseClasses = ['font-medium', disabled ? 'text-gray-400' : 'text-gray-700'].join(' ');
-	const helpTextColor = disabled ? 'text-gray-300' : 'text-gray-500';
+	const labelBaseClasses = ['font-medium', $$restProps.disabled ? 'text-gray-400' : 'text-gray-700'].join(' ');
+	const helpTextColor = $$restProps.disabled ? 'text-gray-300' : 'text-gray-500';
 	const inputBaseClasses = [
 		'focus:ring-teal-500',
 		'h-4',
@@ -29,8 +34,7 @@
 			{id}
 			aria-describedby={`${name}-description`}
 			class={inputBaseClasses}
-			{checked}
-			{disabled}
+			{...$$restProps}
 		/>
 	</div>
 	<div class="ml-3 text-sm">

--- a/pkg/ui/src/FormFields/TextField/TextField.svelte
+++ b/pkg/ui/src/FormFields/TextField/TextField.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-	export let name: string;
+	import type { HTMLInputAttributes } from 'svelte/elements';
 
+	interface $$Props extends HTMLInputAttributes {
+		name: string;
+		label?: string;
+		helpText?: string;
+	}
+
+	export let name: string;
 	export let label = '';
-	export let placeholder = '';
 	export let helpText = '';
-	export let disabled = false;
 
 	const labelBaseClasses = ['block', 'text-sm', 'font-medium', 'text-gray-700'];
 	const helpTextBaseClasses = ['mt-2', 'text-sm', 'min-h-[20px]'];
@@ -32,6 +37,9 @@
 <div class="space-y-1">
 	<label for={name} class={labelClasses}>
 		{label}
+		{#if $$restProps.required}
+			<span class="text-md font-medium text-red-700">*</span>
+		{/if}
 	</label>
 	<div class={containerClasses}>
 		{#if $$slots.startAdornment}
@@ -39,7 +47,7 @@
 				<slot name="startAdornment" />
 			</div>
 		{/if}
-		<input type="text" id={name} aria-label={name} class={inputClasses} {name} {disabled} {placeholder} />
+		<input type="text" id={name} aria-label={name} class={inputClasses} {name} {...$$restProps} />
 		{#if $$slots.endAdornment}
 			<div class="ml-1 mr-3 flex items-center text-gray-400">
 				<slot name="endAdornment" />

--- a/pkg/ui/src/FormFields/TextField/TextField.svelte
+++ b/pkg/ui/src/FormFields/TextField/TextField.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
+	import type { Action } from 'svelte/action';
 	import type { HTMLInputAttributes } from 'svelte/elements';
 
 	interface $$Props extends HTMLInputAttributes {
 		name: string;
 		label?: string;
 		helpText?: string;
+		inputAction?: Action | (() => void);
 	}
 
 	export let name: string;
 	export let label = '';
 	export let helpText = '';
+	export let inputAction: Action = () => {};
 
 	const labelBaseClasses = ['block', 'text-sm', 'font-medium', 'text-gray-700'];
 	const helpTextBaseClasses = ['mt-2', 'text-sm', 'min-h-[20px]'];
@@ -47,7 +50,7 @@
 				<slot name="startAdornment" />
 			</div>
 		{/if}
-		<input type="text" id={name} aria-label={name} class={inputClasses} {name} {...$$restProps} />
+		<input type="text" id={name} aria-label={name} class={inputClasses} {name} {...$$restProps} use:inputAction />
 		{#if $$slots.endAdornment}
 			<div class="ml-1 mr-3 flex items-center text-gray-400">
 				<slot name="endAdornment" />

--- a/pkg/ui/src/FormFields/index.ts
+++ b/pkg/ui/src/FormFields/index.ts
@@ -1,2 +1,3 @@
 export * from './TextField';
 export * from './TextArea';
+export * from './Checkbox';

--- a/pkg/ui/src/Forms/BookDetailForm.story.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.story.svelte
@@ -13,8 +13,10 @@
 		year: '',
 		price: 0
 	};
+
+	const publisherList = ['TCK Publishing', 'Reed Elsevier', 'Penguin Random House', 'Harper Collins', 'Bloomsbury'];
 </script>
 
 <Hst.Story title="Forms / BookDetailForm" layout={{ type: 'grid', width: 600 }}>
-	<BookDetailForm {book} onSubmit={() => console.info('yee-haw')} />
+	<BookDetailForm {book} {publisherList} />
 </Hst.Story>

--- a/pkg/ui/src/Forms/BookDetailForm.story.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.story.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { Hst } from '@histoire/plugin-svelte';
+
+	import BookDetailForm from './BookDetailForm.svelte';
+
+	export let Hst: Hst;
+
+	const book = {
+		isbn: '',
+		title: '',
+		authors: [],
+		publisher: '',
+		year: '',
+		price: 0
+	};
+</script>
+
+<Hst.Story title="Forms / BookDetailForm" layout={{ type: 'grid', width: 600 }}>
+	<BookDetailForm {book} onSubmit={() => {}} />
+</Hst.Story>

--- a/pkg/ui/src/Forms/BookDetailForm.story.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.story.svelte
@@ -8,7 +8,7 @@
 	const book = {
 		isbn: '',
 		title: '',
-		authors: [],
+		authors: '',
 		publisher: '',
 		year: '',
 		price: 0
@@ -16,5 +16,5 @@
 </script>
 
 <Hst.Story title="Forms / BookDetailForm" layout={{ type: 'grid', width: 600 }}>
-	<BookDetailForm {book} onSubmit={() => {}} />
+	<BookDetailForm {book} onSubmit={() => console.info('yee-haw')} />
 </Hst.Story>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -32,7 +32,7 @@
 				<TextField name="year" label="Year" />
 			</div>
 			<div class="basis-full">
-				<TextField name="author" label="Author" />
+				<TextField name="authors" label="Authors" />
 			</div>
 			<div class="basis-full">
 				<TextField name="publisher" label="Publisher" />
@@ -50,7 +50,7 @@
 		</div>
 	</div>
 	<div class="flex justify-end gap-x-2 p-4">
-		<Button color={ButtonColor.Secondary} on:click={() => onCancel}>Cancel</Button>
+		<Button color={ButtonColor.Secondary} on:click={onCancel}>Cancel</Button>
 		<Button type="submit">Save</Button>
 	</div>
 </form>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -16,7 +16,7 @@
 	});
 </script>
 
-<form class="flex h-auto flex-col gap-y-6" use:form aria-label="Edit book details">
+<form class="divide-y-gray-200 flex h-auto flex-col gap-y-6 divide-y-2" use:form aria-label="Edit book details">
 	<div class="flex flex-col justify-between gap-6 p-6 lg:flex-row-reverse">
 		<div class="flex grow flex-col flex-wrap gap-y-4 lg:flex-row">
 			<div class="basis-full">

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createForm } from 'felte';
 
-	import { TextField } from '../FormFields';
+	import { TextField, Checkbox } from '../FormFields';
 	import { Button, ButtonColor } from '../Button';
 
 	import type { BookEntry } from './types';
@@ -24,6 +24,28 @@
 			</div>
 			<div class="basis-full">
 				<TextField name="title" label="Title" required />
+			</div>
+			<div class="flex basis-full justify-between gap-x-4">
+				<TextField name="price" label="Price" required type="number" step="1">
+					<span slot="startAdornment">€</span>
+				</TextField>
+				<TextField name="year" label="Year" />
+			</div>
+			<div class="basis-full">
+				<TextField name="author" label="Author" />
+			</div>
+			<div class="basis-full">
+				<TextField name="publisher" label="Publisher" />
+			</div>
+			<div class="basis-full">
+				<TextField name="editedBy" label="Edited by" />
+			</div>
+			<div class="basis-full">
+				<Checkbox
+					name="outOfPrint"
+					label="Out of print"
+					helpText="This book is no longer available from the publisher"
+				/>
 			</div>
 		</div>
 	</div>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -29,6 +29,6 @@
 	</div>
 	<div class="flex justify-end gap-x-2 p-4">
 		<Button color={ButtonColor.Secondary} on:click={() => onCancel}>Cancel</Button>
-		<Button>Save</Button>
+		<Button type="submit">Save</Button>
 	</div>
 </form>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import { createForm } from 'felte';
+	import { createCombobox } from 'svelte-headlessui';
+	import { ChevronsUpDown } from 'lucide-svelte';
 
 	import { TextField, Checkbox } from '../FormFields';
 	import { Button, ButtonColor } from '../Button';
+	import { ComboboxMenu } from '../Menus';
 
 	import type { BookEntry } from './types';
 
 	export let book: BookEntry;
+	export let publisherList: string[];
 	export let onSubmit: (values: BookEntry) => void = () => {};
 	export let onCancel = () => {};
 
@@ -14,6 +18,8 @@
 		initialValues: book,
 		onSubmit
 	});
+
+	const publisherCombo = createCombobox({ label: 'Publisher list' });
 </script>
 
 <form class="divide-y-gray-200 flex h-auto flex-col gap-y-6 divide-y-2" use:form aria-label="Edit book details">
@@ -34,8 +40,20 @@
 			<div class="basis-full">
 				<TextField name="authors" label="Authors" />
 			</div>
-			<div class="basis-full">
-				<TextField name="publisher" label="Publisher" />
+			<div class="relative basis-full">
+				<TextField
+					name="publisher"
+					label="Publisher"
+					inputAction={publisherCombo.input}
+					value={$publisherCombo.selected}
+				>
+					<div slot="endAdornment">
+						<button use:publisherCombo.button type="button" class="flex items-center">
+							<ChevronsUpDown class="text-gray-400" />
+						</button>
+					</div>
+				</TextField>
+				<ComboboxMenu combobox={publisherCombo} options={publisherList} />
 			</div>
 			<div class="basis-full">
 				<TextField name="editedBy" label="Edited by" />

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -20,10 +20,10 @@
 	<div class="flex flex-col justify-between gap-6 p-6 lg:flex-row-reverse">
 		<div class="flex grow flex-col flex-wrap gap-y-4 lg:flex-row">
 			<div class="basis-full">
-				<TextField name="isbn" label="ISBN" />
+				<TextField name="isbn" label="ISBN" required />
 			</div>
 			<div class="basis-full">
-				<TextField name="title" label="Title" />
+				<TextField name="title" label="Title" required />
 			</div>
 		</div>
 	</div>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { createForm } from 'felte';
+
+	import { TextField } from '../FormFields';
+	import { Button, ButtonColor } from '../Button';
+
+	import type { BookEntry } from './types';
+
+	export let book: BookEntry;
+	export let onSubmit: (values: BookEntry) => void = () => {};
+	export let onCancel = () => {};
+
+	const { form } = createForm({
+		initialValues: book,
+		onSubmit
+	});
+</script>
+
+<form class="flex h-auto flex-col gap-y-6" use:form aria-label="Edit book details">
+	<div class="flex flex-col justify-between gap-6 p-6 lg:flex-row-reverse">
+		<div class="flex grow flex-col flex-wrap gap-y-4 lg:flex-row">
+			<div class="basis-full">
+				<TextField name="isbn" label="ISBN" />
+			</div>
+			<div class="basis-full">
+				<TextField name="title" label="Title" />
+			</div>
+		</div>
+	</div>
+	<div class="flex justify-end gap-x-2 p-4">
+		<Button color={ButtonColor.Secondary} on:click={() => onCancel}>Cancel</Button>
+		<Button>Save</Button>
+	</div>
+</form>

--- a/pkg/ui/src/Forms/BookDetailForm.svelte
+++ b/pkg/ui/src/Forms/BookDetailForm.svelte
@@ -10,7 +10,7 @@
 	import type { BookEntry } from './types';
 
 	export let book: BookEntry;
-	export let publisherList: string[];
+	export let publisherList: string[] = [];
 	export let onSubmit: (values: BookEntry) => void = () => {};
 	export let onCancel = () => {};
 
@@ -19,7 +19,7 @@
 		onSubmit
 	});
 
-	const publisherCombo = createCombobox({ label: 'Publisher list' });
+	const publisherCombo = createCombobox({ label: 'publisher' });
 </script>
 
 <form class="divide-y-gray-200 flex h-auto flex-col gap-y-6 divide-y-2" use:form aria-label="Edit book details">

--- a/pkg/ui/src/Forms/index.ts
+++ b/pkg/ui/src/Forms/index.ts
@@ -1,0 +1,3 @@
+export { default as BookDetailForm } from './BookDetailForm.svelte';
+
+export * from './types';

--- a/pkg/ui/src/Forms/schema/book-detail.schema.json
+++ b/pkg/ui/src/Forms/schema/book-detail.schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "book-detail.schema.json",
+    "title": "Book",
+    "description": "A book in stock",
+    "type": "object",
+    "properties": {
+      "isbn": {
+        "description": "The books unique ISBN",
+        "type": "string"
+      },
+      "title": {
+        "description": "The books title",
+        "type": "string"
+      },
+      "price": {
+        "description": "The books current price",
+        "type": "integer"
+      },
+      "year": {
+        "description": "The year the book was published",
+        "type": "string"
+      },
+      "authors": {
+        "description": "The books authors as a comma separated string",
+        "type": "string"
+      },
+      "publisher": {
+        "description": "The books publisher",
+        "type": "string"
+      },
+      "editedBy": {
+        "description": "The books editors as a comma separated string",
+        "type": "string"
+      },
+      "outOfPrint": {
+        "description": "Flag indicating if the book is no longer being printed by the publisher",
+        "type": "boolean"
+      }
+    },
+    "required": [ "isbn", "title", "price"]
+  }

--- a/pkg/ui/src/Forms/schema/book-detail.schema.json
+++ b/pkg/ui/src/Forms/schema/book-detail.schema.json
@@ -1,42 +1,42 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "book-detail.schema.json",
-    "title": "Book",
-    "description": "A book in stock",
-    "type": "object",
-    "properties": {
-      "isbn": {
-        "description": "The books unique ISBN",
-        "type": "string"
-      },
-      "title": {
-        "description": "The books title",
-        "type": "string"
-      },
-      "price": {
-        "description": "The books current price",
-        "type": "integer"
-      },
-      "year": {
-        "description": "The year the book was published",
-        "type": "string"
-      },
-      "authors": {
-        "description": "The books authors as a comma separated string",
-        "type": "string"
-      },
-      "publisher": {
-        "description": "The books publisher",
-        "type": "string"
-      },
-      "editedBy": {
-        "description": "The books editors as a comma separated string",
-        "type": "string"
-      },
-      "outOfPrint": {
-        "description": "Flag indicating if the book is no longer being printed by the publisher",
-        "type": "boolean"
-      }
-    },
-    "required": [ "isbn", "title", "price"]
-  }
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "book-detail.schema.json",
+	"title": "Book",
+	"description": "A book in stock",
+	"type": "object",
+	"properties": {
+		"isbn": {
+			"description": "The books unique ISBN",
+			"type": "string"
+		},
+		"title": {
+			"description": "The books title",
+			"type": "string"
+		},
+		"price": {
+			"description": "The books current price",
+			"type": "integer"
+		},
+		"year": {
+			"description": "The year the book was published",
+			"type": "string"
+		},
+		"authors": {
+			"description": "The books authors as a comma separated string",
+			"type": "string"
+		},
+		"publisher": {
+			"description": "The books publisher",
+			"type": "string"
+		},
+		"editedBy": {
+			"description": "The books editors as a comma separated string",
+			"type": "string"
+		},
+		"outOfPrint": {
+			"description": "Flag indicating if the book is no longer being printed by the publisher",
+			"type": "boolean"
+		}
+	},
+	"required": ["isbn", "title", "price"]
+}

--- a/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
+++ b/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
@@ -1,4 +1,4 @@
-import { it, describe, expect, afterEach, vi } from 'vitest';
+import { test, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 
@@ -23,99 +23,60 @@ afterEach(() => {
 	book = newBook();
 });
 
-it('Renders without exploding', () => {
+test('Renders without exploding', () => {
 	render(BookDetailForm, { book });
 	expect(screen.getByRole('form')).toBeInTheDocument();
 });
 
-describe('Sets form field initial values via props:', () => {
-	it('input -> isbn', () => {
-		const isbn = '819200012';
-		book.isbn = isbn;
+test('Sets form field initial values via props:', () => {
+	const isbn = '819200012';
+	const title = 'A brief history of the cosmos and essential kitchen appliances';
+	const price = 15;
+	const authors = 'Stephen Hawking, Bill Bryson';
+	const publisher = 'Penguin';
+	const editedBy = 'Anonymous';
+	const outOfPrint = true;
 
-		render(BookDetailForm, { book });
+	book.isbn = isbn;
+	book.title = title;
+	book.price = price;
+	book.authors = authors;
+	book.publisher = publisher;
+	book.editedBy = editedBy;
+	book.outOfPrint = outOfPrint;
 
-		expect(screen.getByRole('textbox', { name: 'isbn' })).toHaveValue(isbn);
-	});
+	render(BookDetailForm, { book });
 
-	it('input -> title', () => {
-		const title = 'A brief history of the cosmos and essential kitchen appliances';
-		book.title = title;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('textbox', { name: 'title' })).toHaveValue(title);
-	});
-
-	it('input -> price', () => {
-		const price = 15;
-		book.price = price;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('spinbutton', { name: 'price' })).toHaveValue(price);
-	});
-
-	it('input -> author', () => {
-		const authors = 'Stephen Hawking, Bill Bryson';
-		book.authors = authors;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('textbox', { name: 'authors' })).toHaveValue(authors);
-	});
-
-	it('input -> publisher', () => {
-		const publisher = 'Penguin';
-		book.publisher = publisher;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('combobox', { name: 'publisher' })).toHaveValue(publisher);
-	});
-
-	it('input -> editedBy', () => {
-		const editedBy = 'Anonymous';
-		book.editedBy = editedBy;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('textbox', { name: 'editedBy' })).toHaveValue(editedBy);
-	});
-
-	it('input -> outOfPrint', () => {
-		const outOfPrint = true;
-		book.outOfPrint = outOfPrint;
-
-		render(BookDetailForm, { book });
-
-		expect(screen.getByRole('checkbox', { name: 'Out of print' })).toBeChecked();
-	});
+	expect(screen.getByRole('textbox', { name: 'isbn' })).toHaveValue(isbn);
+	expect(screen.getByRole('textbox', { name: 'title' })).toHaveValue(title);
+	expect(screen.getByRole('spinbutton', { name: 'price' })).toHaveValue(price);
+	expect(screen.getByRole('textbox', { name: 'authors' })).toHaveValue(authors);
+	expect(screen.getByRole('combobox', { name: 'publisher' })).toHaveValue(publisher);
+	expect(screen.getByRole('textbox', { name: 'editedBy' })).toHaveValue(editedBy);
+	expect(screen.getByRole('checkbox', { name: 'Out of print' })).toBeChecked();
 });
 
-describe('Actions', async () => {
-	it('fires onSubmit & onCancel handlers', async () => {
-		const user = userEvent.setup();
+test('Fires onSubmit & onCancel handlers', async () => {
+	const user = userEvent.setup();
 
-		const mockSubmit = vi.fn();
-		const mockCancel = vi.fn();
+	const mockSubmit = vi.fn();
+	const mockCancel = vi.fn();
 
-		render(BookDetailForm, {
-			book,
-			onSubmit: mockSubmit,
-			onCancel: mockCancel
-		});
-
-		// TODO: For some reason mockSubmit is not being called. Have confirmed manually that this works.
-		// Likely because onSubmit is not being passed directly to button, but is managed through felte's `createForm`
-
-		// const saveButton = screen.getByText('Save');
-		const cancelButton = screen.getByText('Cancel');
-
-		// await user.click(saveButton);
-		await user.click(cancelButton);
-
-		// expect(mockSubmit).toHaveBeenCalled();
-		expect(mockCancel).toHaveBeenCalled();
+	render(BookDetailForm, {
+		book,
+		onSubmit: mockSubmit,
+		onCancel: mockCancel
 	});
+
+	// TODO: For some reason mockSubmit is not being called. Have confirmed manually that this works.
+	// Likely because onSubmit is not being passed directly to button, but is managed through felte's `createForm`
+
+	// const saveButton = screen.getByText('Save');
+	const cancelButton = screen.getByText('Cancel');
+
+	// await user.click(saveButton);
+	await user.click(cancelButton);
+
+	// expect(mockSubmit).toHaveBeenCalled();
+	expect(mockCancel).toHaveBeenCalled();
 });

--- a/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
+++ b/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
@@ -1,0 +1,121 @@
+import { it, describe, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+
+import { BookDetailForm } from '$lib/Forms';
+
+const newBook = () => ({
+	isbn: '',
+	title: '',
+	price: 0,
+	year: '',
+	authors: '',
+	publisher: '',
+	editedBy: '',
+	outOfPrint: false
+});
+
+let book = newBook();
+
+afterEach(() => {
+	cleanup();
+	vi.resetAllMocks();
+	book = newBook();
+});
+
+it('Renders without exploding', () => {
+	render(BookDetailForm, { book });
+	expect(screen.getByRole('form')).toBeInTheDocument();
+});
+
+describe('Sets form field initial values via props:', () => {
+	it('input -> isbn', () => {
+		const isbn = '819200012';
+		book.isbn = isbn;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('textbox', { name: 'isbn' })).toHaveValue(isbn);
+	});
+
+	it('input -> title', () => {
+		const title = 'A brief history of the cosmos and essential kitchen appliances';
+		book.title = title;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('textbox', { name: 'title' })).toHaveValue(title);
+	});
+
+	it('input -> price', () => {
+		const price = 15;
+		book.price = price;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('spinbutton', { name: 'price' })).toHaveValue(price);
+	});
+
+	it('input -> author', () => {
+		const authors = 'Stephen Hawking, Bill Bryson';
+		book.authors = authors;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('textbox', { name: 'authors' })).toHaveValue(authors);
+	});
+
+	it('input -> publisher', () => {
+		const publisher = 'Penguin';
+		book.publisher = publisher;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('textbox', { name: 'publisher' })).toHaveValue(publisher);
+	});
+
+	it('input -> editedBy', () => {
+		const editedBy = 'Anonymous';
+		book.editedBy = editedBy;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('textbox', { name: 'editedBy' })).toHaveValue(editedBy);
+	});
+
+	it('input -> outOfPrint', () => {
+		const outOfPrint = true;
+		book.outOfPrint = outOfPrint;
+
+		render(BookDetailForm, { book });
+
+		expect(screen.getByRole('checkbox', { name: 'Out of print' })).toBeChecked();
+	});
+});
+
+describe('Actions', async () => {
+	it('fires onSubmit & onCancel handlers', async () => {
+		const user = userEvent.setup();
+
+		const mockSubmit = vi.fn();
+		const mockCancel = vi.fn();
+
+		render(BookDetailForm, {
+			book,
+			onSubmit: mockSubmit,
+			onCancel: mockCancel
+		});
+
+		// TODO: For some reason mockSubmit is not being called. Have confirmed manually that this works.
+		// Likely because onSubmit is not being passed directly to button, but is managed through felte's `createForm`
+
+		// const saveButton = screen.getByText('Save');
+		const cancelButton = screen.getByText('Cancel');
+
+		// await user.click(saveButton);
+		await user.click(cancelButton);
+
+		// expect(mockSubmit).toHaveBeenCalled();
+		expect(mockCancel).toHaveBeenCalled();
+	});
+});

--- a/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
+++ b/pkg/ui/src/Forms/tests/BookDetailForm.spec.ts
@@ -71,7 +71,7 @@ describe('Sets form field initial values via props:', () => {
 
 		render(BookDetailForm, { book });
 
-		expect(screen.getByRole('textbox', { name: 'publisher' })).toHaveValue(publisher);
+		expect(screen.getByRole('combobox', { name: 'publisher' })).toHaveValue(publisher);
 	});
 
 	it('input -> editedBy', () => {

--- a/pkg/ui/src/Forms/types.ts
+++ b/pkg/ui/src/Forms/types.ts
@@ -1,8 +1,10 @@
 export interface BookEntry {
 	isbn: string;
 	title: string;
-	authors?: string[];
-	publisher?: string;
+	price: number;
 	year?: string;
-	price?: number;
+	authors?: string;
+	publisher?: string;
+	editedBy?: string;
+	outOfPrint?: string;
 }

--- a/pkg/ui/src/Forms/types.ts
+++ b/pkg/ui/src/Forms/types.ts
@@ -6,5 +6,5 @@ export interface BookEntry {
 	authors?: string;
 	publisher?: string;
 	editedBy?: string;
-	outOfPrint?: string;
+	outOfPrint?: boolean;
 }

--- a/pkg/ui/src/Forms/types.ts
+++ b/pkg/ui/src/Forms/types.ts
@@ -1,0 +1,8 @@
+export interface BookEntry {
+	isbn: string;
+	title: string;
+	authors?: string[];
+	publisher?: string;
+	year?: string;
+	price?: number;
+}

--- a/pkg/ui/src/Menus/ComboboxMenu.story.svelte
+++ b/pkg/ui/src/Menus/ComboboxMenu.story.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { Hst } from '@histoire/plugin-svelte';
+	import { createCombobox } from 'svelte-headlessui';
+	import { ChevronsUpDown } from 'lucide-svelte';
+
+	import ComboboxMenu from './ComboboxMenu.svelte';
+	import { TextField } from '../FormFields';
+
+	export let Hst: Hst;
+
+	const options = ['TCK Publishing', 'Reed Elsevier', 'Penguin Random House', 'Harper Collins', 'Bloomsbury'];
+
+	const combobox = createCombobox({ label: 'Test combobox', expanded: true });
+</script>
+
+<Hst.Story title="Menus / Combobox" layout={{ type: 'grid', width: 600 }}>
+	<div class="relative m-2 h-72 w-4/6">
+		<TextField name="publisher" label="Publisher" inputAction={combobox.input} value={$combobox.selected}>
+			<div slot="endAdornment">
+				<button use:combobox.button type="button" class="flex items-center">
+					<ChevronsUpDown class="text-gray-400" />
+				</button>
+			</div>
+		</TextField>
+		<ComboboxMenu {combobox} {options} />
+	</div>
+</Hst.Story>

--- a/pkg/ui/src/Menus/ComboboxMenu.svelte
+++ b/pkg/ui/src/Menus/ComboboxMenu.svelte
@@ -27,7 +27,7 @@
 			{@const active = $combobox.active === value}
 			{@const selected = $combobox.selected === value}
 			<li
-				class="relative cursor-default select-none py-2 pl-10 pr-4 {active
+				class="relative cursor-pointer select-none py-2 pl-10 pr-4 {active
 					? 'bg-teal-500 text-white'
 					: 'text-gray-900'}"
 				use:combobox.item={{ value }}

--- a/pkg/ui/src/Menus/ComboboxMenu.svelte
+++ b/pkg/ui/src/Menus/ComboboxMenu.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import Transition from 'svelte-transition';
+	import { Check } from 'lucide-svelte';
+
+	import type { createCombobox } from 'svelte-headlessui';
+
+	export let combobox: ReturnType<typeof createCombobox>;
+	export let options: string[];
+
+	$: filtered = options.filter((person) =>
+		person.toLowerCase().replace(/\s+/g, '').includes($combobox.filter.toLowerCase().replace(/\s+/g, ''))
+	);
+</script>
+
+<Transition
+	show={$combobox.expanded}
+	leave="transition ease-in duration-100"
+	leaveFrom="opacity-100"
+	leaveTo="opacity-0"
+	on:after-leave={() => combobox.reset()}
+>
+	<ul
+		use:combobox.items
+		class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-md"
+	>
+		{#each filtered as value}
+			{@const active = $combobox.active === value}
+			{@const selected = $combobox.selected === value}
+			<li
+				class="relative cursor-default select-none py-2 pl-10 pr-4 {active
+					? 'bg-teal-500 text-white'
+					: 'text-gray-900'}"
+				use:combobox.item={{ value }}
+			>
+				<span class="block truncate {selected ? 'font-medium' : 'font-normal'}">{value}</span>
+				{#if selected}
+					<span
+						class="absolute inset-y-0 left-0 flex items-center pl-3 {active
+							? 'text-white'
+							: 'text-teal-500'}"
+					>
+						<Check />
+					</span>
+				{/if}
+			</li>
+		{:else}
+			<li class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900">
+				<span class="block truncate font-normal">Nothing found</span>
+			</li>
+		{/each}
+	</ul>
+</Transition>

--- a/pkg/ui/src/Menus/index.ts
+++ b/pkg/ui/src/Menus/index.ts
@@ -1,0 +1,1 @@
+export { default as ComboboxMenu } from './ComboboxMenu.svelte';

--- a/pkg/ui/src/index.ts
+++ b/pkg/ui/src/index.ts
@@ -13,3 +13,4 @@ export * from './Header';
 export * from './Dropdown';
 export * from './SelectMenu';
 export * from './TextEditable';
+export * from './Forms';

--- a/pkg/ui/vite.config.js
+++ b/pkg/ui/vite.config.js
@@ -15,7 +15,6 @@ const config = {
 				open: true,
 				fs: {
 					// Allow serving files from workspace root with dev server
-
 					allow: [searchForWorkspaceRoot(process.cwd()), '../..']
 				}
 			}

--- a/pkg/ui/vite.config.js
+++ b/pkg/ui/vite.config.js
@@ -1,6 +1,8 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { HstSvelte } from '@histoire/plugin-svelte';
 
+import { searchForWorkspaceRoot } from 'vite';
+
 /** @type {import('vite').UserConfig} */
 const config = {
 	plugins: [sveltekit()],
@@ -10,7 +12,12 @@ const config = {
 		vite: {
 			base: '/',
 			server: {
-				open: true
+				open: true,
+				fs: {
+					// Allow serving files from workspace root with dev server
+
+					allow: [searchForWorkspaceRoot(process.cwd()), '../..']
+				}
 			}
 		}
 	},

--- a/pkg/ui/vitest.config.ts
+++ b/pkg/ui/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'jsdom',
-		deps: { inline: true }
+		deps: { inline: true },
+		// Add @testing-library/jest-dom matchers and mock modules
+		setupFiles: ['./vitest.setup.ts']
 	}
 });

--- a/pkg/ui/vitest.setup.ts
+++ b/pkg/ui/vitest.setup.ts
@@ -1,0 +1,15 @@
+import { expect } from "vitest";
+import matchers, { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+
+// Required to appease TS
+// Merges standard matchers declaration with js-dom extensions
+declare global {
+	namespace Vi {
+		interface JestAssertion<T = any>
+			extends jest.Matchers<void, T>,
+				TestingLibraryMatchers<T, void> {}
+	}
+}
+
+// Add custom jest matchers
+expect.extend(matchers);

--- a/pkg/ui/vitest.setup.ts
+++ b/pkg/ui/vitest.setup.ts
@@ -1,13 +1,11 @@
-import { expect } from "vitest";
-import matchers, { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+import { expect } from 'vitest';
+import matchers, { TestingLibraryMatchers } from '@testing-library/jest-dom/matchers';
 
 // Required to appease TS
 // Merges standard matchers declaration with js-dom extensions
 declare global {
 	namespace Vi {
-		interface JestAssertion<T = any>
-			extends jest.Matchers<void, T>,
-				TestingLibraryMatchers<T, void> {}
+		interface JestAssertion<T = any> extends jest.Matchers<void, T>, TestingLibraryMatchers<T, void> {}
 	}
 }
 


### PR DESCRIPTION
Fixes #117 

Some notes:
1. `BookEntry` is borrowed from `pkg/db`. Opted for this as a temp measure to avoid adding db package to UI package; this can be resolved if we move UI into web-client, or via shared type package. Also had a discussion with Silvio over form data, and updated to reflect the outcome of this discussion:
    1. `authors` => from `string[]` to `string` (of comma separated names)
    2. + `editedBy` - string
    3. + `outOfPrint` - boolean
2. I have added a `book-detail.schema.json` to describe the forms shape. I have not yet used it for validation as planned because:
    1. The form is quite simple, and the "required" validation for isbn, title, and price is (at least in Firefox & Safari) handled natively.
    2. I need to put some more research & time into choosing & adding a [validator](https://felte.dev/docs/svelte/validators) & [reporter](https://felte.dev/docs/svelte/reporters). It doesn't feel essential for this form, but it's a decision I would like to make for our general form building procedure.
3. As I mentioned on call this morning, I have also:
    1. Extended test setup based off of this write-up: [svelte-component-test-recipes](https://github.com/davipon/svelte-component-test-recipes)
    2. Extended Button & FormFields prop types based off of this write-up: [Typing components in svelte](https://www.viget.com/articles/typing-components-in-svelte/) (which is a write-up of this official [RFC](https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md)
   3. And of course, the beloved [svelte-headlessui](https://captaincodeman.github.io/svelte-headlessui/) has been introduced to handle the Publisher input combobox. Take a look at it. It's lovely isn't it? (Even if you disagree) I will proceed to replace it in other places (namely the SelectMenu & TabNav).