### PR TITLE
Fix database typing (in tests and otherwise)

### DIFF
--- a/apps/web-client/src/lib/__testUtils__/db.ts
+++ b/apps/web-client/src/lib/__testUtils__/db.ts
@@ -1,6 +1,7 @@
 import PouchDB from 'pouchdb';
 import MemoryAdapter from 'pouchdb-adapter-memory';
 import { v4 as uuid } from 'uuid';
+
 import { newDatabaseInterface } from '@librocco/db';
 
 // Enable running of the tests against in-memory PouchDB

--- a/pkg/db/src/index.ts
+++ b/pkg/db/src/index.ts
@@ -1,7 +1,9 @@
 import { currentVersion } from './currentVersion';
 
 import * as implementations from './implementations';
-const newDatabaseInterface = implementations[currentVersion];
+import type { NewDatabase } from './types';
+
+const newDatabaseInterface = implementations[currentVersion] as NewDatabase;
 export { newDatabaseInterface };
 
 export * from './enums';

--- a/pkg/db/src/types/index.ts
+++ b/pkg/db/src/types/index.ts
@@ -196,4 +196,8 @@ export interface DatabaseInterface<W extends WarehouseInterface = WarehouseInter
 	stream: (ctx: debug.DebugCtx) => DbStream;
 	init: (params: { remoteDb?: string }, ctx: debug.DebugCtx) => Promise<DatabaseInterface>;
 }
+
+export interface NewDatabase {
+	(db: PouchDB.Database): DatabaseInterface;
+}
 // #endregion db


### PR DESCRIPTION
Small fix to standardise `@librocco/db` exported types