### PR TITLE
Fix: hanging 'replication' when remote COUCH_URL is undefined

### DIFF
--- a/apps/web-client/src/routes/inventory/+layout.svelte
+++ b/apps/web-client/src/routes/inventory/+layout.svelte
@@ -19,6 +19,7 @@
 	onMount(() => {
 		// There is not remote CouchDB instance
 		if (!COUCH_URL) {
+			replicating = false;
 			return;
 		}
 


### PR DESCRIPTION
I didn't check my previous work in production/preview. Currently, in dev the COUCH_URL is always defined/set in the initial load function. On the initial load in production/preview the is url is undefined => we return early. Fix adds a single line to revert "replication" var back to false so UI will render