### PR TITLE
Update/no committed notes in nav

### DIFF
--- a/apps/web-client/src/lib/data.ts
+++ b/apps/web-client/src/lib/data.ts
@@ -1,0 +1,14 @@
+export const inventoryLinks = [
+	{
+		label: 'Stock',
+		href: '/inventory/stock'
+	},
+	{
+		label: 'Inbound',
+		href: '/inventory/inbound'
+	},
+	{
+		label: 'Outbound',
+		href: '/inventory/outbound'
+	}
+];

--- a/apps/web-client/src/routes/debug/+page.svelte
+++ b/apps/web-client/src/routes/debug/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { ChevronLeft as SA } from 'lucide-svelte';
+
+	import { Button, ButtonColor, Header, InventoryPage } from '@librocco/ui';
+
+	import { getDB } from '$lib/db';
+
+	const destroyDB = () => getDB()._pouch.destroy();
+</script>
+
+<InventoryPage>
+	<!-- Header slot -->
+	<Header currentLocation="/" title="Debug" slot="header" />
+
+	<section class="px-48 pt-14" slot="table">
+		<div class="mb-12">
+			<a href="/inventory/stock">
+				<Button color={ButtonColor.White}><SA slot="startAdornment" />Back to inventory</Button>
+			</a>
+		</div>
+		<div class="mb-5 w-3/4 py-5">
+			<h2 class="mb-6 text-2xl">Destroy IndexedDB</h2>
+			<p class="mb-6 text-gray-500">
+				Click here to destroy the db instance. This is a convenience action to avoid having to manually delete
+				the IndexedDB, which can, sometimes, cause problems with Chrome's storage for the route. <br /><br />
+				If you wish to reset the db (destroy it and initialise a new instance), you can click this button and then
+				refresh the page (or click "Back to inventory" button). This will initialise the new instance of the db and,
+				if the docker dev db is running, populate the db with the data pulled from the remote db.
+			</p>
+			<Button on:click={destroyDB}>Destroy IndexedDB</Button>
+		</div>
+	</section>
+</InventoryPage>

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -31,6 +31,8 @@
 	import { generateUpdatedAtString } from '$lib/utils/time';
 	import { readableFromStream } from '$lib/utils/streams';
 
+	import { inventoryLinks } from '$lib/data';
+
 	export let data: PageData;
 
 	// Db will be undefined only on server side. If in browser,
@@ -68,7 +70,7 @@
 <!-- svelte-ignore missing-declaration -->
 <InventoryPage>
 	<!-- Header slot -->
-	<Header title="Inbound" currentLocation="/inventory/inbound" slot="header" />
+	<Header links={inventoryLinks} title="Inbound" currentLocation="/inventory/inbound" slot="header" />
 
 	<!-- Sidebar slot -->
 	<SideBarNav slot="sidebar">

--- a/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
@@ -30,6 +30,7 @@
 
 	import { generateUpdatedAtString } from '$lib/utils/time';
 	import { readableFromStream } from '$lib/utils/streams';
+	import { inventoryLinks } from '$lib/data';
 
 	export let data: PageData;
 
@@ -65,7 +66,7 @@
 
 <InventoryPage>
 	<!-- Header slot -->
-	<Header title="Outbound" currentLocation="/inventory/outbound" slot="header" />
+	<Header links={inventoryLinks} title="Outbound" currentLocation="/inventory/outbound" slot="header" />
 
 	<!-- Sidebar slot -->
 	<SideBarNav slot="sidebar">

--- a/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
@@ -25,6 +25,8 @@
 
 	import { readableFromStream } from '$lib/utils/streams';
 
+	import { inventoryLinks } from '$lib/data';
+
 	export let data: PageData;
 
 	// Db will be undefined only on server side. If in browser,
@@ -57,7 +59,7 @@
 
 <InventoryPage>
 	<!-- Header slot -->
-	<Header title="Stock" currentLocation="/inventory/stock" slot="header" />
+	<Header links={inventoryLinks} title="Stock" currentLocation="/inventory/stock" slot="header" />
 
 	<!-- Sidebar slot -->
 	<SideBarNav slot="sidebar">

--- a/pkg/db/src/implementations/version-1.1/designDocuments.ts
+++ b/pkg/db/src/implementations/version-1.1/designDocuments.ts
@@ -90,17 +90,28 @@ export const listDeisgnDocument: DesignDocument = {
 		},
 		outbound: {
 			map: function (doc: NoteData | WarehouseData) {
-				if (doc.docType === 'note' && (doc as NoteData).noteType === 'outbound') {
-					emit(doc._id, { displayName: doc.displayName });
+				if (doc.docType !== 'note' || (doc as NoteData).noteType !== 'outbound') {
+					return;
 				}
+
+				const note = doc as NoteData;
+
+				emit(doc._id, { displayName: doc.displayName, committed: note.committed });
 			}.toString()
 		},
 		inbound: {
 			map: function (doc: NoteData | WarehouseData) {
-				// Emit warehouse and inbound note documents
-				if (doc.docType === 'warehouse' || (doc.docType === 'note' && (doc as NoteData).noteType === 'inbound')) {
+				if (doc.docType === 'warehouse') {
 					emit(doc._id, { type: doc.docType, displayName: doc.displayName });
+					return;
 				}
+
+				const note = doc as NoteData;
+				if (note.docType !== 'note' || note.noteType !== 'inbound') {
+					return;
+				}
+
+				emit(doc._id, { type: doc.docType, displayName: doc.displayName, committed: note.committed });
 			}.toString()
 		}
 	}

--- a/pkg/db/src/implementations/version-1.1/misc.ts
+++ b/pkg/db/src/implementations/version-1.1/misc.ts
@@ -1,0 +1,4 @@
+export const replicationError = `The above error originated from the db replication process. 
+Please check the remote db's availability. 
+
+Note: This error is not fatal and the app will continue with local-db only.`;

--- a/pkg/db/src/utils/pouchdb.ts
+++ b/pkg/db/src/utils/pouchdb.ts
@@ -217,12 +217,12 @@ export const replicateFromRemote: ReplicateFn = ({ remote, local }, ctx) =>
 			.on('denied', (error) => {
 				// boo, something went wrong!
 				debug.log(ctx, 'replicate_from_remote:error')({ ...info, error });
-				reject();
+				reject(error);
 			})
 			.on('error', (error) => {
 				// boo, something went wrong!
 				debug.log(ctx, 'replicate_from_remote:error')({ ...info, error });
-				reject();
+				reject(error);
 			});
 	});
 

--- a/pkg/ui/src/Header/Header.svelte
+++ b/pkg/ui/src/Header/Header.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
 	import Logo from './Logo.svelte';
 
+	interface HeaderLink {
+		label: string;
+		href: string;
+	}
+
 	export let title = 'Stock';
 	export let currentLocation: string;
-
-	const links = [
-		{
-			label: 'Stock',
-			href: '/inventory/stock'
-		},
-		{
-			label: 'Inbound',
-			href: '/inventory/inbound'
-		},
-		{
-			label: 'Outbound',
-			href: '/inventory/outbound'
-		}
-	];
+	export let links = [] as HeaderLink[];
 </script>
 
 <header class="w-full bg-gray-900 px-[70px]">


### PR DESCRIPTION
As discussed, this PR disables the displaying of committed notes in `/inventory` page.

The dev db image has also been updated to leave 5 notes per warehouse (including 5 outbound notes) as not committed (to give us something to work with in dev app)