### PR TITLE
Make the note/warehouse interface always in sync with the db state:

### DIFF
--- a/apps/web-client/src/lib/stores/inventory/__tests__/display_name.test.ts
+++ b/apps/web-client/src/lib/stores/inventory/__tests__/display_name.test.ts
@@ -83,7 +83,7 @@ describe("createDisplayNameStore", () => {
 		const mockEntity = {
 			setName: mockSetName,
 			stream: () => ({
-				displayName: new BehaviorSubject("temp")
+				displayName: () => new BehaviorSubject("temp")
 			})
 		} as any;
 
@@ -101,7 +101,7 @@ describe("createDisplayNameStore", () => {
 		const mockEntity = {
 			setName: mockSetName,
 			stream: () => ({
-				displayName: new BehaviorSubject("Current Name")
+				displayName: () => new BehaviorSubject("Current Name")
 			})
 		} as any;
 
@@ -119,7 +119,7 @@ describe("createDisplayNameStore", () => {
 		const mockEntity = {
 			setName: mockSetName,
 			stream: () => ({
-				displayName: new BehaviorSubject("Current Name")
+				displayName: () => new BehaviorSubject("Current Name")
 			})
 		} as any;
 

--- a/apps/web-client/src/lib/stores/inventory/__tests__/note_state.test.ts
+++ b/apps/web-client/src/lib/stores/inventory/__tests__/note_state.test.ts
@@ -61,7 +61,7 @@ describe("createDisplayStateStore", () => {
 		});
 
 		// Check that the note state in db has been updated
-		const noteState = await firstValueFrom(note.stream({}).state);
+		const noteState = await firstValueFrom(note.stream().state({}));
 		expect(noteState).toBe(NoteState.Committed);
 
 		// Close the dummy subscription after assertions

--- a/apps/web-client/src/lib/stores/inventory/display_name.ts
+++ b/apps/web-client/src/lib/stores/inventory/display_name.ts
@@ -26,7 +26,7 @@ interface CreateDisplayNameStore {
  * @param internalStateStore (optional) reference to the internal state store for the note. If provided, the store will be updated with the temp state while the content store updates.
  */
 export const createDisplayNameStore: CreateDisplayNameStore = (entity, internalStateStore, ctx = {}) => {
-	const displayNameInternal = readableFromStream(entity?.stream(ctx).displayName, "", ctx);
+	const displayNameInternal = readableFromStream(entity?.stream().displayName(ctx), "", ctx);
 
 	// Set method updates the displayName in the database and, if the internal state store is provided, sets the temp state
 	// if internal state store is provided (and set to temp state by this action), it will be updated to the non-temp state

--- a/apps/web-client/src/lib/stores/inventory/index.ts
+++ b/apps/web-client/src/lib/stores/inventory/index.ts
@@ -39,7 +39,7 @@ export const createNoteStores: CreateNoteStores = (note) => {
 		name: `[NOTE_UPDATED_AT::${note?._id}]`,
 		debug: false
 	};
-	const updatedAt = readableFromStream(note?.stream(updatedAtCtx).updatedAt, null, updatedAtCtx);
+	const updatedAt = readableFromStream(note?.stream().updatedAt(updatedAtCtx), null, updatedAtCtx);
 
 	const currentPage = writable(0);
 

--- a/apps/web-client/src/lib/stores/inventory/note_state.ts
+++ b/apps/web-client/src/lib/stores/inventory/note_state.ts
@@ -28,10 +28,13 @@ export const createInternalStateStore: CreateInternalStateStore = (note, ctx) =>
 	// Open note subscription opens a subscription to the note state which updates the internal store on change
 	const openNoteSubscription = () => {
 		debug.log(ctx, "internal_state_store:opening_note_subscription")({});
-		noteSubscription = note?.stream(ctx).state.subscribe((content) => {
-			debug.log(ctx, "internal_state_store:update_from_db")(content);
-			state.set(content);
-		});
+		noteSubscription = note
+			?.stream()
+			.state(ctx)
+			.subscribe((content) => {
+				debug.log(ctx, "internal_state_store:update_from_db")(content);
+				state.set(content);
+			});
 	};
 
 	// Close note subscription closes the subscription to the note state

--- a/apps/web-client/src/lib/stores/inventory/table_content.ts
+++ b/apps/web-client/src/lib/stores/inventory/table_content.ts
@@ -27,18 +27,21 @@ interface CreateDisplayRowStream {
 }
 
 const createDisplayRowStream: CreateDisplayRowStream = (db, entity, ctx) => {
-	const fullTableRow = entity?.stream(ctx).entries.pipe(
-		switchMap((valueFromEntryStream) => {
-			// map entry to just isbns
-			const isbns = valueFromEntryStream.map((entry) => entry.isbn);
+	const fullTableRow = entity
+		?.stream()
+		.entries(ctx)
+		.pipe(
+			switchMap((valueFromEntryStream) => {
+				// map entry to just isbns
+				const isbns = valueFromEntryStream.map((entry) => entry.isbn);
 
-			// return array of merged values of books and volume stock client
-			return db
-				.books()
-				.stream(isbns, ctx)
-				.pipe(map((booksFromDb) => booksFromDb.map((b = {} as BookEntry, i) => ({ ...b, ...valueFromEntryStream[i] }))));
-		})
-	);
+				// return array of merged values of books and volume stock client
+				return db
+					.books()
+					.stream(isbns, ctx)
+					.pipe(map((booksFromDb) => booksFromDb.map((b = {} as BookEntry, i) => ({ ...b, ...valueFromEntryStream[i] }))));
+			})
+		);
 
 	return fullTableRow;
 };
@@ -80,7 +83,7 @@ export const createPaginationDataStore = (
 	currentPageStore: Readable<number>,
 	ctx: debug.DebugCtx
 ): Readable<PaginationData> => {
-	const entriesStore = readableFromStream(entity?.stream(ctx).entries, [], ctx);
+	const entriesStore = readableFromStream(entity?.stream().entries(ctx), [], ctx);
 	// Create a derived store that streams the pagination data derived from the entries and current page stores
 	const paginationData = derived([entriesStore, currentPageStore], ([$entriesStore, $currentPageStore]) => {
 		debug.log(ctx, "pagination_data:derived:inputs")({ $entriesStore, $currentPageStore });

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -41,7 +41,7 @@
 	const db = getDB();
 
 	const inNoteListCtx = { name: "[IN_NOTE_LIST]", debug: false };
-	const inNoteList = readableFromStream(db?.stream(inNoteListCtx).inNoteList, [], inNoteListCtx);
+	const inNoteList = readableFromStream(db?.stream().inNoteList(inNoteListCtx), [], inNoteListCtx);
 
 	/**
 	 * Handle create note returns an `on:click` handler enclosed with the id of the warehouse

--- a/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
@@ -40,7 +40,7 @@
 	const db = getDB();
 
 	const outNoteListCtx = { name: "[OUT_NOTE_LIST]", debug: false };
-	const outNoteList = readableFromStream(db?.stream(outNoteListCtx).outNoteList, [], outNoteListCtx);
+	const outNoteList = readableFromStream(db?.stream().outNoteList(outNoteListCtx), [], outNoteListCtx);
 
 	/**
 	 * Handle create note is an `on:click` handler used to create a new outbound note

--- a/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
@@ -34,8 +34,8 @@
 	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
 	const db = getDB();
 
-	const wareouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
-	const warehouseList = readableFromStream(db?.stream(wareouseListCtx).warehouseList, [], wareouseListCtx);
+	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
+	const warehouseList = readableFromStream(db?.stream().warehouseList(warehouseListCtx), [], warehouseListCtx);
 
 	/**
 	 * Handle create warehouse is an `no:click` handler used to create the new warehouse

--- a/pkg/db/src/__tests__/benchmarks.ts
+++ b/pkg/db/src/__tests__/benchmarks.ts
@@ -25,7 +25,7 @@ export const commit20Notes: TestFunction = async (db, version, getNotesAndWareho
 	);
 	await Promise.all(noteUpdates);
 
-	const stock = await firstValueFrom(db.warehouse().stream({}).entries);
+	const stock = await firstValueFrom(db.warehouse().stream().entries({}));
 
 	expect(stock).toEqual(fullStock.books);
 };

--- a/pkg/db/src/__tests__/tests.ts
+++ b/pkg/db/src/__tests__/tests.ts
@@ -101,7 +101,9 @@ export const noteTransactionOperations: TestFunction = async (db) => {
 
 	// Subscribe to entries to receive updates
 	let entries: PossiblyEmpty<VolumeStock[]> = EMPTY;
-	note.stream({}).entries.subscribe((e) => (entries = e));
+	note.stream()
+		.entries({})
+		.subscribe((e) => (entries = e));
 
 	// Initial stream should be empty
 	await waitFor(() => {
@@ -176,17 +178,17 @@ export const streamNoteValuesAccordingToSpec: TestFunction = async (db) => {
 	const note = await db.warehouse("test-warehouse").note().create();
 
 	// Subscribe to note streams
-	const { displayName: dn$, entries: e$, state: s$, updatedAt: ua$ } = note.stream({});
+	const { displayName: displayNameStream, entries: entriesStream, state: stateStream, updatedAt: updatedAtStream } = note.stream();
 
 	let displayName: PossiblyEmpty<string> = EMPTY;
 	let entries: PossiblyEmpty<VolumeStock[]> = EMPTY;
 	let state: PossiblyEmpty<NoteState> = EMPTY;
 	let updatedAt: PossiblyEmpty<Date | null> = EMPTY;
 
-	dn$.subscribe((dn) => (displayName = dn));
-	e$.subscribe((e) => (entries = e));
-	s$.subscribe((s) => (state = s));
-	ua$.subscribe((ua) => {
+	displayNameStream({}).subscribe((dn) => (displayName = dn));
+	entriesStream({}).subscribe((e) => (entries = e));
+	stateStream({}).subscribe((s) => (state = s));
+	updatedAtStream({}).subscribe((ua) => {
 		updatedAt = ua;
 	});
 
@@ -246,9 +248,18 @@ export const streamWarehouseStock: TestFunction = async (db) => {
 	let defaultWarehouesStock: PossiblyEmpty<VolumeStock[]> = EMPTY;
 
 	// Subscribe to warehouse stock streams
-	warehouse1.stream({}).entries.subscribe((e) => (warehoues1Stock = e));
-	warehouse2.stream({}).entries.subscribe((e) => (warehoues2Stock = e));
-	defaultWarehouse.stream({}).entries.subscribe((e) => (defaultWarehouesStock = e));
+	warehouse1
+		.stream()
+		.entries({})
+		.subscribe((e) => (warehoues1Stock = e));
+	warehouse2
+		.stream()
+		.entries({})
+		.subscribe((e) => (warehoues2Stock = e));
+	defaultWarehouse
+		.stream()
+		.entries({})
+		.subscribe((e) => (defaultWarehouesStock = e));
 
 	// Check that the stream gets initialised with the current values
 	await waitFor(() => {
@@ -369,7 +380,7 @@ export const streamWarehouseStock: TestFunction = async (db) => {
 };
 
 export const warehousesListStream: TestFunction = async (db) => {
-	const { warehouseList: wl$ } = db.stream({});
+	const wl$ = db.stream().warehouseList({});
 	let warehouseList: PossiblyEmpty<NavListEntry[]> = EMPTY;
 	wl$.subscribe((wl) => (warehouseList = wl));
 
@@ -406,7 +417,7 @@ export const warehousesListStream: TestFunction = async (db) => {
 };
 
 export const inNotesStream: TestFunction = async (db) => {
-	const { inNoteList: inl$ } = db.stream({});
+	const inl$ = db.stream().inNoteList({});
 	let inNoteList: PossiblyEmpty<InNoteList> = EMPTY;
 
 	// The stream should be initialized with the existing documents (it should display current state, not only the changes)
@@ -554,7 +565,7 @@ export const inNotesStream: TestFunction = async (db) => {
 };
 
 export const outNotesStream: TestFunction = async (db) => {
-	const { outNoteList: onl$ } = db.stream({});
+	const onl$ = db.stream().outNoteList({});
 	let outNoteList: PossiblyEmpty<NavListEntry[]> = EMPTY;
 
 	// The stream should be initialized with the existing documents (it should display current state, not only the changes)
@@ -664,9 +675,15 @@ export const streamsShouldFallBackToDefaultValueForTheirType: TestFunction = asy
 	let inNoteList: PossiblyEmpty<InNoteList> = EMPTY;
 	let outNoteList: PossiblyEmpty<NavListEntry[]> = EMPTY;
 	let warehouseList: PossiblyEmpty<NavListEntry[]> = EMPTY;
-	db.stream({}).inNoteList.subscribe((inl) => (inNoteList = inl));
-	db.stream({}).outNoteList.subscribe((onl) => (outNoteList = onl));
-	db.stream({}).warehouseList.subscribe((wl) => (warehouseList = wl));
+	db.stream()
+		.inNoteList({})
+		.subscribe((inl) => (inNoteList = inl));
+	db.stream()
+		.outNoteList({})
+		.subscribe((onl) => (outNoteList = onl));
+	db.stream()
+		.warehouseList({})
+		.subscribe((wl) => (warehouseList = wl));
 	// The default warehosue gets created automatically, so we will essentially
 	// always be receiving the default warehouse in the warehouse (and in-note) list
 	const defaultWarehouse = {
@@ -684,8 +701,14 @@ export const streamsShouldFallBackToDefaultValueForTheirType: TestFunction = asy
 	let w1entries: PossiblyEmpty<VolumeStockClient[]> = EMPTY;
 	let w1DisplayName: PossiblyEmpty<string> = EMPTY;
 	// Subscribing to the stream should not throw (even if the warehouse doesn't exist)
-	warehouse1.stream({}).entries.subscribe((w1e) => (w1entries = w1e));
-	warehouse1.stream({}).displayName.subscribe((w1dn) => (w1DisplayName = w1dn));
+	warehouse1
+		.stream()
+		.entries({})
+		.subscribe((w1e) => (w1entries = w1e));
+	warehouse1
+		.stream()
+		.displayName({})
+		.subscribe((w1dn) => (w1DisplayName = w1dn));
 	await waitFor(() => {
 		expect(w1entries).toEqual([]);
 		expect(w1DisplayName).toEqual("");
@@ -700,10 +723,22 @@ export const streamsShouldFallBackToDefaultValueForTheirType: TestFunction = asy
 	let n1UpdatedAt: PossiblyEmpty<Date | null> = EMPTY;
 	// Subscribing to the stream should not throw (even if the note doesn't exist)
 	// and the stream should be initialized with an empty array
-	note1.stream({}).entries.subscribe((n1e) => (n1entries = n1e));
-	note1.stream({}).displayName.subscribe((n1dn) => (n1DisplayName = n1dn));
-	note1.stream({}).state.subscribe((n1s) => (n1State = n1s));
-	note1.stream({}).updatedAt.subscribe((n1u) => (n1UpdatedAt = n1u));
+	note1
+		.stream()
+		.entries({})
+		.subscribe((n1e) => (n1entries = n1e));
+	note1
+		.stream()
+		.displayName({})
+		.subscribe((n1dn) => (n1DisplayName = n1dn));
+	note1
+		.stream()
+		.state({})
+		.subscribe((n1s) => (n1State = n1s));
+	note1
+		.stream()
+		.updatedAt({})
+		.subscribe((n1u) => (n1UpdatedAt = n1u));
 	await waitFor(() => {
 		expect(n1entries).toEqual([]);
 		expect(n1DisplayName).toEqual("");
@@ -881,37 +916,39 @@ export const syncNoteAndWarehouseInterfaceWithTheDb: TestFunction = async (db) =
 	// Create and displayName "store" for the note
 	let ndn: PossiblyEmpty<string> = EMPTY;
 
-	const note = await db.warehouse().note('note-1').create();
-	note.stream({}).displayName.subscribe((dn$) => (ndn = dn$));
+	const note = await db.warehouse().note("note-1").create();
+	note.stream()
+		.displayName({})
+		.subscribe((dn$) => (ndn = dn$));
 
 	// Set the initial name for the note
-	note.setName('Note name', {});
+	note.setName("Note name", {});
 	await waitFor(() => {
-		expect(ndn).toEqual('Note name');
+		expect(ndn).toEqual("Note name");
 	});
 
 	// Update the name from a different instance, simulating an outside update
-	await db.warehouse().note('note-1').setName('Note name updated', {});
+	await db.warehouse().note("note-1").setName("Note name updated", {});
 	await waitFor(() => {
-		expect(ndn).toEqual('Note name updated');
+		expect(ndn).toEqual("Note name updated");
 	});
 
 	// Original instance should also be able to update the name (should have the correct _rev)
-	note.setName('Note name updated again', {});
+	note.setName("Note name updated again", {});
 	await waitFor(() => {
-		expect(ndn).toEqual('Note name updated again');
+		expect(ndn).toEqual("Note name updated again");
 	});
 
 	// The note interface should be in sync with the db
 	// We test this by instantianting a new note interface for the same note and checking equality after updates
-	const noteInst2 = db.warehouse().note('note-1');
-	await noteInst2.addVolumes({ isbn: '11111111', quantity: 2, warehouseId: versionId('warehouse-1') });
+	const noteInst2 = db.warehouse().note("note-1");
+	await noteInst2.addVolumes({ isbn: "11111111", quantity: 2, warehouseId: versionId("warehouse-1") });
 
 	await waitFor(() => expect(note).toEqual(noteInst2));
 
 	// Test the same behaviour for the warehouse interface
-	const wInst1 = db.warehouse('warehosue-1');
-	const wInst2 = db.warehouse('warehosue-1');
+	const wInst1 = db.warehouse("warehosue-1");
+	const wInst2 = db.warehouse("warehosue-1");
 
 	await wInst2.setName("Warehouse 1's name", {});
 

--- a/pkg/db/src/implementations/version-1.1/db.ts
+++ b/pkg/db/src/implementations/version-1.1/db.ts
@@ -114,49 +114,49 @@ class Database implements DatabaseInterface {
 		return note && warehouse ? { note, warehouse } : undefined;
 	}
 
-	stream(ctx: debug.DebugCtx): DbStream {
+	stream(): DbStream {
 		return {
-			warehouseList: newViewStream<{ rows: { key: string; value: { displayName?: string } } }, NavListEntry[]>(
-				this._pouch,
-				"v1_list/warehouses",
-				{},
-				({ rows }) => rows.map(({ key: id, value: { displayName = "" } }) => ({ id, displayName })),
-				ctx
-			),
+			warehouseList: (ctx: debug.DebugCtx) =>
+				newViewStream<{ rows: { key: string; value: { displayName?: string } } }, NavListEntry[]>(
+					this._pouch,
+					"v1_list/warehouses",
+					{},
+					({ rows }) => rows.map(({ key: id, value: { displayName = "" } }) => ({ id, displayName })),
+					ctx
+				),
 
-			outNoteList: newViewStream<{ rows: { key: string; value: { displayName?: string; committed?: boolean } } }, NavListEntry[]>(
-				this._pouch,
-				"v1_list/outbound",
-				{},
-				({ rows }) =>
-					rows
-						.filter(({ value: { committed } }) => !committed)
-						.map(({ key: id, value: { displayName = "" } }) => ({ id, displayName })),
-				ctx
-			),
+			outNoteList: (ctx: debug.DebugCtx) =>
+				newViewStream<{ rows: { key: string; value: { displayName?: string; committed?: boolean } } }, NavListEntry[]>(
+					this._pouch,
+					"v1_list/outbound",
+					{},
+					({ rows }) =>
+						rows
+							.filter(({ value: { committed } }) => !committed)
+							.map(({ key: id, value: { displayName = "" } }) => ({ id, displayName })),
+					ctx
+				),
 
-			inNoteList: newViewStream<
-				{ rows: { key: string; value: { type: DocType; displayName?: string; committed?: boolean } } },
-				InNoteList
-			>(
-				this._pouch,
-				"v1_list/inbound",
-				{},
-				({ rows }) =>
-					rows.reduce((acc, { key, value: { type, displayName = "", committed } }) => {
-						if (type === "warehouse") {
-							return [...acc, { id: key, displayName, notes: [] }];
-						}
-						if (committed) {
+			inNoteList: (ctx: debug.DebugCtx) =>
+				newViewStream<{ rows: { key: string; value: { type: DocType; displayName?: string; committed?: boolean } } }, InNoteList>(
+					this._pouch,
+					"v1_list/inbound",
+					{},
+					({ rows }) =>
+						rows.reduce((acc, { key, value: { type, displayName = "", committed } }) => {
+							if (type === "warehouse") {
+								return [...acc, { id: key, displayName, notes: [] }];
+							}
+							if (committed) {
+								return acc;
+							}
+							// Add note to the default warehouse (first in the list) as well as the corresponding warehouse (last in the list so far)
+							acc[0].notes.push({ id: key, displayName });
+							acc[acc.length - 1].notes.push({ id: key, displayName });
 							return acc;
-						}
-						// Add note to the default warehouse (first in the list) as well as the corresponding warehouse (last in the list so far)
-						acc[0].notes.push({ id: key, displayName });
-						acc[acc.length - 1].notes.push({ id: key, displayName });
-						return acc;
-					}, [] as InNoteList),
-				ctx
-			)
+						}, [] as InNoteList),
+					ctx
+				)
 		};
 	}
 }

--- a/pkg/db/src/implementations/version-1.1/note.ts
+++ b/pkg/db/src/implementations/version-1.1/note.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, combineLatest, map, Observable, tap } from "rxjs";
+import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from 'rxjs';
 
 import { debug } from "@librocco/shared";
 
@@ -7,9 +7,9 @@ import { DocType, NoteState } from "@/enums";
 import { NoteType, VolumeStock, VersionedString, PickPartial } from "@/types";
 import { NoteInterface, WarehouseInterface, NoteData, DatabaseInterface } from "./types";
 
-import { isVersioned, runAfterCondition, sortBooks, uniqueTimestamp, versionId } from "@/utils/misc";
-import { newDocumentStream } from "@/utils/pouchdb";
-import { OutOfStockError, TransactionWarehouseMismatchError } from "@/errors";
+import { isEmpty, isVersioned, runAfterCondition, sortBooks, uniqueTimestamp, versionId } from '@/utils/misc';
+import { newDocumentStream } from '@/utils/pouchdb';
+import { OutOfStockError, TransactionWarehouseMismatchError } from '@/errors';
 
 class Note implements NoteInterface {
 	// We wish the warehouse back-reference to be "invisible" when printing, serializing JSON, etc.
@@ -19,6 +19,7 @@ class Note implements NoteInterface {
 
 	#initialized = new BehaviorSubject(false);
 	#exists = false;
+	#stream: Observable<NoteData>;
 
 	_id: VersionedString;
 	docType = DocType.Note;
@@ -54,28 +55,20 @@ class Note implements NoteInterface {
 			? id
 			: versionId(`${warehouse._id}/${this.noteType}/${id}`);
 
-		// If this is a new note, no need to check for DB, it should't exist, and unique timestamp as id
-		// assures this id is not taken
-		if (!id) {
-			this.#initialized.next(true);
-			return this;
-		}
+		// Create the internal document stream, which will be used to update the local instance on each change in the db.
+		const cache = new ReplaySubject<NoteData>(1);
+		this.#stream = newDocumentStream<NoteData, NoteData>(this.#db._pouch, this._id).pipe(
+			// We're connecting the stream to a ReplaySubject as a multicast object: this enables us to share the internal stream
+			// with the exposed streams (displayName) and to cache the last value emitted by the stream: so that each subscriber to the stream
+			// will get the 'initialValue' (repeated value from the latest stream).
+			share({ connector: () => cache, resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
+		);
 
-		// If id provided, the note might or might not exist in the DB
-		// perform a check and update the instance accordingly
-		this.#db._pouch
-			.get<NoteData>(this._id)
-			// If note exists, populate the local instance with the data from db,
-			// set the "exists" flag to true and mark the instance as initialized
-			.then((res) => {
-				this.updateInstance(res);
-				this.#exists = true;
-				this.#initialized.next(true);
-			})
-			// If note doesn't exist, mark the instance as initialized ('exists' is false by default)
-			.catch(() => {
-				this.#initialized.next(true);
-			});
+		// The first value from the stream will be either note data, or an empty object (if the note doesn't exist in the db).
+		// This is enough to signal that the note intsance is initialised.
+		firstValueFrom(this.#stream).then(() => this.#initialized.next(true));
+		// If data is not empty (note exists), setting of 'exists' flag is handled inside the 'updateInstance' method.
+		this.#stream.subscribe((w) => this.updateInstance(w));
 
 		return this;
 	}
@@ -94,7 +87,12 @@ class Note implements NoteInterface {
 	/**
 	 * Update instance is a method for internal usage, used to update the instance with the data (doesn't update the DB)
 	 */
-	private updateInstance(data: Partial<Omit<NoteData, "_id">>): NoteInterface {
+	private updateInstance(data: Partial<Omit<NoteData, '_id'>>): NoteInterface {
+		// No-op if the data is empty
+		if (isEmpty(data)) {
+			return this;
+		}
+
 		// Update the data with provided fields
 		this.updateField("_rev", data._rev);
 		this.updateField("noteType", data.noteType);
@@ -333,6 +331,7 @@ class Note implements NoteInterface {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * Create stream is a convenience method for internal usage, leveraging `newDocumentStream` to create a
 	 * pouchdb changes stream for a specific property on a note, while abstracting away the details of the subscription
 	 * such as the db and the note id as well as to abstract signature bolierplate (as document type is always `NoteData` and the
@@ -343,12 +342,15 @@ class Note implements NoteInterface {
 	}
 
 	/**
+=======
+>>>>>>> 25d6e8a (Make the note/warehouse interface always in sync with the db state:)
 	 * Creates streams for the note data. The streams are hot in a way that they will
 	 * emit the value from external source (i.e. db), but cold in a way that the db subscription is
 	 * initiated only when the stream is subscribed to (and canceled on unsubscribe).
 	 */
 	stream(ctx: debug.DebugCtx) {
 		return {
+<<<<<<< HEAD
 			displayName: this.createStream((doc) => {
 				return doc?.displayName || "";
 			}, ctx),
@@ -356,6 +358,17 @@ class Note implements NoteInterface {
 			// Combine latest is like an rxjs equivalent of svelte derived stores with multiple sources.
 			entries: combineLatest([
 				this.createStream((doc) => (doc?.entries || []).map((e) => ({ ...e, warehouseName: "" })).sort(sortBooks), ctx),
+=======
+			displayName: this.#stream.pipe(
+				tap(debug.log(ctx, 'note_streams: display_name: input')),
+				map(({ displayName }) => displayName || ''),
+				tap(debug.log(ctx, 'note_streams: display_name: res'))
+			),
+
+			// Combine latest is like an rxjs equivalent of svelte derived stores with multiple sources.
+			entries: combineLatest([
+				this.#stream.pipe(map(({ entries }) => (entries || []).map((e) => ({ ...e, warehouseName: '' })).sort(sortBooks))),
+>>>>>>> 25d6e8a (Make the note/warehouse interface always in sync with the db state:)
 				this.#db.stream(ctx).warehouseList
 			]).pipe(
 				tap(debug.log(ctx, "note:entries:stream:input")),
@@ -367,14 +380,17 @@ class Note implements NoteInterface {
 				tap(debug.log(ctx, "note:entries:stream:output"))
 			),
 
-			/** @TODO update the data model to have 'state' */
-			state: this.createStream((doc) => (doc?.committed ? NoteState.Committed : NoteState.Draft), ctx),
+			state: this.#stream.pipe(
+				tap(debug.log(ctx, 'note_streams: state: input')),
+				map(({ committed }) => (committed ? NoteState.Committed : NoteState.Draft)),
+				tap(debug.log(ctx, 'note_streams: state: res'))
+			),
 
-			updatedAt: this.createStream((doc) => {
-				// The date gets serialized as a string in the db, so we need to convert it back to a date object (if defined)
-				const ua = doc?.updatedAt;
-				return ua ? new Date(ua) : null;
-			}, ctx)
+			updatedAt: this.#stream.pipe(
+				tap(debug.log(ctx, 'note_streams: updated_at: input')),
+				map(({ updatedAt: ua }) => (ua ? new Date(ua) : null)),
+				tap(debug.log(ctx, 'note_streams: updated_at: res'))
+			)
 		};
 	}
 }

--- a/pkg/db/src/implementations/version-1.1/types.ts
+++ b/pkg/db/src/implementations/version-1.1/types.ts
@@ -17,7 +17,7 @@ export type NoteData = ND<AdditionalData>;
 export type NoteInterface = NI<AdditionalData>;
 
 /** Warehouse data (extended with additional fields) for internal implementation usage. */
-export type WarehouseData = WD<AdditionalData>;
-export type WarehouseInterface = WI<NoteInterface, AdditionalData>;
+export type WarehouseData = WD;
+export type WarehouseInterface = WI<NoteInterface>;
 
 export type DatabaseInterface = DI<WarehouseInterface, NoteInterface>;

--- a/pkg/db/src/implementations/version-1.1/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.1/warehouse.ts
@@ -1,20 +1,20 @@
-import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from "rxjs";
 
-import { debug } from '@librocco/shared';
+import { debug } from "@librocco/shared";
 
-import { DocType } from '@/enums';
+import { DocType } from "@/enums";
 
-import { VersionedString, VolumeStockClient } from '@/types';
+import { VersionedString, VolumeStockClient } from "@/types";
 
-import { NEW_WAREHOUSE } from '@/constants';
+import { NEW_WAREHOUSE } from "@/constants";
 
-import { NoteData, NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from './types';
+import { NoteData, NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from "./types";
 
-import { newNote } from './note';
-import { WarehouseStockEntry } from './designDocuments';
+import { newNote } from "./note";
+import { WarehouseStockEntry } from "./designDocuments";
 
-import { runAfterCondition, sortBooks, uniqueTimestamp, versionId, isEmpty } from '@/utils/misc';
-import { newDocumentStream, newViewStream } from '@/utils/pouchdb';
+import { runAfterCondition, sortBooks, uniqueTimestamp, versionId, isEmpty } from "@/utils/misc";
+import { newDocumentStream, newViewStream } from "@/utils/pouchdb";
 
 class Warehouse implements WarehouseInterface {
 	// We wish the db back-reference to be "invisible" when printing, serializing JSON, etc.
@@ -29,14 +29,14 @@ class Warehouse implements WarehouseInterface {
 	docType = DocType.Warehouse;
 	_rev?: string;
 
-	displayName = '';
+	displayName = "";
 
 	constructor(db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE) {
 		this.#db = db;
 
 		this._id = !id
 			? // If id not provided, we're accessing the default warehouse
-			  versionId('0-all')
+			  versionId("0-all")
 			: // If NEW_WAREHOUSE sentinel provided, generate a new id
 			id === NEW_WAREHOUSE
 			? versionId(uniqueTimestamp())
@@ -73,15 +73,15 @@ class Warehouse implements WarehouseInterface {
 	/**
 	 * Update instance is a method for internal usage, used to update the instance with the data (doesn't update the DB)
 	 */
-	private updateInstance(data: Partial<Omit<WarehouseData, '_id'>>) {
+	private updateInstance(data: Partial<Omit<WarehouseData, "_id">>) {
 		// No-op if the data is empty
 		if (isEmpty(data)) {
 			return this;
 		}
 
 		// Update the data with provided fields
-		this.updateField('_rev', data._rev);
-		this.updateField('displayName', data.displayName);
+		this.updateField("_rev", data._rev);
+		this.updateField("displayName", data.displayName);
 
 		this.#exists = true;
 
@@ -100,17 +100,17 @@ class Warehouse implements WarehouseInterface {
 
 			let sequentialNumber = 0;
 			try {
-				const sequenceQuery = await this.#db._pouch.query('v1_sequence/warehouse');
+				const sequenceQuery = await this.#db._pouch.query("v1_sequence/warehouse");
 				sequentialNumber = sequenceQuery.rows[0].value.max;
 			} catch {
 				//
 			}
-			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : '';
+			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : "";
 
 			const initialValues = {
 				...this,
 				// If creating a default warehouse, we're initialising the 'displayName' as "All"
-				displayName: this._id === versionId('0-all') ? 'All' : `New Warehouse${seqIndex}`
+				displayName: this._id === versionId("0-all") ? "All" : `New Warehouse${seqIndex}`
 			};
 			// Try and store the warehouse in the db
 			try {
@@ -186,14 +186,14 @@ class Warehouse implements WarehouseInterface {
 	 */
 	setName(displayName: string, ctx: debug.DebugCtx): Promise<WarehouseInterface> {
 		const currentDisplayName = this.displayName;
-		debug.log(ctx, 'note:set_name')({ displayName, currentDisplayName });
+		debug.log(ctx, "note:set_name")({ displayName, currentDisplayName });
 
 		if (displayName === currentDisplayName || !displayName) {
-			debug.log(ctx, 'note:set_name:noop')({ displayName, currentDisplayName });
+			debug.log(ctx, "note:set_name:noop")({ displayName, currentDisplayName });
 			return Promise.resolve(this);
 		}
 
-		debug.log(ctx, 'note:set_name:updating')({ displayName });
+		debug.log(ctx, "note:set_name:updating")({ displayName });
 		return this.update({ displayName });
 	}
 
@@ -202,58 +202,56 @@ class Warehouse implements WarehouseInterface {
 	 * emit the value from external source (i.e. db), but cold in a way that the db subscription is
 	 * initiated only when the stream is subscribed to (and canceled on unsubscribe).
 	 */
-	stream(ctx: debug.DebugCtx) {
+	stream() {
 		return {
-			displayName: this.#stream.pipe(
-				tap(debug.log(ctx, 'streams: display_name: input')),
-				map(({ displayName }) => displayName || ''),
-				tap(debug.log(ctx, 'streams: display_name: res'))
-			),
-
-			entries: combineLatest([
-				newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
-					this.#db._pouch,
-					'v1_stock/by_warehouse',
-					{
-						group_level: 2,
-						...(this._id !== versionId('0-all') && {
-							startkey: [this._id],
-							endkey: [this._id, {}],
-							include_end: true
-						})
-					},
-					({ rows }) =>
-						rows
-							.map(({ key: [warehouseId, isbn], value: quantity }) => ({
-								isbn,
-								quantity,
-								warehouseId,
-								warehouseName: ''
-							}))
-							.filter(({ quantity }) => quantity > 0)
-							.sort(sortBooks),
-					ctx
+			displayName: (ctx: debug.DebugCtx) =>
+				this.#stream.pipe(
+					tap(debug.log(ctx, "streams: display_name: input")),
+					map(({ displayName }) => displayName || ""),
+					tap(debug.log(ctx, "streams: display_name: res"))
 				),
-				this.#db.stream(ctx).warehouseList
-			]).pipe(
-				tap(debug.log(ctx, 'warehouse_entries:stream:input')),
-				map(([entries, warehouses]) => {
-					// Create a record of warehouse ids and names for easy lookup
-					const warehouseNames = warehouses.reduce(
-						(acc, { id, displayName }) => ({ ...acc, [id]: displayName }),
-						{}
-					);
-					const res = entries.map((e) => ({
-						...e,
-						warehouseName: warehouseNames[e.warehouseId] || 'not-found'
-					}));
-					return res;
-				}),
-				tap(debug.log(ctx, 'warehouse_entries:stream:output'))
-			)
+
+			entries: (ctx: debug.DebugCtx) =>
+				combineLatest([
+					newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
+						this.#db._pouch,
+						"v1_stock/by_warehouse",
+						{
+							group_level: 2,
+							...(this._id !== versionId("0-all") && {
+								startkey: [this._id],
+								endkey: [this._id, {}],
+								include_end: true
+							})
+						},
+						({ rows }) =>
+							rows
+								.map(({ key: [warehouseId, isbn], value: quantity }) => ({
+									isbn,
+									quantity,
+									warehouseId,
+									warehouseName: ""
+								}))
+								.filter(({ quantity }) => quantity > 0)
+								.sort(sortBooks),
+						ctx
+					),
+					this.#db.stream().warehouseList(ctx)
+				]).pipe(
+					tap(debug.log(ctx, "warehouse_entries:stream:input")),
+					map(([entries, warehouses]) => {
+						// Create a record of warehouse ids and names for easy lookup
+						const warehouseNames = warehouses.reduce((acc, { id, displayName }) => ({ ...acc, [id]: displayName }), {});
+						const res = entries.map((e) => ({
+							...e,
+							warehouseName: warehouseNames[e.warehouseId] || "not-found"
+						}));
+						return res;
+					}),
+					tap(debug.log(ctx, "warehouse_entries:stream:output"))
+				)
 		};
 	}
 }
 
-export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface =>
-	new Warehouse(db, id);
+export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface => new Warehouse(db, id);

--- a/pkg/db/src/implementations/version-1.1/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.1/warehouse.ts
@@ -1,20 +1,20 @@
-import { BehaviorSubject, combineLatest, map, Observable, tap } from "rxjs";
+import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from 'rxjs';
 
-import { debug } from "@librocco/shared";
+import { debug } from '@librocco/shared';
 
-import { DocType } from "@/enums";
+import { DocType } from '@/enums';
 
-import { VersionedString, VolumeStock, VolumeStockClient } from "@/types";
+import { VersionedString, VolumeStockClient } from '@/types';
 
-import { NEW_WAREHOUSE } from "@/constants";
+import { NEW_WAREHOUSE } from '@/constants';
 
-import { NoteData, NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from "./types";
+import { NoteData, NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from './types';
 
-import { newNote } from "./note";
-import { WarehouseStockEntry } from "./designDocuments";
+import { newNote } from './note';
+import { WarehouseStockEntry } from './designDocuments';
 
-import { runAfterCondition, sortBooks, uniqueTimestamp, versionId } from "@/utils/misc";
-import { newDocumentStream, newViewStream } from "@/utils/pouchdb";
+import { runAfterCondition, sortBooks, uniqueTimestamp, versionId, isEmpty } from '@/utils/misc';
+import { newDocumentStream, newViewStream } from '@/utils/pouchdb';
 
 class Warehouse implements WarehouseInterface {
 	// We wish the db back-reference to be "invisible" when printing, serializing JSON, etc.
@@ -23,56 +23,40 @@ class Warehouse implements WarehouseInterface {
 
 	#initialized = new BehaviorSubject(false);
 	#exists = false;
+	#stream: Observable<WarehouseData>;
 
 	_id: VersionedString;
 	docType = DocType.Warehouse;
 	_rev?: string;
 
-	displayName = "";
-	entries: VolumeStock[] = [];
+	displayName = '';
 
 	constructor(db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE) {
 		this.#db = db;
 
 		this._id = !id
 			? // If id not provided, we're accessing the default warehouse
-			  versionId("0-all")
+			  versionId('0-all')
 			: // If NEW_WAREHOUSE sentinel provided, generate a new id
 			id === NEW_WAREHOUSE
 			? versionId(uniqueTimestamp())
 			: // Run 'versionId' to ensure the id is versioned (if it already is versioned, it will be a no-op)
 			  versionId(id);
 
-		// If id provided, the note might or might not exist in the DB
-		// perform a check and update the instance accordingly
-		this.#db._pouch
-			.get<NoteData>(this._id)
-			// If note exists, populate the local instance with the data from db,
-			// set the "exists" flag to true and mark the instance as initialized
-			.then((res) => {
-				this.updateInstance(res);
-				this.#exists = true;
-				this.#initialized.next(true);
-			})
-			// If note doesn't exist, mark the instance as initialized ('exists' is false by default)
-			.catch(() => {
-				this.#initialized.next(true);
-			});
-		this.#db = db;
+		// Create the internal document stream, which will be used to update the local instance on each change in the db.
+		const cache = new ReplaySubject<WarehouseData>(1);
+		this.#stream = newDocumentStream<NoteData, NoteData>(this.#db._pouch, this._id).pipe(
+			// We're connecting the stream to a ReplaySubject as a multicast object: this enables us to share the internal stream
+			// with the exposed streams (displayName) and to cache the last value emitted by the stream: so that each subscriber to the stream
+			// will get the 'initialValue' (repeated value from the latest stream).
+			share({ connector: () => cache, resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
+		);
 
-		this.#db._pouch
-			.get<WarehouseData>(this._id)
-			// If warehouse exists, populate the local instance with the data from db,
-			// set the "exists" flag to true and mark the instance as initialized
-			.then((res) => {
-				this.updateInstance(res);
-				this.#exists = true;
-				this.#initialized.next(true);
-			})
-			// If warehouse doesn't exist, mark the instance as initialized ('exists' is false by default)
-			.catch(() => {
-				this.#initialized.next(true);
-			});
+		// The first value from the stream will be either warehouse data, or an empty object (if the warehouse doesn't exist in the db).
+		// This is enough to signal that the warehouse intsance is initialised.
+		firstValueFrom(this.#stream).then(() => this.#initialized.next(true));
+		// If data is not empty (warehouse exists), setting of 'exists' flag is handled inside the 'updateInstance' method.
+		this.#stream.subscribe((w) => this.updateInstance(w));
 	}
 
 	/**
@@ -89,11 +73,15 @@ class Warehouse implements WarehouseInterface {
 	/**
 	 * Update instance is a method for internal usage, used to update the instance with the data (doesn't update the DB)
 	 */
-	private updateInstance(data: Partial<Omit<WarehouseData, "_id">>) {
+	private updateInstance(data: Partial<Omit<WarehouseData, '_id'>>) {
+		// No-op if the data is empty
+		if (isEmpty(data)) {
+			return this;
+		}
+
 		// Update the data with provided fields
-		this.updateField("_rev", data._rev);
-		this.updateField("displayName", data.displayName);
-		this.updateField("entries", data.entries);
+		this.updateField('_rev', data._rev);
+		this.updateField('displayName', data.displayName);
 
 		this.#exists = true;
 
@@ -112,17 +100,17 @@ class Warehouse implements WarehouseInterface {
 
 			let sequentialNumber = 0;
 			try {
-				const sequenceQuery = await this.#db._pouch.query("v1_sequence/warehouse");
+				const sequenceQuery = await this.#db._pouch.query('v1_sequence/warehouse');
 				sequentialNumber = sequenceQuery.rows[0].value.max;
 			} catch {
 				//
 			}
-			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : "";
+			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : '';
 
 			const initialValues = {
 				...this,
 				// If creating a default warehouse, we're initialising the 'displayName' as "All"
-				displayName: this._id === versionId("0-all") ? "All" : `New Warehouse${seqIndex}`
+				displayName: this._id === versionId('0-all') ? 'All' : `New Warehouse${seqIndex}`
 			};
 			// Try and store the warehouse in the db
 			try {
@@ -198,25 +186,15 @@ class Warehouse implements WarehouseInterface {
 	 */
 	setName(displayName: string, ctx: debug.DebugCtx): Promise<WarehouseInterface> {
 		const currentDisplayName = this.displayName;
-		debug.log(ctx, "note:set_name")({ displayName, currentDisplayName });
+		debug.log(ctx, 'note:set_name')({ displayName, currentDisplayName });
 
 		if (displayName === currentDisplayName || !displayName) {
-			debug.log(ctx, "note:set_name:noop")({ displayName, currentDisplayName });
+			debug.log(ctx, 'note:set_name:noop')({ displayName, currentDisplayName });
 			return Promise.resolve(this);
 		}
 
-		debug.log(ctx, "note:set_name:updating")({ displayName });
+		debug.log(ctx, 'note:set_name:updating')({ displayName });
 		return this.update({ displayName });
-	}
-
-	/**
-	 * Create stream is a convenience method for internal usage, leveraging `newDocumentStream` to create a
-	 * pouchdb changes stream for a specific property on a note, while abstracting away the details of the subscription
-	 * such as the db and the note id as well as to abstract signature bolierplate (as document type is always `NoteData` and the
-	 * observable signature type is inferred from the selector callback)
-	 */
-	private createStream<S extends (doc?: WarehouseData) => any>(selector: S, ctx: debug.DebugCtx): Observable<ReturnType<S>> {
-		return newDocumentStream<WarehouseData, ReturnType<S>>(this.#db._pouch, this._id, selector, this, ctx);
 	}
 
 	/**
@@ -226,15 +204,19 @@ class Warehouse implements WarehouseInterface {
 	 */
 	stream(ctx: debug.DebugCtx) {
 		return {
-			displayName: this.createStream((doc) => doc?.displayName || "", ctx),
+			displayName: this.#stream.pipe(
+				tap(debug.log(ctx, 'streams: display_name: input')),
+				map(({ displayName }) => displayName || ''),
+				tap(debug.log(ctx, 'streams: display_name: res'))
+			),
 
 			entries: combineLatest([
 				newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
 					this.#db._pouch,
-					"v1_stock/by_warehouse",
+					'v1_stock/by_warehouse',
 					{
 						group_level: 2,
-						...(this._id !== versionId("0-all") && {
+						...(this._id !== versionId('0-all') && {
 							startkey: [this._id],
 							endkey: [this._id, {}],
 							include_end: true
@@ -246,7 +228,7 @@ class Warehouse implements WarehouseInterface {
 								isbn,
 								quantity,
 								warehouseId,
-								warehouseName: ""
+								warehouseName: ''
 							}))
 							.filter(({ quantity }) => quantity > 0)
 							.sort(sortBooks),
@@ -254,20 +236,24 @@ class Warehouse implements WarehouseInterface {
 				),
 				this.#db.stream(ctx).warehouseList
 			]).pipe(
-				tap(debug.log(ctx, "warehouse_entries:stream:input")),
+				tap(debug.log(ctx, 'warehouse_entries:stream:input')),
 				map(([entries, warehouses]) => {
 					// Create a record of warehouse ids and names for easy lookup
-					const warehouseNames = warehouses.reduce((acc, { id, displayName }) => ({ ...acc, [id]: displayName }), {});
+					const warehouseNames = warehouses.reduce(
+						(acc, { id, displayName }) => ({ ...acc, [id]: displayName }),
+						{}
+					);
 					const res = entries.map((e) => ({
 						...e,
-						warehouseName: warehouseNames[e.warehouseId] || "not-found"
+						warehouseName: warehouseNames[e.warehouseId] || 'not-found'
 					}));
 					return res;
 				}),
-				tap(debug.log(ctx, "warehouse_entries:stream:output"))
+				tap(debug.log(ctx, 'warehouse_entries:stream:output'))
 			)
 		};
 	}
 }
 
-export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface => new Warehouse(db, id);
+export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface =>
+	new Warehouse(db, id);

--- a/pkg/db/src/implementations/version-1.1/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.1/warehouse.ts
@@ -1,20 +1,20 @@
-import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from "rxjs";
+import { BehaviorSubject, combineLatest, firstValueFrom, map, Observable, ReplaySubject, share, tap } from 'rxjs';
 
-import { debug } from "@librocco/shared";
+import { debug } from '@librocco/shared';
 
-import { DocType } from "@/enums";
+import { DocType } from '@/enums';
 
-import { VersionedString, VolumeStockClient } from "@/types";
+import { VersionedString, VolumeStockClient } from '@/types';
 
-import { NEW_WAREHOUSE } from "@/constants";
+import { NEW_WAREHOUSE } from '@/constants';
 
-import { NoteData, NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from "./types";
+import { NoteInterface, WarehouseInterface, DatabaseInterface, WarehouseData } from './types';
 
-import { newNote } from "./note";
-import { WarehouseStockEntry } from "./designDocuments";
+import { newNote } from './note';
+import { WarehouseStockEntry } from './designDocuments';
 
-import { runAfterCondition, sortBooks, uniqueTimestamp, versionId, isEmpty } from "@/utils/misc";
-import { newDocumentStream, newViewStream } from "@/utils/pouchdb";
+import { runAfterCondition, sortBooks, uniqueTimestamp, versionId, isEmpty } from '@/utils/misc';
+import { newDocumentStream, newViewStream } from '@/utils/pouchdb';
 
 class Warehouse implements WarehouseInterface {
 	// We wish the db back-reference to be "invisible" when printing, serializing JSON, etc.
@@ -29,14 +29,14 @@ class Warehouse implements WarehouseInterface {
 	docType = DocType.Warehouse;
 	_rev?: string;
 
-	displayName = "";
+	displayName = '';
 
 	constructor(db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE) {
 		this.#db = db;
 
 		this._id = !id
 			? // If id not provided, we're accessing the default warehouse
-			  versionId("0-all")
+			  versionId('0-all')
 			: // If NEW_WAREHOUSE sentinel provided, generate a new id
 			id === NEW_WAREHOUSE
 			? versionId(uniqueTimestamp())
@@ -45,7 +45,7 @@ class Warehouse implements WarehouseInterface {
 
 		// Create the internal document stream, which will be used to update the local instance on each change in the db.
 		const cache = new ReplaySubject<WarehouseData>(1);
-		this.#stream = newDocumentStream<NoteData, NoteData>(this.#db._pouch, this._id).pipe(
+		this.#stream = newDocumentStream<WarehouseData, WarehouseData>(this.#db._pouch, this._id).pipe(
 			// We're connecting the stream to a ReplaySubject as a multicast object: this enables us to share the internal stream
 			// with the exposed streams (displayName) and to cache the last value emitted by the stream: so that each subscriber to the stream
 			// will get the 'initialValue' (repeated value from the latest stream).
@@ -73,15 +73,15 @@ class Warehouse implements WarehouseInterface {
 	/**
 	 * Update instance is a method for internal usage, used to update the instance with the data (doesn't update the DB)
 	 */
-	private updateInstance(data: Partial<Omit<WarehouseData, "_id">>) {
+	private updateInstance(data: Partial<Omit<WarehouseData, '_id'>>) {
 		// No-op if the data is empty
 		if (isEmpty(data)) {
 			return this;
 		}
 
 		// Update the data with provided fields
-		this.updateField("_rev", data._rev);
-		this.updateField("displayName", data.displayName);
+		this.updateField('_rev', data._rev);
+		this.updateField('displayName', data.displayName);
 
 		this.#exists = true;
 
@@ -100,17 +100,17 @@ class Warehouse implements WarehouseInterface {
 
 			let sequentialNumber = 0;
 			try {
-				const sequenceQuery = await this.#db._pouch.query("v1_sequence/warehouse");
+				const sequenceQuery = await this.#db._pouch.query('v1_sequence/warehouse');
 				sequentialNumber = sequenceQuery.rows[0].value.max;
 			} catch {
 				//
 			}
-			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : "";
+			const seqIndex = sequentialNumber ? ` (${sequentialNumber + 1})` : '';
 
 			const initialValues = {
 				...this,
 				// If creating a default warehouse, we're initialising the 'displayName' as "All"
-				displayName: this._id === versionId("0-all") ? "All" : `New Warehouse${seqIndex}`
+				displayName: this._id === versionId('0-all') ? 'All' : `New Warehouse${seqIndex}`
 			};
 			// Try and store the warehouse in the db
 			try {
@@ -186,14 +186,14 @@ class Warehouse implements WarehouseInterface {
 	 */
 	setName(displayName: string, ctx: debug.DebugCtx): Promise<WarehouseInterface> {
 		const currentDisplayName = this.displayName;
-		debug.log(ctx, "note:set_name")({ displayName, currentDisplayName });
+		debug.log(ctx, 'note:set_name')({ displayName, currentDisplayName });
 
 		if (displayName === currentDisplayName || !displayName) {
-			debug.log(ctx, "note:set_name:noop")({ displayName, currentDisplayName });
+			debug.log(ctx, 'note:set_name:noop')({ displayName, currentDisplayName });
 			return Promise.resolve(this);
 		}
 
-		debug.log(ctx, "note:set_name:updating")({ displayName });
+		debug.log(ctx, 'note:set_name:updating')({ displayName });
 		return this.update({ displayName });
 	}
 
@@ -206,19 +206,19 @@ class Warehouse implements WarehouseInterface {
 		return {
 			displayName: (ctx: debug.DebugCtx) =>
 				this.#stream.pipe(
-					tap(debug.log(ctx, "streams: display_name: input")),
-					map(({ displayName }) => displayName || ""),
-					tap(debug.log(ctx, "streams: display_name: res"))
+					tap(debug.log(ctx, 'streams: display_name: input')),
+					map(({ displayName }) => displayName || ''),
+					tap(debug.log(ctx, 'streams: display_name: res'))
 				),
 
 			entries: (ctx: debug.DebugCtx) =>
 				combineLatest([
 					newViewStream<{ rows: WarehouseStockEntry }, VolumeStockClient[]>(
 						this.#db._pouch,
-						"v1_stock/by_warehouse",
+						'v1_stock/by_warehouse',
 						{
 							group_level: 2,
-							...(this._id !== versionId("0-all") && {
+							...(this._id !== versionId('0-all') && {
 								startkey: [this._id],
 								endkey: [this._id, {}],
 								include_end: true
@@ -230,7 +230,7 @@ class Warehouse implements WarehouseInterface {
 									isbn,
 									quantity,
 									warehouseId,
-									warehouseName: ""
+									warehouseName: ''
 								}))
 								.filter(({ quantity }) => quantity > 0)
 								.sort(sortBooks),
@@ -238,20 +238,24 @@ class Warehouse implements WarehouseInterface {
 					),
 					this.#db.stream().warehouseList(ctx)
 				]).pipe(
-					tap(debug.log(ctx, "warehouse_entries:stream:input")),
+					tap(debug.log(ctx, 'warehouse_entries:stream:input')),
 					map(([entries, warehouses]) => {
 						// Create a record of warehouse ids and names for easy lookup
-						const warehouseNames = warehouses.reduce((acc, { id, displayName }) => ({ ...acc, [id]: displayName }), {});
+						const warehouseNames = warehouses.reduce(
+							(acc, { id, displayName }) => ({ ...acc, [id]: displayName }),
+							{}
+						);
 						const res = entries.map((e) => ({
 							...e,
-							warehouseName: warehouseNames[e.warehouseId] || "not-found"
+							warehouseName: warehouseNames[e.warehouseId] || 'not-found'
 						}));
 						return res;
 					}),
-					tap(debug.log(ctx, "warehouse_entries:stream:output"))
+					tap(debug.log(ctx, 'warehouse_entries:stream:output'))
 				)
 		};
 	}
 }
 
-export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface => new Warehouse(db, id);
+export const newWarehouse = (db: DatabaseInterface, id?: string | typeof NEW_WAREHOUSE): WarehouseInterface =>
+	new Warehouse(db, id);

--- a/pkg/db/src/test-runner/__tests__/tests.ts
+++ b/pkg/db/src/test-runner/__tests__/tests.ts
@@ -11,7 +11,7 @@ const { waitFor } = testUtils;
 // A smoke test for the test runner
 const runnerSmokeTests: TestFunction = async (db, version, getNotesAndWarehouses) => {
 	// Full stock should be empty to begin with
-	const fullStock = await firstValueFrom(db.warehouse().stream({}).entries);
+	const fullStock = await firstValueFrom(db.warehouse().stream().entries({}));
 	expect(fullStock).toEqual([]);
 
 	// Create warehouse documents and update displayNames
@@ -47,7 +47,7 @@ const runnerSmokeTests: TestFunction = async (db, version, getNotesAndWarehouses
 		];
 		const assertions = assertionTuples.map(([warehouse, books]) =>
 			waitFor(async () => {
-				const stock = await firstValueFrom(warehouse.stream({}).entries);
+				const stock = await firstValueFrom(warehouse.stream().entries({}));
 				expect(stock).toEqual(books);
 			})
 		);

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -79,10 +79,10 @@ export type NoteData<A extends Record<string, any> = {}> = CouchDocument<
  * A standardized interface for streams received from a note
  */
 export interface NoteStream {
-	state: Observable<NoteState>;
-	displayName: Observable<string>;
-	updatedAt: Observable<Date | null>;
-	entries: Observable<VolumeStockClient[]>;
+	state: (ctx: debug.DebugCtx) => Observable<NoteState>;
+	displayName: (ctx: debug.DebugCtx) => Observable<string>;
+	updatedAt: (ctx: debug.DebugCtx) => Observable<Date | null>;
+	entries: (ctx: debug.DebugCtx) => Observable<VolumeStockClient[]>;
 }
 
 /**
@@ -123,7 +123,7 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 	 * - `updatedAt` - streams the note's `updatedAt`
 	 * - `entries` - streams the note's `entries` (volume transactions)
 	 */
-	stream: (ctx: debug.DebugCtx) => NoteStream;
+	stream: () => NoteStream;
 }
 
 /**
@@ -149,8 +149,8 @@ export type WarehouseData<A extends Record<string, any> = {}> = CouchDocument<
  * A standardized interface for streams received from a warehouse
  */
 export interface WarehouseStream {
-	displayName: Observable<string>;
-	entries: Observable<VolumeStockClient[]>;
+	displayName: (ctx: debug.DebugCtx) => Observable<string>;
+	entries: (ctx: debug.DebugCtx) => Observable<VolumeStockClient[]>;
 }
 
 /**
@@ -173,7 +173,7 @@ export interface WarehouseProto<N extends NoteInterface = NoteInterface, A exten
 	 * - `displayName` - streams the warehouse's `displayName`
 	 * - `entries` - streams the warehouse's `entries` (stock)
 	 */
-	stream: (ctx: debug.DebugCtx) => WarehouseStream;
+	stream: () => WarehouseStream;
 }
 
 /**
@@ -206,9 +206,9 @@ export interface FindNote<N extends NoteInterface, W extends WarehouseInterface>
  * A standardized interface for streams received from a db
  */
 export interface DbStream {
-	warehouseList: Observable<NavListEntry[]>;
-	outNoteList: Observable<NavListEntry[]>;
-	inNoteList: Observable<InNoteList>;
+	warehouseList: (ctx: debug.DebugCtx) => Observable<NavListEntry[]>;
+	outNoteList: (ctx: debug.DebugCtx) => Observable<NavListEntry[]>;
+	inNoteList: (ctx: debug.DebugCtx) => Observable<InNoteList>;
 }
 
 /**
@@ -243,7 +243,7 @@ export interface DatabaseInterface<W extends WarehouseInterface = WarehouseInter
 	 * - `outNoteList` a stream of out note list entries (for navigation)
 	 * - `inNoteList` - a stream of in note list entries (for navigation)
 	 */
-	stream: (ctx: debug.DebugCtx) => DbStream;
+	stream: () => DbStream;
 	/**
 	 * Init initialises the db:
 	 * - creates the default warehouse

--- a/pkg/db/src/utils/misc.ts
+++ b/pkg/db/src/utils/misc.ts
@@ -1,15 +1,15 @@
-import { distinctUntilChanged, firstValueFrom, Observable, Subject, Subscription } from "rxjs";
+import { distinctUntilChanged, firstValueFrom, Observable, Subject, Subscription } from 'rxjs';
 
-import { VersionedString, VolumeStock } from "../types";
+import { VersionedString, VolumeStock } from '../types';
 
 export const sortBooks = ({ isbn: i1, warehouseId: w1 }: VolumeStock, { isbn: i2, warehouseId: w2 }: VolumeStock) =>
 	i1 < i2 ? -1 : i1 > i2 ? 1 : w1 < w2 ? -1 : 1;
 
 /** Replaces JS friendly version name ('version_1_1') with a human friendly version name ('version 1.1') */
-export const processVersionName = (s: string): string => s.replace("_", " ").replace("_", ".");
+export const processVersionName = (s: string): string => s.replace('_', ' ').replace('_', '.');
 
 /** Replaces JS friendly test function name ('commitNotes') with a human friendly test name ('commit notes') */
-export const processTestName = (s: string): string => s.replaceAll(/([A-Z]|[0-9]+)/g, (c) => " " + c.toLowerCase());
+export const processTestName = (s: string): string => s.replaceAll(/([A-Z]|[0-9]+)/g, (c) => ' ' + c.toLowerCase());
 
 /**
  * A util used to generate a timestamped unique string.
@@ -29,12 +29,12 @@ export const uniqueTimestamp = (i = 0) => {
 	// Able to represent 1296 numbers and it's safe to assume no more
 	// then that will be processed under the same timestamp (in single millisecond)
 	const iStr = (i % 1296).toString(36);
-	const index = ["0".repeat(2 - iStr.length), iStr].join("");
+	const index = ['0'.repeat(2 - iStr.length), iStr].join('');
 
 	// Additional two characters for uniqueness buffer
 	const additional = Math.floor(Math.random() * 1296).toString(36);
 
-	return [hexTimestamp, index, additional].join("");
+	return [hexTimestamp, index, additional].join('');
 };
 
 export const runAfterCondition = async <R>(cb: () => Promise<R>, condition: Observable<boolean>): Promise<R> => {
@@ -94,4 +94,7 @@ export const versionId = (id: string): VersionedString => (isVersioned(id) ? id 
 /**
  * Returns true if the id is a versioned string.
  */
-export const isVersioned = (id: string): id is VersionedString => id.startsWith("v1/");
+export const isVersioned = (id: string): id is VersionedString => id.startsWith('v1/');
+
+/** Is empty is a helper function, checking for an object being defined, but empty (`{}`) */
+export const isEmpty = (obj: Record<string, unknown>): boolean => Object.keys(obj).length === 0;

--- a/pkg/db/src/utils/misc.ts
+++ b/pkg/db/src/utils/misc.ts
@@ -1,15 +1,15 @@
-import { distinctUntilChanged, firstValueFrom, Observable, Subject, Subscription } from 'rxjs';
+import { distinctUntilChanged, firstValueFrom, Observable, Subject, Subscription } from "rxjs";
 
-import { VersionedString, VolumeStock } from '../types';
+import { VersionedString, VolumeStock } from "../types";
 
 export const sortBooks = ({ isbn: i1, warehouseId: w1 }: VolumeStock, { isbn: i2, warehouseId: w2 }: VolumeStock) =>
 	i1 < i2 ? -1 : i1 > i2 ? 1 : w1 < w2 ? -1 : 1;
 
 /** Replaces JS friendly version name ('version_1_1') with a human friendly version name ('version 1.1') */
-export const processVersionName = (s: string): string => s.replace('_', ' ').replace('_', '.');
+export const processVersionName = (s: string): string => s.replace("_", " ").replace("_", ".");
 
 /** Replaces JS friendly test function name ('commitNotes') with a human friendly test name ('commit notes') */
-export const processTestName = (s: string): string => s.replaceAll(/([A-Z]|[0-9]+)/g, (c) => ' ' + c.toLowerCase());
+export const processTestName = (s: string): string => s.replaceAll(/([A-Z]|[0-9]+)/g, (c) => " " + c.toLowerCase());
 
 /**
  * A util used to generate a timestamped unique string.
@@ -29,12 +29,12 @@ export const uniqueTimestamp = (i = 0) => {
 	// Able to represent 1296 numbers and it's safe to assume no more
 	// then that will be processed under the same timestamp (in single millisecond)
 	const iStr = (i % 1296).toString(36);
-	const index = ['0'.repeat(2 - iStr.length), iStr].join('');
+	const index = ["0".repeat(2 - iStr.length), iStr].join("");
 
 	// Additional two characters for uniqueness buffer
 	const additional = Math.floor(Math.random() * 1296).toString(36);
 
-	return [hexTimestamp, index, additional].join('');
+	return [hexTimestamp, index, additional].join("");
 };
 
 export const runAfterCondition = async <R>(cb: () => Promise<R>, condition: Observable<boolean>): Promise<R> => {
@@ -94,7 +94,7 @@ export const versionId = (id: string): VersionedString => (isVersioned(id) ? id 
 /**
  * Returns true if the id is a versioned string.
  */
-export const isVersioned = (id: string): id is VersionedString => id.startsWith('v1/');
+export const isVersioned = (id: string): id is VersionedString => id.startsWith("v1/");
 
 /** Is empty is a helper function, checking for an object being defined, but empty (`{}`) */
 export const isEmpty = (obj: Record<string, unknown>): boolean => Object.keys(obj).length === 0;


### PR DESCRIPTION
* Create internal stream, updating the internal data (for note/warehouse) on each stream
* Write tests for the behaviour
* Utilise the internal strem to 'derive' other, exposed, streams from it (multicast) - in note, and warehouse interfaces