### PR TITLE
Feature/db init states

### DIFF
--- a/apps/web-client/src/lib/stores/inventory/__tests__/note_state.test.ts
+++ b/apps/web-client/src/lib/stores/inventory/__tests__/note_state.test.ts
@@ -18,8 +18,8 @@ describe("createDisplayStateStore", () => {
 		const db = await newTestDB();
 		const note = await db.warehouse().note("note-1").create();
 
-		const internalStateStore = createInternalStateStore(note, {});
-		const displayStateStore = createDisplayStateStore(note, internalStateStore, {});
+		const internalStateStore = createInternalStateStore({}, note);
+		const displayStateStore = createDisplayStateStore({}, note, internalStateStore);
 
 		// The display state store subscribes to the internal state store and the note store (in db). When the first subscriber is subscribed to the
 		// display state store, the subscription to note state is opened. When the last subscriber unsubscribes from the display state store, the
@@ -47,8 +47,8 @@ describe("createDisplayStateStore", () => {
 		const db = await newTestDB();
 		const note = await db.warehouse().note("note-1").create();
 
-		const internalStateStore = createInternalStateStore(note, {});
-		const displayStateStore = createDisplayStateStore(note, internalStateStore, {});
+		const internalStateStore = createInternalStateStore({}, note);
+		const displayStateStore = createDisplayStateStore({}, note, internalStateStore);
 
 		// See dummy subscription in the previous test ^^
 		const cleanupSubscription = displayStateStore.subscribe(() => null);
@@ -76,8 +76,8 @@ describe("createDisplayStateStore", () => {
 		// On init the state picker's bind:value runs an update with the initial state, which is the same as the current state.
 		await note.commit({});
 
-		const internalStateStore = createInternalStateStore(note, {});
-		const displayStateStore = createDisplayStateStore(note, internalStateStore, {});
+		const internalStateStore = createInternalStateStore({}, note);
+		const displayStateStore = createDisplayStateStore({}, note, internalStateStore);
 
 		// See dummy subscription in the previous test ^^
 		const cleanupSubscription = displayStateStore.subscribe(() => null);
@@ -100,8 +100,8 @@ describe("createDisplayStateStore", () => {
 
 	test("should stream 'undefined' if no note provided", () => {
 		// Check for both internal state store as well as display state store
-		const internalStateStore = createInternalStateStore(undefined, {});
-		const displayStateStore = createDisplayStateStore(undefined, internalStateStore, {});
+		const internalStateStore = createInternalStateStore({}, undefined);
+		const displayStateStore = createDisplayStateStore({}, undefined, internalStateStore);
 		expect(get(displayStateStore)).toEqual(undefined);
 	});
 });

--- a/apps/web-client/src/lib/stores/inventory/__tests__/table_content.test.ts
+++ b/apps/web-client/src/lib/stores/inventory/__tests__/table_content.test.ts
@@ -15,7 +15,7 @@ describe("tableContentStore", () => {
 		let displayEntries: VolumeQuantity[] | undefined;
 
 		// Both db and entity are undefined (this will happen at build time, as db is instantiated only in browser)
-		let de$ = createDisplayEntriesStore(undefined, undefined, readable(0), {});
+		let de$ = createDisplayEntriesStore({}, undefined, undefined, readable(0));
 		de$.subscribe((de) => (displayEntries = de));
 		expect(displayEntries).toEqual([]);
 
@@ -24,12 +24,12 @@ describe("tableContentStore", () => {
 
 		// Should also work if db is defined but entity is undefined (this might happen if the entity id is not specified)
 		const db = await newTestDB();
-		de$ = createDisplayEntriesStore(db, undefined, readable(0), {});
+		de$ = createDisplayEntriesStore({}, db, undefined, readable(0));
 		de$.subscribe((de) => (displayEntries = de));
 		expect(displayEntries).toEqual([]);
 
 		// Same check for pagination
-		const pd$ = createPaginationDataStore(undefined, readable(0), {});
+		const pd$ = createPaginationDataStore({}, undefined, readable(0));
 		let paginationData: PaginationData | undefined;
 		pd$.subscribe((pd) => (paginationData = pd));
 		expect(paginationData).toEqual({
@@ -77,7 +77,7 @@ describe("tableContentStore", () => {
 			db.books().upsert([book1, book2])
 		]);
 
-		const de$ = createDisplayEntriesStore(db, note, readable(0), {});
+		const de$ = createDisplayEntriesStore({}, db, note, readable(0));
 		let displayEntries: DisplayRow[];
 		de$.subscribe((de) => (displayEntries = de));
 

--- a/apps/web-client/src/lib/stores/inventory/display_name.ts
+++ b/apps/web-client/src/lib/stores/inventory/display_name.ts
@@ -11,9 +11,9 @@ import { readableFromStream } from "$lib/utils/streams";
 
 interface CreateDisplayNameStore {
 	(
+		ctx: debug.DebugCtx,
 		entity: WarehouseInterface | NoteInterface | undefined,
-		internalStateStore: Writable<NoteAppState> | null,
-		ctx: debug.DebugCtx
+		internalStateStore: Writable<NoteAppState> | null
 	): Writable<string | undefined>;
 }
 
@@ -22,11 +22,12 @@ interface CreateDisplayNameStore {
  * - the store listens to updates in the database and streams the value for the displayName to the UI
  * - propagates the update of displayName (from the UI) to the database.
  *
+ * @param ctx Debug context
  * @param entity the note/warehouse interface
  * @param internalStateStore (optional) reference to the internal state store for the note. If provided, the store will be updated with the temp state while the content store updates.
  */
-export const createDisplayNameStore: CreateDisplayNameStore = (entity, internalStateStore, ctx = {}) => {
-	const displayNameInternal = readableFromStream(entity?.stream().displayName(ctx), "", ctx);
+export const createDisplayNameStore: CreateDisplayNameStore = (ctx, entity, internalStateStore) => {
+	const displayNameInternal = readableFromStream(ctx, entity?.stream().displayName(ctx), "");
 
 	// Set method updates the displayName in the database and, if the internal state store is provided, sets the temp state
 	// if internal state store is provided (and set to temp state by this action), it will be updated to the non-temp state
@@ -44,7 +45,7 @@ export const createDisplayNameStore: CreateDisplayNameStore = (entity, internalS
 		}
 
 		internalStateStore?.set(NoteTempState.Saving);
-		entity?.setName(displayName, ctx);
+		entity?.setName(ctx, displayName);
 	};
 
 	// Update method updates the store using the set method, only providing the current value of the store to the update function

--- a/apps/web-client/src/lib/stores/inventory/index.ts
+++ b/apps/web-client/src/lib/stores/inventory/index.ts
@@ -29,33 +29,24 @@ interface CreateNoteStores {
  * @returns
  */
 export const createNoteStores: CreateNoteStores = (note) => {
-	const noteStateCtx = {
-		name: `[NOTE_STATE::${note?._id}]`,
-		debug: false
-	};
-	const internalState = createInternalStateStore(note, noteStateCtx);
+	const noteStateCtx = { name: `[NOTE_STATE::${note?._id}]`, debug: false };
+	const internalState = createInternalStateStore(noteStateCtx, note);
 
-	const updatedAtCtx = {
-		name: `[NOTE_UPDATED_AT::${note?._id}]`,
-		debug: false
-	};
-	const updatedAt = readableFromStream(note?.stream().updatedAt(updatedAtCtx), null, updatedAtCtx);
+	const updatedAtCtx = { name: `[NOTE_UPDATED_AT::${note?._id}]`, debug: false };
+	const updatedAt = readableFromStream(updatedAtCtx, note?.stream().updatedAt(updatedAtCtx), null);
 
 	const currentPage = writable(0);
 
-	const displayName = createDisplayNameStore(note, undefined, {
-		name: `[NOTE_DISPLAY_NAME::${note?._id}]`,
-		debug: false
-	});
-	const state = createDisplayStateStore(note, internalState, noteStateCtx);
-	const entries = createDisplayEntriesStore(getDB(), note, currentPage, {
-		name: `[NOTE_ENTRIES::${note?._id}]`,
-		debug: false
-	});
-	const paginationData = createPaginationDataStore(note, currentPage, {
-		name: `[NOTE_PAGINATION::${note?._id}]`,
-		debug: false
-	});
+	const displayNameCtx = { name: `[NOTE_DISPLAY_NAME::${note?._id}]`, debug: false };
+	const displayName = createDisplayNameStore(displayNameCtx, note, undefined);
+
+	const state = createDisplayStateStore(noteStateCtx, note, internalState);
+
+	const entriesCtx = { name: `[NOTE_ENTRIES::${note?._id}]`, debug: false };
+	const entries = createDisplayEntriesStore(entriesCtx, getDB(), note, currentPage);
+
+	const paginationCtx = { name: `[NOTE_PAGINATION::${note?._id}]`, debug: false };
+	const paginationData = createPaginationDataStore(paginationCtx, note, currentPage);
 
 	return {
 		displayName,
@@ -79,25 +70,20 @@ interface CreateWarehouseStores {
 
 /**
  * Creates all the stores needed to display a warehouse view.
- * @param db db interface
- * @param warehouseId
+ * @param warehouse WarehouseInterface object
  * @returns
  */
 export const createWarehouseStores: CreateWarehouseStores = (warehouse) => {
 	const currentPage = writable(0);
 
-	const displayName = createDisplayNameStore(warehouse, null, {
-		name: `[WAREHOUSE_DISPLAY_NAME::${warehouse?._id}]`,
-		debug: false
-	});
-	const entries = createDisplayEntriesStore(getDB(), warehouse, currentPage, {
-		name: `[WAREHOUSE_ENTRIES::${warehouse?._id}]`,
-		debug: false
-	});
-	const paginationData = createPaginationDataStore(warehouse, currentPage, {
-		name: `[WAREHOUSE_PAGINATION::${warehouse?._id}]`,
-		debug: false
-	});
+	const displayNameCtx = { name: `[WAREHOUSE_DISPLAY_NAME::${warehouse?._id}]`, debug: false };
+	const displayName = createDisplayNameStore(displayNameCtx, warehouse, null);
+
+	const entriesCtx = { name: `[WAREHOUSE_ENTRIES::${warehouse?._id}]`, debug: false };
+	const entries = createDisplayEntriesStore(entriesCtx, getDB(), warehouse, currentPage);
+
+	const paginationDataCtx = { name: `[WAREHOUSE_PAGINATION::${warehouse?._id}]`, debug: false };
+	const paginationData = createPaginationDataStore(paginationDataCtx, warehouse, currentPage);
 
 	return {
 		displayName,

--- a/apps/web-client/src/lib/stores/inventory/note_state.ts
+++ b/apps/web-client/src/lib/stores/inventory/note_state.ts
@@ -12,15 +12,16 @@ import type { Subscription } from "rxjs";
 type NoteAppState = NoteState | NoteTempState | undefined;
 
 interface CreateInternalStateStore {
-	(note: NoteInterface | undefined, ctx: debug.DebugCtx): Writable<NoteAppState>;
+	(ctx: debug.DebugCtx, note: NoteInterface | undefined): Writable<NoteAppState>;
 }
 /**
  * Creates a note state store for internal usage:
  * - the store listens to updates to the note in the db and streams the value for the state to the UI
  * - the store allows for explicit updates (being a writable store) so that we can set temporary states until the update is confirmed by the db
+ * @param ctx Debug context
  * @param note Note interface for db communication
  */
-export const createInternalStateStore: CreateInternalStateStore = (note, ctx) => {
+export const createInternalStateStore: CreateInternalStateStore = (ctx, note) => {
 	const state = writable<NoteAppState>();
 
 	let noteSubscription: Subscription | undefined = undefined;
@@ -83,7 +84,7 @@ export const createInternalStateStore: CreateInternalStateStore = (note, ctx) =>
 };
 
 interface CreateDisplayStateStore {
-	(note: NoteInterface | undefined, internalStateStore: Writable<NoteAppState>, ctx: debug.DebugCtx): Writable<NoteAppState>;
+	(ctx: debug.DebugCtx, note: NoteInterface | undefined, internalStateStore: Writable<NoteAppState>): Writable<NoteAppState>;
 }
 /**
  * Creates a note state store for display purposes:
@@ -91,10 +92,11 @@ interface CreateDisplayStateStore {
  * - it streams the current value of the internal state store
  *   (either a definitive state of the note in the db, or temporary state, while the note in the database is being updated)
  * - it handles updates, comming from the UI, by updating the internal state store and the note in the db accordingly
+ * @param ctx debug context
  * @param note Note interface for db communication
  * @param internalStateStore a store in charge of internal state (this is used to set the temporary state while the note in the db is being updated)
  */
-export const createDisplayStateStore: CreateDisplayStateStore = (note, internalStateStore, ctx) => {
+export const createDisplayStateStore: CreateDisplayStateStore = (ctx, note, internalStateStore) => {
 	const set = (state: NoteState) => {
 		const internalState = get(internalStateStore);
 		debug.log(ctx, "display_state_store:set")({ state, internalState });

--- a/apps/web-client/src/lib/utils/streams.ts
+++ b/apps/web-client/src/lib/utils/streams.ts
@@ -42,7 +42,7 @@ export const derivedObservable = <T, U>(store: Readable<T>, fn: (value: T) => U)
  * @param observable observable stream
  * @returns readable store
  */
-export const readableFromStream = <T>(observable: Observable<T> | undefined, fallback: T, ctx: debug.DebugCtx): Readable<T> => {
+export const readableFromStream = <T>(ctx: debug.DebugCtx, observable: Observable<T> | undefined, fallback: T): Readable<T> => {
 	return readable<T>(fallback, (set) => {
 		if (!observable) {
 			debug.log(ctx, "readable_from_stream: stream not provided:fallback:")(fallback);

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -1,13 +1,27 @@
-<script>
+<script lang="ts">
+	import { readableFromStream } from "$lib/utils/streams";
+	import type { DBInitState } from "@librocco/db";
+	import { Header, InventoryPage } from "@librocco/ui";
+
 	// Import main.css in order to generate tailwind classes used in the app
 	import "../main.css";
 
-	// TEMP
-	// import { db } from '$lib/db/temp';
-	// import { onMount } from 'svelte';
-	// onMount(() => {
-	// 	window['db'] = db;
-	// });
+	import type { LayoutData } from "./$types";
+
+	export let data: LayoutData;
+
+	$: db = data.db;
+	$: initState = readableFromStream(db?.stream().initState({}), { state: "void", withReplication: false }, {});
 </script>
 
-<slot />
+<!-- We're returning <slot /> if db doesn't initialise (it's "void") in case of SSR env or if the db is fully initialised -->
+{#if ["ready", "void", "initialising"].includes($initState.state)}
+	<slot />
+{:else}
+	<InventoryPage>
+		<Header slot="header" currentLocation="/" links={[]} />
+		<h1 slot="table" class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-2xl capitalize text-gray-400">
+			{$initState.state}...
+		</h1>
+	</InventoryPage>
+{/if}

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 	export let data: LayoutData;
 
 	$: db = data.db;
-	$: initState = readableFromStream(db?.stream().initState({}), { state: "void", withReplication: false }, {});
+	$: initState = readableFromStream({}, db?.stream().initState({}), { state: "void", withReplication: false });
 </script>
 
 <!-- We're returning <slot /> if db doesn't initialise (it's "void") in case of SSR env or if the db is fully initialised -->

--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -22,7 +22,7 @@ export const load: LayoutLoad = async ({ url }) => {
 		const remoteDb = COUCHDB_HOST ? `http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@${COUCHDB_HOST}:${COUCHDB_PORT}/${DB_NAME}` : undefined;
 
 		return {
-			db: await createDB().init({ remoteDb }, { name: "[DB_INIT]", debug: false })
+			db: await createDB().init({ name: "[DB_INIT]", debug: false }, { remoteDb })
 		};
 	}
 

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -42,7 +42,7 @@
 	const db = getDB();
 
 	const inNoteListCtx = { name: "[IN_NOTE_LIST]", debug: false };
-	const inNoteList = readableFromStream(db?.stream().inNoteList(inNoteListCtx), [], inNoteListCtx);
+	const inNoteList = readableFromStream(inNoteListCtx, db?.stream().inNoteList(inNoteListCtx), []);
 
 	/**
 	 * Handle create note returns an `on:click` handler enclosed with the id of the warehouse

--- a/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
@@ -41,7 +41,7 @@
 	const db = getDB();
 
 	const outNoteListCtx = { name: "[OUT_NOTE_LIST]", debug: false };
-	const outNoteList = readableFromStream(db?.stream().outNoteList(outNoteListCtx), [], outNoteListCtx);
+	const outNoteList = readableFromStream(outNoteListCtx, db?.stream().outNoteList(outNoteListCtx), []);
 
 	/**
 	 * Handle create note is an `on:click` handler used to create a new outbound note

--- a/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
@@ -36,7 +36,7 @@
 	const db = getDB();
 
 	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
-	const warehouseList = readableFromStream(db?.stream().warehouseList(warehouseListCtx), [], warehouseListCtx);
+	const warehouseList = readableFromStream(warehouseListCtx, db?.stream().warehouseList(warehouseListCtx), []);
 
 	/**
 	 * Handle create warehouse is an `no:click` handler used to create the new warehouse

--- a/pkg/db/src/__tests__/benchmarks.ts
+++ b/pkg/db/src/__tests__/benchmarks.ts
@@ -13,7 +13,7 @@ export const commit20Notes: TestFunction = async (db, version, getNotesAndWareho
 			db
 				.warehouse(id)
 				.create()
-				.then((w) => w.setName(id, {}))
+				.then((w) => w.setName({}, id))
 		)
 	);
 

--- a/pkg/db/src/__tests__/tests.ts
+++ b/pkg/db/src/__tests__/tests.ts
@@ -78,10 +78,10 @@ export const standardApi: TestFunction = async (db) => {
 	expect(nonExistingNote).toBeUndefined();
 
 	// Committed notes can't be updated nor deleted.
-	note1 = await note1.setName("Note 1", {});
+	note1 = await note1.setName({}, "Note 1");
 	expect(note1.displayName).toEqual("Note 1");
 	await note1.commit({});
-	note1 = await note1.setName("New name", {});
+	note1 = await note1.setName({}, "New name");
 	expect(note1.displayName).toEqual("Note 1");
 
 	// Notes on the default warehouse should atomatically be outbound, and on specific warehouses inbound.
@@ -94,7 +94,7 @@ export const standardApi: TestFunction = async (db) => {
 export const noteTransactionOperations: TestFunction = async (db) => {
 	// Set up two warehouses (with display names) and an outbound note
 	const [wh1, wh2] = await Promise.all([db.warehouse("wh1").create(), db.warehouse("wh2").create()]);
-	await Promise.all([wh1.setName("Warehouse 1", {}), wh2.setName("Warehouse 2", {})]);
+	await Promise.all([wh1.setName({}, "Warehouse 1"), wh2.setName({}, "Warehouse 2")]);
 
 	// We're testing against an outbound note as it lets us test against more robust functionality (different warehouses and such)
 	const note = await db.warehouse().note().create();
@@ -200,7 +200,7 @@ export const streamNoteValuesAccordingToSpec: TestFunction = async (db) => {
 		expect(updatedAt).toBeDefined();
 	});
 
-	await note.setName("test", {});
+	await note.setName({}, "test");
 	await waitFor(() => {
 		expect(displayName).toEqual("test");
 	});
@@ -354,7 +354,7 @@ export const streamWarehouseStock: TestFunction = async (db) => {
 	});
 
 	// Updating a warehouse name should be reflected in the stock stream
-	await warehouse1.setName("Warehouse 1", {});
+	await warehouse1.setName({}, "Warehouse 1");
 	await waitFor(() => {
 		expect(warehoues1Stock).toEqual([
 			{ isbn: "0123456789", quantity: 1, warehouseId: versionId("warehouse-1"), warehouseName: "Warehouse 1" }
@@ -398,7 +398,7 @@ export const warehousesListStream: TestFunction = async (db) => {
 	});
 
 	// Updating a warehouse name, should be reflected in warehouseList stream as well
-	await warehouse.setName("New Name", {});
+	await warehouse.setName({}, "New Name");
 	await waitFor(() => {
 		expect(warehouseList).toEqual([
 			{ id: versionId("0-all"), displayName: "All" },
@@ -445,7 +445,7 @@ export const inNotesStream: TestFunction = async (db) => {
 	});
 
 	// Updating of the note name should be reflected in the stream
-	await note1.setName("New Name", {});
+	await note1.setName({}, "New Name");
 	await waitFor(() => {
 		expect(inNoteList).toEqual([
 			{ id: versionId("0-all"), displayName: "All", notes: [{ id: note1._id, displayName: "New Name" }] },
@@ -501,7 +501,7 @@ export const inNotesStream: TestFunction = async (db) => {
 	// Testing the async update which shouldn't happen is a bit tricky, so we're applying additional update
 	// which, most certainly should happen, but would happen after the not-wanted update, so we can assert that
 	// only the latter took place.
-	await note1.setName("New Note - Updated", {});
+	await note1.setName({}, "New Note - Updated");
 	await waitFor(() => {
 		expect(inNoteList).toEqual([
 			{
@@ -592,7 +592,7 @@ export const outNotesStream: TestFunction = async (db) => {
 	});
 
 	// Change of note display name should be reflected in the stream
-	await note1.setName("New Name", {});
+	await note1.setName({}, "New Name");
 	await waitFor(() => {
 		expect(outNoteList).toEqual([{ id: note1._id, displayName: "New Name" }]);
 	});
@@ -602,7 +602,7 @@ export const outNotesStream: TestFunction = async (db) => {
 	// Testing the async update which shouldn't happen is a bit tricky, so we're applying additional update
 	// which, most certainly should happen, but would happen after the not-wanted update, so we can assert that
 	// only the latter took place.
-	await note1.setName("New Note - Updated", {});
+	await note1.setName({}, "New Note - Updated");
 	await waitFor(() => {
 		expect(outNoteList).toEqual([{ id: note1._id, displayName: "New Note - Updated" }]);
 	});
@@ -632,14 +632,14 @@ export const sequenceWarehouseDesignDocument: TestFunction = async (db) => {
 	expect(wh2.displayName).toEqual("New Warehouse (2)");
 	expect(wh3.displayName).toEqual("New Warehouse (3)");
 
-	await wh1.setName("New Name1", {});
-	await wh2.setName("New Name2", {});
+	await wh1.setName({}, "New Name1");
+	await wh2.setName({}, "New Name2");
 
 	const wh4 = await db.warehouse("3").create(); // New Warehouse (4)
 	expect(wh4.displayName).toEqual("New Warehouse (4)");
 
-	await wh3.setName("New Name3", {});
-	await wh4.setName("New Name4", {});
+	await wh3.setName({}, "New Name3");
+	await wh4.setName({}, "New Name4");
 
 	const wh5 = await db.warehouse("4").create(); // New Warehouse
 	expect(wh5.displayName).toEqual("New Warehouse");
@@ -658,13 +658,13 @@ export const sequenceNoteDesignDocument: TestFunction = async (db) => {
 	expect(note2).toMatchObject({ displayName: "New Note (2)" });
 	expect(note3).toMatchObject({ displayName: "New Note (3)" });
 
-	await note1.setName("New Name", {});
-	await note2.setName("New Name2", {});
+	await note1.setName({}, "New Name");
+	await note2.setName({}, "New Name2");
 	const note4 = await defaultWarehouse.note().create(); // New Note
 	expect(note4).toMatchObject({ displayName: "New Note (4)" });
 
-	await note3.setName("New Name", {});
-	await note4.setName("New Name2", {});
+	await note3.setName({}, "New Name");
+	await note4.setName({}, "New Name2");
 
 	const note5 = await defaultWarehouse.note().create(); // New Note
 	expect(note5).toMatchObject({ displayName: "New Note" });
@@ -803,7 +803,7 @@ export const booksInterface: TestFunction = async (db) => {
 
 	let bookEntries: (BookEntry | undefined)[] = [];
 
-	booksInterface.stream([book1.isbn, book2.isbn, book3.isbn], {}).subscribe((stream) => {
+	booksInterface.stream({}, [book1.isbn, book2.isbn, book3.isbn]).subscribe((stream) => {
 		bookEntries = stream;
 	});
 
@@ -922,19 +922,19 @@ export const syncNoteAndWarehouseInterfaceWithTheDb: TestFunction = async (db) =
 		.subscribe((dn$) => (ndn = dn$));
 
 	// Set the initial name for the note
-	note.setName("Note name", {});
+	note.setName({}, "Note name");
 	await waitFor(() => {
 		expect(ndn).toEqual("Note name");
 	});
 
 	// Update the name from a different instance, simulating an outside update
-	await db.warehouse().note("note-1").setName("Note name updated", {});
+	await db.warehouse().note("note-1").setName({}, "Note name updated");
 	await waitFor(() => {
 		expect(ndn).toEqual("Note name updated");
 	});
 
 	// Original instance should also be able to update the name (should have the correct _rev)
-	note.setName("Note name updated again", {});
+	note.setName({}, "Note name updated again");
 	await waitFor(() => {
 		expect(ndn).toEqual("Note name updated again");
 	});
@@ -950,7 +950,7 @@ export const syncNoteAndWarehouseInterfaceWithTheDb: TestFunction = async (db) =
 	const wInst1 = db.warehouse("warehosue-1");
 	const wInst2 = db.warehouse("warehosue-1");
 
-	await wInst2.setName("Warehouse 1's name", {});
+	await wInst2.setName({}, "Warehouse 1's name");
 
 	await waitFor(() => expect(wInst1).toEqual(wInst2));
 };

--- a/pkg/db/src/implementations/version-1.1/books.ts
+++ b/pkg/db/src/implementations/version-1.1/books.ts
@@ -43,7 +43,7 @@ class Books implements BooksInterface {
 		return unwrapDocs(rawBooks);
 	}
 
-	stream(isbns: string[], ctx: debug.DebugCtx) {
+	stream(ctx: debug.DebugCtx, isbns: string[]) {
 		return new Observable<(BookEntry | undefined)[]>((subscriber) => {
 			const emitter = this.#db._pouch.changes<BookEntry[]>({
 				since: "now",
@@ -64,7 +64,7 @@ class Books implements BooksInterface {
 				})
 			);
 
-			const changeStream = newChangesStream<BookEntry[]>(emitter, ctx).pipe(
+			const changeStream = newChangesStream<BookEntry[]>(ctx, emitter).pipe(
 				// The change only triggers a new query (as changes are partial and we need the "all docs" update)
 				switchMap(() =>
 					from(

--- a/pkg/db/src/implementations/version-1.1/types.ts
+++ b/pkg/db/src/implementations/version-1.1/types.ts
@@ -21,3 +21,12 @@ export type WarehouseData = WD;
 export type WarehouseInterface = WI<NoteInterface>;
 
 export type DatabaseInterface = DI<WarehouseInterface, NoteInterface>;
+
+export type WarehouseListViewResp = {
+	key: string;
+	value: { displayName?: string };
+};
+export type NoteListViewResp = {
+	key: string;
+	value: { displayName?: string; committed?: boolean };
+};

--- a/pkg/db/src/test-runner/__tests__/tests.ts
+++ b/pkg/db/src/test-runner/__tests__/tests.ts
@@ -22,7 +22,7 @@ const runnerSmokeTests: TestFunction = async (db, version, getNotesAndWarehouses
 				.create()
 				// For the purose of testing, we set the displayName to the warehouse id
 				// correct default displayNames are tested in the unit tests
-				.then((w) => w.setName(id, {}));
+				.then((w) => w.setName({}, id));
 		})
 	);
 

--- a/pkg/db/src/test-runner/test-setup.ts
+++ b/pkg/db/src/test-runner/test-setup.ts
@@ -50,7 +50,7 @@ export const newModel = (rawData: RawData, config: ImplementationSetup) => {
 		// If testing with docker support, we're using the remote db to replicate to/from
 		const remoteDb = __withDocker__ ? ["http://admin:admin@127.0.0.1:5001", `test-${dbName}`].join("/") : undefined;
 
-		return db.init({ remoteDb }, {});
+		return db.init({}, { remoteDb });
 	};
 
 	const test: TestTask = (name, cb) => {

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -202,10 +202,16 @@ export interface FindNote<N extends NoteInterface, W extends WarehouseInterface>
 	(noteId: string): Promise<NoteLookupResult<N, W> | undefined>;
 }
 
+export interface DBInitState {
+	state: "void" | "initialising" | "replicating" | "ready";
+	withReplication: boolean;
+}
+
 /**
  * A standardized interface for streams received from a db
  */
 export interface DbStream {
+	initState: (ctx: debug.DebugCtx) => Observable<DBInitState>;
 	warehouseList: (ctx: debug.DebugCtx) => Observable<NavListEntry[]>;
 	outNoteList: (ctx: debug.DebugCtx) => Observable<NavListEntry[]>;
 	inNoteList: (ctx: debug.DebugCtx) => Observable<InNoteList>;
@@ -253,7 +259,7 @@ export interface DatabaseInterface<W extends WarehouseInterface = WarehouseInter
 	 * _Note: this has to be called only the first time the db is initialised (unless using live replication), but is
 	 * idempotent in nature and it's good to run it each time the app is loaded (+ it's necessary if using live replication)._
 	 */
-	init: (params: { remoteDb?: string }, ctx: debug.DebugCtx) => Promise<DatabaseInterface>;
+	init: (params: { remoteDb?: string }, ctx: debug.DebugCtx) => DatabaseInterface;
 	/**
 	 * Books constructs an interface used for book operations agains the db:
 	 * - `get` - accepts an array of isbns and returns a same length array of book data or `undefined`.

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -98,7 +98,7 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 
 	// Note specific methods
 	/** Set name updates the `displayName` of the note. */
-	setName: (name: string, ctx: debug.DebugCtx) => Promise<NoteInterface<A>>;
+	setName: (ctx: debug.DebugCtx, name: string) => Promise<NoteInterface<A>>;
 	/**
 	 * Add volumes accepts an array of volume stock entries and adds them to the note.
 	 * If any transactions (for a given isbn and warehouse) already exist, the quantity gets aggregated.
@@ -167,7 +167,7 @@ export interface WarehouseProto<N extends NoteInterface = NoteInterface, A exten
 	/** Note constructs a note interface for the note with the provided id. If ommitted, a new (timestamped) id is generated (for note creation). */
 	note: (id?: string) => N;
 	/** Set name udpates the `displayName` of the warehouse */
-	setName: (name: string, ctx: debug.DebugCtx) => Promise<WarehouseInterface<N, A>>;
+	setName: (ctx: debug.DebugCtx, name: string) => Promise<WarehouseInterface<N, A>>;
 	/**
 	 * Stream returns an object containing observable streams for the warehouse:
 	 * - `displayName` - streams the warehouse's `displayName`
@@ -259,7 +259,7 @@ export interface DatabaseInterface<W extends WarehouseInterface = WarehouseInter
 	 * _Note: this has to be called only the first time the db is initialised (unless using live replication), but is
 	 * idempotent in nature and it's good to run it each time the app is loaded (+ it's necessary if using live replication)._
 	 */
-	init: (params: { remoteDb?: string }, ctx: debug.DebugCtx) => DatabaseInterface;
+	init: (ctx: debug.DebugCtx, params: { remoteDb?: string }) => DatabaseInterface;
 	/**
 	 * Books constructs an interface used for book operations agains the db:
 	 * - `get` - accepts an array of isbns and returns a same length array of book data or `undefined`.
@@ -294,7 +294,7 @@ export interface BooksInterface {
 	 * as the results being in the same order as the input array: a book data at index 'i' will correspond to the isbn at
 	 * index 'i' of the request array, if the book data doesn't exist in the db, `undefined` will be found at its place._
 	 */
-	stream: (isbns: string[], ctx: debug.DebugCtx) => Observable<(BookEntry | undefined)[]>;
+	stream: (ctx: debug.DebugCtx, isbns: string[]) => Observable<(BookEntry | undefined)[]>;
 }
 
 export interface NewDatabase {

--- a/pkg/db/src/utils/pouchdb.ts
+++ b/pkg/db/src/utils/pouchdb.ts
@@ -184,7 +184,6 @@ export const newChangesStream = <Model extends Record<any, any>>(emitter: PouchD
 interface ReplicateFn<R = Promise<void>> {
 	(params: { local: PouchDB.Database; remote: string }, ctx: debug.DebugCtx): R;
 }
-
 /**
  * A helper function used to replicate a remote (PouchDB/CouchDB) db to a local PouchDB instance.
  * This is a one time, one way replication used to initialize the local db.


### PR DESCRIPTION
Fixes #198 

Additionally, includes some cleanups and a small performance optimisation: db streams (nav lists) are kept internal to db interface, kept alive and multicasted to consumers (much "snappier" switching of views).

_Note: The way 'initialising' and 'replicating' state are communicated to the UI is more of a quick preview of the functionality, then the way it should actually be, but it gives us a starting point for enhancements._