### PR TITLE
Prepend all design documents with version string

### DIFF
--- a/pkg/db/src/implementations/version-1.1/db.ts
+++ b/pkg/db/src/implementations/version-1.1/db.ts
@@ -109,7 +109,7 @@ class Database implements DatabaseInterface {
 		return {
 			warehouseList: newViewStream<{ rows: { key: string; value: { displayName?: string } } }, NavListEntry[]>(
 				this._pouch,
-				'list/warehouses',
+				'v1_list/warehouses',
 				{},
 				({ rows }) => rows.map(({ key: id, value: { displayName = '' } }) => ({ id, displayName })),
 				ctx
@@ -117,7 +117,7 @@ class Database implements DatabaseInterface {
 
 			outNoteList: newViewStream<{ rows: { key: string; value: { displayName?: string } } }, NavListEntry[]>(
 				this._pouch,
-				'list/outbound',
+				'v1_list/outbound',
 				{},
 				({ rows }) => rows.map(({ key: id, value: { displayName = '' } }) => ({ id, displayName })),
 				ctx
@@ -125,7 +125,7 @@ class Database implements DatabaseInterface {
 
 			inNoteList: newViewStream<{ rows: { key: string; value: { type: DocType; displayName?: string } } }, InNoteList>(
 				this._pouch,
-				'list/inbound',
+				'v1_list/inbound',
 				{},
 				({ rows }) =>
 					rows.reduce((acc, { key, value: { type, displayName = '' } }) => {

--- a/pkg/db/src/implementations/version-1.1/designDocuments.ts
+++ b/pkg/db/src/implementations/version-1.1/designDocuments.ts
@@ -3,7 +3,7 @@ import { DesignDocument } from '@/types';
 import { WarehouseData, NoteData } from './types';
 
 const sequenceNamingDesignDocument: DesignDocument = {
-	_id: '_design/sequence',
+	_id: '_design/v1_sequence',
 	views: {
 		warehouse: {
 			map: function (doc: WarehouseData) {
@@ -39,7 +39,7 @@ const sequenceNamingDesignDocument: DesignDocument = {
 };
 
 const warehouseDesignDocument: DesignDocument = {
-	_id: '_design/warehouse',
+	_id: '_design/v1_warehouse',
 	views: {
 		stock: {
 			map: function (doc: WarehouseData | NoteData) {
@@ -61,7 +61,7 @@ const warehouseDesignDocument: DesignDocument = {
 };
 
 /**
- * A row in `_design/warehouse/_view/stock` query reponse.
+ * A row in `_design/v1_warehouse/_view/stock` query reponse.
  * The rows are sorted by warehouse and isbn. There might be multiple entries
  * for each [warehouse, isbn] pair so the results should be aggregated to show real quantity.
  */
@@ -79,7 +79,7 @@ export type WarehouseStockEntry = {
 };
 
 export const listDeisgnDocument: DesignDocument = {
-	_id: '_design/list',
+	_id: '_design/v1_list',
 	views: {
 		warehouses: {
 			map: function (doc: WarehouseData | NoteData) {

--- a/pkg/db/src/implementations/version-1.1/note.ts
+++ b/pkg/db/src/implementations/version-1.1/note.ts
@@ -124,7 +124,7 @@ class Note implements NoteInterface {
 
 			const updatedAt = new Date().toISOString();
 
-			const sequentialNumber = (await this.#db._pouch.query('sequence/note')).rows[0];
+			const sequentialNumber = (await this.#db._pouch.query('v1_sequence/note')).rows[0];
 			const seqIndex = sequentialNumber ? sequentialNumber.value.max && ` (${sequentialNumber.value.max + 1})` : '';
 
 			const initialValues = { ...this, displayName: `New Note${seqIndex}`, updatedAt };

--- a/pkg/db/src/implementations/version-1.1/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.1/warehouse.ts
@@ -113,7 +113,7 @@ class Warehouse implements WarehouseInterface {
 
 			let sequentialNumber = 0;
 			try {
-				const sequenceQuery = await this.#db._pouch.query('sequence/warehouse');
+				const sequenceQuery = await this.#db._pouch.query('v1_sequence/warehouse');
 				sequentialNumber = sequenceQuery.rows[0].value.max;
 			} catch {
 				//
@@ -234,7 +234,7 @@ class Warehouse implements WarehouseInterface {
 			entries: combineLatest([
 				newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
 					this.#db._pouch,
-					'warehouse/stock',
+					'v1_warehouse/stock',
 					{
 						group_level: 2,
 						...(this._id !== versionId('0-all') && {


### PR DESCRIPTION
Fixes #175 
I couldn't get the design document queries to work if prepending like this `_design/v1/<design-doc-name>`, so I've resorted to `_design/v1_<design-doc-name>`