### PR TITLE
Fix/small fixes 5

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -23,7 +23,6 @@ importers:
       eslint: ^8.16.0
       eslint-config-prettier: ^8.3.0
       eslint-plugin-svelte3: ^4.0.0
-      fast-glob: ~3.2.12
       lucide-svelte: ^0.210.0
       postcss: ~8.4.13
       pouchdb: ~7.3.0

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "aaaa092591815fd39b057b7ff46f1bdcb637d052",
+  "pnpmShrinkwrapHash": "fb8c85a1b05d15ec52766f4255b1086499369c8d",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/pkg/db/src/__tests__/tests.ts
+++ b/pkg/db/src/__tests__/tests.ts
@@ -87,11 +87,22 @@ export const standardApi: TestFunction = async (db) => {
 	note1 = await note1.setName({}, "New name");
 	expect(note1.displayName).toEqual("Note 1");
 
-	// Notes on the default warehouse should atomatically be outbound, and on specific warehouses inbound.
+	// Notes on the default warehouse should automatically be outbound, and on specific warehouses inbound.
 	const outboundNote = db.warehouse().note();
 	const inboundNote = db.warehouse("wh1").note();
 	expect(outboundNote.noteType).toEqual("outbound");
 	expect(inboundNote.noteType).toEqual("inbound");
+
+	// Trying to access a note belonging to a different warehouse should throw an error.
+	const wh1Note = db.warehouse("wh1").note("wh1-note");
+	const wh1NoteFullId = wh1Note._id;
+	let err;
+	try {
+		db.warehouse("wh2").note(wh1NoteFullId);
+	} catch (e) {
+		err = e;
+	}
+	expect(err).toBeDefined();
 };
 
 export const noteTransactionOperations: TestFunction = async (db) => {

--- a/pkg/db/src/implementations/version-1.2/db.ts
+++ b/pkg/db/src/implementations/version-1.2/db.ts
@@ -143,9 +143,11 @@ class Database implements DatabaseInterface {
 		});
 	}
 
-	async findNote(id: string) {
+	async findNote(noteId: string) {
+		// Remove trailing slash if any
+		const id = noteId.replace(/\/$/, "");
 		// Note id looks something like this: "v1/<warehouse-id>/<note-type>/<note-id>"
-		const idSegments = id.split("/");
+		const idSegments = id.split("/").filter(Boolean);
 
 		// Validate the id is correct
 		if (idSegments.length !== 4) {

--- a/pkg/db/src/implementations/version-1.2/db.ts
+++ b/pkg/db/src/implementations/version-1.2/db.ts
@@ -87,6 +87,7 @@ class Database implements DatabaseInterface {
 		return this;
 	}
 
+	// #region setup
 	replicate(): Replicator {
 		return newDbReplicator(this);
 	}
@@ -120,6 +121,19 @@ class Database implements DatabaseInterface {
 		return this;
 	}
 
+	updateDesignDoc(doc: DesignDocument) {
+		return this._pouch.put(doc).catch((err) => {
+			// If error is not a conflict, throw it back
+			if (err.status != 409) {
+				throw err;
+			}
+			// If the error was a conflict (document exists), update the document
+			return this._pouch.get(doc._id).then(({ _rev }) => this._pouch.put({ ...doc, _rev }));
+		});
+	}
+	// #endregion setup
+
+	// #region instances
 	view<R extends MapReduceRow, M extends CouchDocument = CouchDocument>(view: string) {
 		return newView<R, M>(this._pouch, view);
 	}
@@ -131,18 +145,9 @@ class Database implements DatabaseInterface {
 	warehouse(id?: string | typeof NEW_WAREHOUSE): WarehouseInterface {
 		return newWarehouse(this, id);
 	}
+	// #endregion instances
 
-	updateDesignDoc(doc: DesignDocument) {
-		return this._pouch.put(doc).catch((err) => {
-			// If error is not a conflict, throw it back
-			if (err.status != 409) {
-				throw err;
-			}
-			// If the error was a conflict (document exists), update the document
-			return this._pouch.get(doc._id).then(({ _rev }) => this._pouch.put({ ...doc, _rev }));
-		});
-	}
-
+	// #region queries
 	async findNote(noteId: string) {
 		// Remove trailing slash if any
 		const id = noteId.replace(/\/$/, "");
@@ -161,6 +166,13 @@ class Database implements DatabaseInterface {
 
 		return note && warehouse ? { note, warehouse } : undefined;
 	}
+
+	async getWarehouseList() {
+		return this.view<WarehouseListRow>("v1_list/warehouses")
+			.query({})
+			.then(({ rows }) => rows.map(({ key: id, value: { displayName = "" } }) => ({ id, displayName })));
+	}
+	// #endregion queries
 
 	stream(): DbStream {
 		return {

--- a/pkg/db/src/implementations/version-1.2/types.ts
+++ b/pkg/db/src/implementations/version-1.2/types.ts
@@ -12,7 +12,8 @@ import {
 	VolumeStock,
 	MapReduceRow,
 	CouchDocument,
-	MapReduceRes
+	MapReduceRes,
+	NavListEntry
 } from "@/types";
 import { DocType } from "@/enums";
 
@@ -32,6 +33,7 @@ export type WarehouseInterface = WI<NoteInterface>;
 export type DatabaseInterface = DI<WarehouseInterface, NoteInterface> & {
 	view: <R extends MapReduceRow, M extends CouchDocument = CouchDocument>(name: string) => ViewInterface<R, M>;
 	stock: () => Observable<VolumeStock[]>;
+	getWarehouseList: () => Promise<NavListEntry[]>;
 };
 
 export interface ViewInterface<R extends MapReduceRow, M extends CouchDocument> {

--- a/pkg/db/src/implementations/version-1.2/utils.ts
+++ b/pkg/db/src/implementations/version-1.2/utils.ts
@@ -5,27 +5,53 @@ import { versionId } from "@/utils/misc";
 export const combineTransactionsWarehouses =
 	({ includeAvailableWarehouses }: { includeAvailableWarehouses: boolean }) =>
 	([entries, stats, warehouses]: [VolumeStock[], { total: number; totalPages: number }, NavListEntry[]]): EntriesStreamResult => {
-		// Create a record of warehouse ids and names for easy lookup
-		const warehouseNames = warehouses.reduce(
-			(acc, { id, displayName }) => ({ ...acc, [id]: displayName }),
-			{} as Record<string, string>
-		);
-
-		const warehouseSelection = Object.entries(warehouseNames)
-			.filter(([id]) => id !== versionId("0-all"))
-			.map(([value, label]) => ({ value, label }));
-
-		const rows = entries.map((e) => {
-			const entry = { ...e } as VolumeStockClient;
-
-			entry.warehouseName = warehouseNames[e.warehouseId] || "not-found";
-
-			if (includeAvailableWarehouses) {
-				entry.availableWarehouses = warehouseSelection;
-			}
-
-			return entry;
-		});
+		const rows = includeAvailableWarehouses
+			? addAvailableWarehouses(addWarehouseNames(entries, warehouses), warehouses)
+			: addWarehouseNames(entries, warehouses);
 
 		return { ...stats, rows };
 	};
+
+/**
+ * Takes in a list of VolumeStock entries and a list of existing warehouses and adds a `warehouseName` field (with respect to warehouseId) to each entry.
+ * @TODO_ITERABLES replace the processing with a iterable function and
+ * @TODO_ITERABLES take in an iterable of entries (instead of an array) and a map of warehouses (instead of a list)
+ *
+ * @param entries
+ * @param warehouses
+ * @returns
+ */
+export const addWarehouseNames = (entries: VolumeStock[], warehouses: NavListEntry[]): VolumeStockClient[] => {
+	const warehouseNameLookup = newWarehouseNameLookup(warehouses);
+
+	return entries.map((e) => {
+		const entry = { ...e } as VolumeStockClient;
+		entry.warehouseName = warehouseNameLookup.get(e.warehouseId) || "not-found";
+		return entry;
+	});
+};
+
+/**
+ * Takes in a list of VolumeStockClient entries and a list of existing warehouses and adds an `availableWarehouses` field to each entry (omitting the default warehouse).
+ * @TODO_ITERABLES replace the processing with a iterable function and
+ * @TODO_ITERABLES take in an iterable of entries (instead of an array) and a map of warehouses (instead of a list)
+ *
+ * @param entries
+ * @param warehouses
+ * @returns
+ */
+export const addAvailableWarehouses = (entries: VolumeStockClient[], warehouses: NavListEntry[]): VolumeStockClient[] => {
+	const warehouseNameLookup = newWarehouseNameLookup(warehouses);
+	warehouseNameLookup.delete(versionId("0-all"));
+	const availableWarehouses = [...warehouseNameLookup.entries()].map(([value, label]) => ({ value, label }));
+	return entries.map((e) => ({ ...e, availableWarehouses }));
+};
+
+const newWarehouseNameLookup = (warehouses: NavListEntry[]) =>
+	new Map(
+		(function* () {
+			for (const { id, displayName } of warehouses) {
+				yield [id, displayName];
+			}
+		})()
+	);

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -63,6 +63,8 @@ export interface EntriesStreamResult {
 	total: number;
 	totalPages: number;
 }
+
+export type EntriesQuery = (ctx: debug.DebugCtx) => Promise<VolumeStockClient[]>;
 // #endregion misc
 
 // #region books
@@ -148,6 +150,10 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 	 * - `entries` - streams the note's `entries` (volume transactions)
 	 */
 	stream: () => NoteStream;
+	/**
+	 * An imperative query (single response) of note's transactions (as opposed to the entries stream - an observable stream).
+	 */
+	getEntries: EntriesQuery;
 }
 
 /**
@@ -198,6 +204,10 @@ export interface WarehouseProto<N extends NoteInterface = NoteInterface, A exten
 	 * - `entries` - streams the warehouse's `entries` (stock)
 	 */
 	stream: () => WarehouseStream;
+	/**
+	 * An imperative query (single response) of warehouse stock (as opposed to the entries stream - an observable stream).
+	 */
+	getEntries: EntriesQuery;
 }
 
 /**

--- a/pkg/ui/src/InventoryTable/InventoryTable.svelte
+++ b/pkg/ui/src/InventoryTable/InventoryTable.svelte
@@ -189,17 +189,17 @@
 					{/if}
 				</td>
 				<td class="py-4 px-3 text-left">
-					{price}
+					{price || "N/A"}
 				</td>
 				<td class="hidden py-4 px-3 text-left sm:table-cell">
-					{year}
+					{year || "N/A"}
 				</td>
 
 				<td class="hidden py-4 px-3 md:table-cell">
-					{publisher}
+					{publisher || ""}
 				</td>
 				<td class="hidden py-4 px-3 xl:table-cell">
-					{editedBy}
+					{editedBy || ""}
 				</td>
 				<td class="py-4 px-3 text-left">
 					<div class="flex items-center bg-white md:left-16 2xl:left-[4.5rem]">


### PR DESCRIPTION
- Provide fallbacks to display "" or "N/A" in the table, rather than "null" or "undefined" (for books with no `year`, `authors`, `editedBy`, etc...)
- Remove trailing slash when using `findNote` (reloading note page breaks otherwise)
- Fixes #207 (points 1 and 2...3 was already solved)