### PR TITLE
Add some db guards:

### DIFF
--- a/pkg/db/src/__tests__/tests.ts
+++ b/pkg/db/src/__tests__/tests.ts
@@ -727,7 +727,7 @@ export const dbGuards: TestFunction = async (db) => {
 	// The db should not allow for committing of inbound notes with transactions belonging
 	// to warehouse different then note's parent warehouse.
 	const note1 = await db.warehouse('warehouse-1').note().create();
-	await note1.addVolumes('12345678', 2, versionId('warehouse-2'));
+	await note1.addVolumes({ isbn: '12345678', quantity: 2, warehouseId: 'warehouse-2' });
 
 	await expect(note1.commit({})).rejects.toThrow(
 		new TransactionWarehouseMismatchError(versionId('warehouse-1'), [{ isbn: '12345678', warehouseId: versionId('warehouse-2') }])
@@ -741,7 +741,12 @@ export const dbGuards: TestFunction = async (db) => {
 	await wh1
 		.note()
 		.create()
-		.then((n) => n.addVolumes(['11111111', 2, versionId('warehouse-1')], ['12345678', 3, versionId('warehouse-1')]))
+		.then((n) =>
+			n.addVolumes(
+				{ isbn: '11111111', quantity: 2, warehouseId: 'warehouse-1' },
+				{ isbn: '12345678', quantity: 3, warehouseId: 'warehouse-1' }
+			)
+		)
 		.then((n) => n.commit({}));
 
 	// Current state of the warehouse is:
@@ -754,7 +759,7 @@ export const dbGuards: TestFunction = async (db) => {
 		.note()
 		.create()
 		// "11111111": 4 (required) > "11111111": 2 (available in warehouse)
-		.then((n) => n.addVolumes(['11111111', 4, versionId('warehouse-1')]));
+		.then((n) => n.addVolumes({ isbn: '11111111', quantity: 4, warehouseId: 'warehouse-1' }));
 
 	await expect(note2.commit({})).rejects.toThrow(
 		new OutOfStockError([{ isbn: '11111111', warehouseId: versionId('warehouse-1'), quantity: 4, available: 2 }])
@@ -766,7 +771,7 @@ export const dbGuards: TestFunction = async (db) => {
 	await wh1
 		.note()
 		.create()
-		.then((n) => n.addVolumes(['11111111', 2, versionId('warehouse-1')]))
+		.then((n) => n.addVolumes({ isbn: '11111111', quantity: 2, warehouseId: 'warehouse-1' }))
 		.then((n) => n.commit({}));
 
 	// Current state of the warehouse is:
@@ -787,7 +792,7 @@ export const dbGuards: TestFunction = async (db) => {
 			.note()
 			.create()
 			// There are no more "11111111" books available in the warehouse
-			.then((n) => n.addVolumes(['11111111', 1, versionId('warehouse-1')]))
+			.then((n) => n.addVolumes({ isbn: '11111111', quantity: 1, warehouseId: 'warehouse-1' }))
 			.then((n) => n.commit({}))
 	).rejects.toThrow(new OutOfStockError([{ isbn: '11111111', warehouseId: versionId('warehouse-1'), quantity: 1, available: 0 }]));
 
@@ -797,7 +802,7 @@ export const dbGuards: TestFunction = async (db) => {
 			.warehouse()
 			.note()
 			.create()
-			.then((n) => n.addVolumes('11111111', 2))
+			.then((n) => n.addVolumes({ isbn: '11111111', quantity: 2 }))
 			.then((n) => n.commit({}))
 	).rejects.toThrow(new OutOfStockError([{ isbn: '11111111', warehouseId: '' as VersionedString, quantity: 2, available: 0 }]));
 };

--- a/pkg/db/src/errors.ts
+++ b/pkg/db/src/errors.ts
@@ -1,0 +1,38 @@
+import { VolumeStock } from './types';
+
+export class TransactionWarehouseMismatchError extends Error {
+	parentWarehouse: string;
+	invalidTransactions: Omit<VolumeStock, 'quantity'>[];
+
+	constructor(parentWarehouse: string, invalidTransactions: Omit<VolumeStock, 'quantity'>[]) {
+		const message = `Trying to commit a note containing transactions belonging to a different warehouse than the note itself.
+    Note's parent warehouse: '${parentWarehouse}'
+    Invalid transactions:
+    ${invalidTransactions.map(({ isbn, warehouseId }) => `ISBN: '${isbn}', warehouse: '${warehouseId}'`).join(`
+    `)}`;
+
+		super(message);
+		this.parentWarehouse = parentWarehouse;
+		this.invalidTransactions = invalidTransactions;
+	}
+}
+
+interface OutOfStockTransaction extends VolumeStock {
+	available: number;
+}
+export class OutOfStockError extends Error {
+	invalidTransactions: OutOfStockTransaction[];
+
+	constructor(invalidTransactions: OutOfStockTransaction[]) {
+		const message = `Trying to commit a note containing transactions that would result in a negative stock.
+        Invalid transactions:
+        ${invalidTransactions.map(
+			({ isbn, warehouseId, quantity, available }) =>
+				`ISBN: '${isbn}', warehouse: '${warehouseId}', quantity: ${quantity}, available in warehouse: ${available}`
+		).join(`
+        `)}`;
+
+		super(message);
+		this.invalidTransactions = invalidTransactions;
+	}
+}

--- a/pkg/db/src/implementations/version-1.1/designDocuments.ts
+++ b/pkg/db/src/implementations/version-1.1/designDocuments.ts
@@ -38,10 +38,10 @@ const sequenceNamingDesignDocument: DesignDocument = {
 	}
 };
 
-const warehouseDesignDocument: DesignDocument = {
-	_id: '_design/v1_warehouse',
+const stockDesignDocument: DesignDocument = {
+	_id: '_design/v1_stock',
 	views: {
-		stock: {
+		by_warehouse: {
 			map: function (doc: WarehouseData | NoteData) {
 				const { entries, committed } = doc as NoteData;
 
@@ -56,6 +56,21 @@ const warehouseDesignDocument: DesignDocument = {
 				}
 			}.toString(),
 			reduce: '_sum'
+		},
+		by_isbn: {
+			map: function (doc: WarehouseData | NoteData) {
+				const { entries, committed } = doc as NoteData;
+
+				// Account for book transactions only if the note is committed
+				if (doc.docType === 'note' && entries && committed) {
+					entries.forEach((entry) => {
+						// Check if we should be incrementing or decrementing the overall quantity
+						const delta = (doc as NoteData).noteType === 'inbound' ? entry.quantity : -entry.quantity;
+
+						emit([entry.isbn, entry.warehouseId], delta);
+					});
+				}
+			}.toString()
 		}
 	}
 };
@@ -117,4 +132,4 @@ export const listDeisgnDocument: DesignDocument = {
 	}
 };
 
-export default [warehouseDesignDocument, listDeisgnDocument, sequenceNamingDesignDocument];
+export default [stockDesignDocument, listDeisgnDocument, sequenceNamingDesignDocument];

--- a/pkg/db/src/implementations/version-1.1/designDocuments.ts
+++ b/pkg/db/src/implementations/version-1.1/designDocuments.ts
@@ -70,7 +70,8 @@ const stockDesignDocument: DesignDocument = {
 						emit([entry.isbn, entry.warehouseId], delta);
 					});
 				}
-			}.toString()
+			}.toString(),
+			reduce: '_sum'
 		}
 	}
 };

--- a/pkg/db/src/implementations/version-1.1/note.ts
+++ b/pkg/db/src/implementations/version-1.1/note.ts
@@ -219,7 +219,7 @@ class Note implements NoteInterface {
 	addVolumes(...params: Parameters<NoteInterface['addVolumes']>): Promise<NoteInterface> {
 		return runAfterCondition(async () => {
 			params.forEach((update) => {
-				const warehouseId = this.noteType === 'inbound' ? this.#w._id : update.warehouseId ? versionId(update.warehouseId) : '';
+				const warehouseId = update.warehouseId ? versionId(update.warehouseId) : this.noteType === 'inbound' ? this.#w._id : '';
 
 				const matchIndex = this.entries.findIndex(
 					(entry) => entry.isbn === update.isbn && entry.warehouseId === update.warehouseId
@@ -248,7 +248,7 @@ class Note implements NoteInterface {
 		const transaction = {
 			isbn,
 			quantity,
-			warehouseId: this.noteType === 'inbound' ? this.#w._id : warehouseId ? versionId(warehouseId) : ''
+			warehouseId: warehouseId ? versionId(warehouseId) : this.noteType === 'inbound' ? this.#w._id : ''
 		};
 
 		const i = entries.findIndex((e) => e.isbn === transaction.isbn && e.warehouseId === transaction.warehouseId);
@@ -267,7 +267,7 @@ class Note implements NoteInterface {
 		const removeTransaction = (transaction: Omit<VolumeStock, 'quantity'>) => {
 			// If this is an inbound note, we infer the warehouse id from the note itself.
 			// If this is an outbound note, we read the transaction's warehouse id, or falling back to an empty string (warhehouse not assigned).
-			const wh = this.noteType === 'inbound' ? this.#w._id : transaction.warehouseId ? versionId(transaction.warehouseId) : '';
+			const wh = transaction.warehouseId ? versionId(transaction.warehouseId) : this.noteType === 'inbound' ? this.#w._id : '';
 
 			this.entries = this.entries.filter(({ isbn, warehouseId }) => isbn !== transaction.isbn || warehouseId !== wh);
 		};

--- a/pkg/db/src/implementations/version-1.1/note.ts
+++ b/pkg/db/src/implementations/version-1.1/note.ts
@@ -280,7 +280,11 @@ class Note implements NoteInterface {
 	private async getStockPerIsbn(isbns: string[]): Promise<Record<string, number>[]> {
 		return Promise.all(
 			isbns.map(async (isbn) => {
-				const { rows } = await this.#db._pouch.query<number>('v1_stock/by_isbn', { startkey: [isbn], endkey: [isbn, {}] });
+				const { rows } = await this.#db._pouch.query<number>('v1_stock/by_isbn', {
+					startkey: [isbn],
+					endkey: [isbn, {}],
+					group_level: 2
+				});
 				return rows.reduce((acc, { key: [, warehouseId], value: quantity }) => ({ ...acc, [warehouseId]: quantity }), {});
 			})
 		);

--- a/pkg/db/src/implementations/version-1.1/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.1/warehouse.ts
@@ -234,7 +234,7 @@ class Warehouse implements WarehouseInterface {
 			entries: combineLatest([
 				newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
 					this.#db._pouch,
-					'v1_warehouse/stock',
+					'v1_stock/by_warehouse',
 					{
 						group_level: 2,
 						...(this._id !== versionId('0-all') && {

--- a/pkg/db/src/index.ts
+++ b/pkg/db/src/index.ts
@@ -9,3 +9,4 @@ export { newDatabaseInterface };
 export * from './enums';
 export * from './types';
 export * from './constants';
+export * from './errors';


### PR DESCRIPTION
* Disallow committing of notes with invalid transactions (Fixes #172):
	- if inbound note includes transactions with warehouse different than the note's parent warehouse
	- if outbound note trying to commit transactions with quantity larger than the quantity in quoted warehouse
* Add special error objects for the aforementioned cases
* Add a design document for easier querying of book availability for isbn, per warehouse
* Test the behaviour