### PR TITLE
Rehaul/iterators 1

### DIFF
--- a/pkg/shared/src/generators.test.ts
+++ b/pkg/shared/src/generators.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 
-import { iterableFromGenerator, wrapIter } from "./generators";
+import { EmptyIterableError, filter, flatMap, iterableFromGenerator, map, reduce, wrapIter } from "./generators";
 
 describe("iterableFromGenerator", () => {
 	test("should allow for multiple iterations over the same generator", () => {
@@ -17,7 +17,59 @@ describe("iterableFromGenerator", () => {
 	});
 });
 
-describe("Composition with 'transform'", () => {
+describe("Smoke test of transformers", () => {
+	test("map", () => {
+		const iterable = [1, 2, 3];
+		const mapped = map(iterable, (value) => value + 1);
+		expect([...mapped]).toEqual([2, 3, 4]);
+	});
+
+	test("flatMap", () => {
+		const iterable = [
+			[1, 2, 3],
+			[4, 5, 6]
+		];
+		const flattened = flatMap(iterable, (value) => value);
+		expect([...flattened]).toEqual([1, 2, 3, 4, 5, 6]);
+	});
+
+	test("filter", () => {
+		const iterable = [1, 2, 3, 4, 5, 6];
+		const filtered = filter(iterable, (value) => value % 2 === 0);
+		expect([...filtered]).toEqual([2, 4, 6]);
+	});
+
+	test("reduce without seed", () => {
+		const iterable = [1, 2, 3, 4, 5, 6];
+		const reduced = reduce(iterable, (acc, value) => acc + value);
+		expect(reduced).toEqual(21);
+	});
+
+	test("reduce with seed", () => {
+		const iterable = [1, 2, 3, 4, 5, 6];
+		const reduced = reduce(iterable, (acc, value) => acc + value, "");
+		expect(reduced).toEqual("123456");
+	});
+
+	test("reduce with empty iterable without seed", () => {
+		const iterable: number[] = [];
+		let error;
+		try {
+			reduce(iterable, (acc, value) => acc + value);
+		} catch (err) {
+			error = err;
+		}
+		expect(error).toBeInstanceOf(EmptyIterableError);
+	});
+
+	test("reduce with empty iterable with seed", () => {
+		const iterable: number[] = [];
+		const reduced = reduce(iterable, (acc, value) => acc + value, 0);
+		expect(reduced).toEqual(0);
+	});
+});
+
+describe("Composition with 'wrapIter'", () => {
 	test("should produce the resulting iterable from the composition of the given transformers", () => {
 		const iterable = [
 			{ step: "1", rows: [1, 2] },

--- a/pkg/shared/src/generators.test.ts
+++ b/pkg/shared/src/generators.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 
-import { iterableFromGenerator } from "./generators";
+import { filter, flatMap, iterableFromGenerator, map, transform } from "./generators";
 
 describe("iterableFromGenerator", () => {
 	test("should allow for multiple iterations over the same generator", () => {
@@ -14,5 +14,25 @@ describe("iterableFromGenerator", () => {
 
 		expect([...iterable]).toEqual([1, 2, 3]);
 		expect([...iterable]).toEqual([1, 2, 3]);
+	});
+});
+
+describe("Composition with 'transform'", () => {
+	test("should produce the resulting iterable from the composition of the given transformers", () => {
+		const iterable = [
+			{ step: "1", rows: [1, 2] },
+			{ step: "2", rows: [3, 4] },
+			{ step: "3", rows: [5, 6] }
+		];
+
+		const result = transform(
+			iterable,
+			flatMap(({ rows }) => rows), // Iterable { 1, 2, 3, 4, 5, 6 }
+			map((value) => value + 1), // Iterable { 2, 3, 4, 5, 6, 7 }
+			filter((value) => value % 2 === 0), // Iterable { 2, 4, 6 }
+			map((value) => value.toString()) // Iterable { "2", "4", "6" }
+		);
+
+		expect([...result]).toEqual(["2", "4", "6"]);
 	});
 });

--- a/pkg/shared/src/generators.test.ts
+++ b/pkg/shared/src/generators.test.ts
@@ -1,0 +1,18 @@
+import { describe, test, expect } from "vitest";
+
+import { iterableFromGenerator } from "./generators";
+
+describe("iterableFromGenerator", () => {
+	test("should allow for multiple iterations over the same generator", () => {
+		const genFn = function* () {
+			yield 1;
+			yield 2;
+			yield 3;
+		};
+
+		const iterable = iterableFromGenerator(genFn);
+
+		expect([...iterable]).toEqual([1, 2, 3]);
+		expect([...iterable]).toEqual([1, 2, 3]);
+	});
+});

--- a/pkg/shared/src/generators.test.ts
+++ b/pkg/shared/src/generators.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "vitest";
 
-import { filter, flatMap, iterableFromGenerator, map, transform } from "./generators";
+import { iterableFromGenerator, wrapIter } from "./generators";
 
 describe("iterableFromGenerator", () => {
 	test("should allow for multiple iterations over the same generator", () => {
@@ -25,13 +25,11 @@ describe("Composition with 'transform'", () => {
 			{ step: "3", rows: [5, 6] }
 		];
 
-		const result = transform(
-			iterable,
-			flatMap(({ rows }) => rows), // Iterable { 1, 2, 3, 4, 5, 6 }
-			map((value) => value + 1), // Iterable { 2, 3, 4, 5, 6, 7 }
-			filter((value) => value % 2 === 0), // Iterable { 2, 4, 6 }
-			map((value) => value.toString()) // Iterable { "2", "4", "6" }
-		);
+		const result = wrapIter(iterable)
+			.flatMap(({ rows }) => rows) // Iterable { 1, 2, 3, 4, 5, 6 }
+			.map((value) => value + 1) // Iterable { 2, 3, 4, 5, 6, 7 }
+			.filter((value) => value % 2 === 0) // Iterable { 2, 4, 6 }
+			.map((value) => value.toString()); // Iterable { "2", "4", "6" }
 
 		expect([...result]).toEqual(["2", "4", "6"]);
 	});

--- a/pkg/shared/src/generators.ts
+++ b/pkg/shared/src/generators.ts
@@ -1,0 +1,61 @@
+export function map<T>(iterable: Iterable<T>, mapper: (value: T) => T): Iterable<T>;
+export function map<T, R>(iterable: Iterable<T>, mapper: (value: T) => R): Iterable<R> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			yield mapper(value);
+		}
+	});
+}
+
+export function flatMap<T>(iterable: Iterable<T>, mapper: (value: T) => Iterable<T>): Iterable<T>;
+export function flatMap<T, R>(iterable: Iterable<T>, mapper: (value: T) => Iterable<R>): Iterable<R> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			yield* mapper(value);
+		}
+	});
+}
+
+export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): Iterable<T> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			if (predicate(value)) {
+				yield value;
+			}
+		}
+	});
+}
+
+export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T): T;
+export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T, seed: T): T;
+export function reduce<T, R>(iterable: Iterable<T>, reducer: (accumulator: R, value: T) => R, seed?: R): R {
+	const iterator = iterable[Symbol.iterator]();
+	let accumulator = seed || iterator.next().value;
+
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const { value, done } = iterator.next();
+		if (done && value === undefined) {
+			break;
+		}
+		accumulator = reducer(accumulator, iterator.next().value);
+	}
+
+	return accumulator;
+}
+
+/**
+ * Iterable from generator produces an iterable from a generator function.
+ * The created iterable can be reused (as opposed to a generator) as it's `[Symbol.iterator]` is the generator function
+ * (returning a new generator each time it's called).
+ *
+ * Unlike other forms of Iterables it holds no internal structures (other than the generator function) and merely references
+ * the structures used by the generator function (if any).
+ * @param genFn
+ * @returns
+ */
+export function iterableFromGenerator<T>(genFn: () => Generator<T>): Iterable<T> {
+	return {
+		[Symbol.iterator]: genFn
+	};
+}

--- a/pkg/shared/src/generators.ts
+++ b/pkg/shared/src/generators.ts
@@ -1,37 +1,31 @@
-type GeneratorTransformer<T, A> = (iterable: Iterable<T>) => Iterable<A>;
-
-export function map<T, R>(mapper: (value: T) => R): GeneratorTransformer<T, R> {
-	return (iterable: Iterable<T>) =>
-		iterableFromGenerator(function* () {
-			for (const value of iterable) {
-				yield mapper(value);
-			}
-		});
+export function map<T, R>(iterable: Iterable<T>, mapper: (value: T) => R): Iterable<R> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			yield mapper(value);
+		}
+	});
 }
 
-export function flatMap<T, R>(mapper: (value: T) => Iterable<R>): GeneratorTransformer<T, R> {
-	return (iterable: Iterable<T>) =>
-		iterableFromGenerator(function* () {
-			for (const value of iterable) {
-				yield* mapper(value);
-			}
-		});
+export function flatMap<T, R>(iterable: Iterable<T>, mapper: (value: T) => Iterable<R>): Iterable<R> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			yield* mapper(value);
+		}
+	});
 }
 
-export function filter<T>(predicate: (value: T) => boolean): GeneratorTransformer<T, T> {
-	return (iterable: Iterable<T>) =>
-		iterableFromGenerator(function* () {
-			for (const value of iterable) {
-				if (predicate(value)) {
-					yield value;
-				}
+export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): Iterable<T> {
+	return iterableFromGenerator(function* () {
+		for (const value of iterable) {
+			if (predicate(value)) {
+				yield value;
 			}
-		});
+		}
+	});
 }
 
-export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T): T;
-export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T, seed: T): T;
-export function reduce<T, R>(iterable: Iterable<T>, reducer: (accumulator: R, value: T) => R, seed?: R): R {
+export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T, seed?: T): T;
+export function reduce<T, R>(iterable: Iterable<T>, reducer: (accumulator: R, value: T) => R, seed: R): R {
 	const iterator = iterable[Symbol.iterator]();
 	let accumulator = seed || iterator.next().value;
 
@@ -45,43 +39,6 @@ export function reduce<T, R>(iterable: Iterable<T>, reducer: (accumulator: R, va
 	}
 
 	return accumulator;
-}
-
-export function transform<T, A>(iterable: Iterable<T>, tr1: GeneratorTransformer<T, A>): Iterable<A>;
-export function transform<T, A, B>(iterable: Iterable<T>, tr1: GeneratorTransformer<T, A>, tr2: GeneratorTransformer<A, B>): Iterable<B>;
-export function transform<T, A, B, C>(
-	iterable: Iterable<T>,
-	tr1: GeneratorTransformer<T, A>,
-	tr2: GeneratorTransformer<A, B>,
-	tr3: GeneratorTransformer<B, C>
-): Iterable<C>;
-export function transform<T, A, B, C, D>(
-	iterable: Iterable<T>,
-	tr1: GeneratorTransformer<T, A>,
-	tr2: GeneratorTransformer<A, B>,
-	tr3: GeneratorTransformer<B, C>,
-	tr4: GeneratorTransformer<C, D>
-): Iterable<D>;
-export function transform<T, A, B, C, D, E>(
-	iterable: Iterable<T>,
-	tr1: GeneratorTransformer<T, A>,
-	tr2: GeneratorTransformer<A, B>,
-	tr3: GeneratorTransformer<B, C>,
-	tr4: GeneratorTransformer<C, D>,
-	tr5: GeneratorTransformer<D, E>
-): Iterable<E>;
-export function transform<T, A, B, C, D, E, F>(
-	iterable: Iterable<T>,
-	tr1: GeneratorTransformer<T, A>,
-	tr2: GeneratorTransformer<A, B>,
-	tr3: GeneratorTransformer<B, C>,
-	tr4: GeneratorTransformer<C, D>,
-	tr5: GeneratorTransformer<D, E>,
-	tr6: GeneratorTransformer<E, F>
-): Iterable<F>;
-export function transform(iterable: Iterable<any>, ...transformers: GeneratorTransformer<any, any>[]): Iterable<any>;
-export function transform<T>(iterable: Iterable<T>, ...transformers: GeneratorTransformer<any, any>[]): Iterable<any> {
-	return transformers.reduce((iterable, transformer) => transformer(iterable), iterable);
 }
 
 /**
@@ -99,3 +56,49 @@ export function iterableFromGenerator<T>(genFn: () => Generator<T>): Iterable<T>
 		[Symbol.iterator]: genFn
 	};
 }
+
+interface TransformableIterable<T> extends Iterable<T> {
+	map<R>(mapper: (value: T) => R): TransformableIterable<R>;
+	flatMap<R>(bind: (value: T) => Iterable<R>): TransformableIterable<R>;
+	filter(predicate: (value: T) => boolean): TransformableIterable<T>;
+	reduce(reducer: (accumulator: T, value: T) => T, seed?: T): T;
+	reduce<R>(reducer: (accumulator: R, value: T) => T, seed: R): R;
+}
+
+/**
+ * Wrap an iterable with a set of transformation methods akin to array methods.
+ * The api (call signatures) is the same as with array methods, but each method returns a new iterable
+ * instead of an array (The iterable is not evaluated until it's iterated over).
+ *
+ * The returned iterable is already wrapped with the same set of methods, allowing for chaining (like in the array methods api).
+ *
+ * _Note: under the hood, the transformations are implemented using generator functions, but the returned iterable is reusable (as opposed to a generator)_
+ * _Note: if the input iterable contains any additional methods (e.g. a Map), they will be lost, as `wrapIter` takes in only the `[Symbol.iterator]` from the input._
+ *
+ * @example
+ * ```ts
+ * // Using array as an example, but the same applies to all types that implement the iterable interface
+ * const iterable = wrapIter([1, 2, 3])
+ * const result = iterable
+ * 		.map(mapper)
+ * 		.flatMap(flatMapper)
+ * 		.filter(predicate)
+ * 		.reduce(reducer, seed);
+ * ```
+ * @param iterable
+ * @returns
+ */
+export const wrapIter = <T>(iterable: Iterable<T>): TransformableIterable<T> => {
+	const m = <R>(mapper: (value: T) => R) => wrapIter(map(iterable, mapper));
+	const fm = <R>(mapper: (value: T) => Iterable<R>) => wrapIter(flatMap(iterable, mapper));
+	const f = (predicate: (value: T) => boolean) => wrapIter(filter(iterable, predicate));
+	const r = (reducer: (accumulator: T, value: T) => T, seed?: T) => reduce(iterable, reducer, seed);
+
+	return {
+		[Symbol.iterator]: iterable[Symbol.iterator],
+		map: m,
+		flatMap: fm,
+		filter: f,
+		reduce: r
+	};
+};

--- a/pkg/shared/src/generators.ts
+++ b/pkg/shared/src/generators.ts
@@ -1,29 +1,32 @@
-export function map<T>(iterable: Iterable<T>, mapper: (value: T) => T): Iterable<T>;
-export function map<T, R>(iterable: Iterable<T>, mapper: (value: T) => R): Iterable<R> {
-	return iterableFromGenerator(function* () {
-		for (const value of iterable) {
-			yield mapper(value);
-		}
-	});
-}
+type GeneratorTransformer<T, A> = (iterable: Iterable<T>) => Iterable<A>;
 
-export function flatMap<T>(iterable: Iterable<T>, mapper: (value: T) => Iterable<T>): Iterable<T>;
-export function flatMap<T, R>(iterable: Iterable<T>, mapper: (value: T) => Iterable<R>): Iterable<R> {
-	return iterableFromGenerator(function* () {
-		for (const value of iterable) {
-			yield* mapper(value);
-		}
-	});
-}
-
-export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): Iterable<T> {
-	return iterableFromGenerator(function* () {
-		for (const value of iterable) {
-			if (predicate(value)) {
-				yield value;
+export function map<T, R>(mapper: (value: T) => R): GeneratorTransformer<T, R> {
+	return (iterable: Iterable<T>) =>
+		iterableFromGenerator(function* () {
+			for (const value of iterable) {
+				yield mapper(value);
 			}
-		}
-	});
+		});
+}
+
+export function flatMap<T, R>(mapper: (value: T) => Iterable<R>): GeneratorTransformer<T, R> {
+	return (iterable: Iterable<T>) =>
+		iterableFromGenerator(function* () {
+			for (const value of iterable) {
+				yield* mapper(value);
+			}
+		});
+}
+
+export function filter<T>(predicate: (value: T) => boolean): GeneratorTransformer<T, T> {
+	return (iterable: Iterable<T>) =>
+		iterableFromGenerator(function* () {
+			for (const value of iterable) {
+				if (predicate(value)) {
+					yield value;
+				}
+			}
+		});
 }
 
 export function reduce<T>(iterable: Iterable<T>, reducer: (accumulator: T, value: T) => T): T;
@@ -42,6 +45,43 @@ export function reduce<T, R>(iterable: Iterable<T>, reducer: (accumulator: R, va
 	}
 
 	return accumulator;
+}
+
+export function transform<T, A>(iterable: Iterable<T>, tr1: GeneratorTransformer<T, A>): Iterable<A>;
+export function transform<T, A, B>(iterable: Iterable<T>, tr1: GeneratorTransformer<T, A>, tr2: GeneratorTransformer<A, B>): Iterable<B>;
+export function transform<T, A, B, C>(
+	iterable: Iterable<T>,
+	tr1: GeneratorTransformer<T, A>,
+	tr2: GeneratorTransformer<A, B>,
+	tr3: GeneratorTransformer<B, C>
+): Iterable<C>;
+export function transform<T, A, B, C, D>(
+	iterable: Iterable<T>,
+	tr1: GeneratorTransformer<T, A>,
+	tr2: GeneratorTransformer<A, B>,
+	tr3: GeneratorTransformer<B, C>,
+	tr4: GeneratorTransformer<C, D>
+): Iterable<D>;
+export function transform<T, A, B, C, D, E>(
+	iterable: Iterable<T>,
+	tr1: GeneratorTransformer<T, A>,
+	tr2: GeneratorTransformer<A, B>,
+	tr3: GeneratorTransformer<B, C>,
+	tr4: GeneratorTransformer<C, D>,
+	tr5: GeneratorTransformer<D, E>
+): Iterable<E>;
+export function transform<T, A, B, C, D, E, F>(
+	iterable: Iterable<T>,
+	tr1: GeneratorTransformer<T, A>,
+	tr2: GeneratorTransformer<A, B>,
+	tr3: GeneratorTransformer<B, C>,
+	tr4: GeneratorTransformer<C, D>,
+	tr5: GeneratorTransformer<D, E>,
+	tr6: GeneratorTransformer<E, F>
+): Iterable<F>;
+export function transform(iterable: Iterable<any>, ...transformers: GeneratorTransformer<any, any>[]): Iterable<any>;
+export function transform<T>(iterable: Iterable<T>, ...transformers: GeneratorTransformer<any, any>[]): Iterable<any> {
+	return transformers.reduce((iterable, transformer) => transformer(iterable), iterable);
 }
 
 /**

--- a/pkg/shared/src/index.ts
+++ b/pkg/shared/src/index.ts
@@ -1,2 +1,5 @@
 export * as testUtils from "./testUtils";
 export * as debug from "./debugger";
+
+/** @TODO it would be nice to export generators as a separate module (nodenext resolution style) */
+export * as generators from "./generators";

--- a/pkg/shared/src/index.ts
+++ b/pkg/shared/src/index.ts
@@ -1,5 +1,3 @@
 export * as testUtils from "./testUtils";
 export * as debug from "./debugger";
-
-/** @TODO it would be nice to export generators as a separate module (nodenext resolution style) */
-export * as generators from "./generators";
+export * from "./generators";


### PR DESCRIPTION
Fixes #257 

The reusability has been achieved by creating an iterable from generator on each transformation:
- the resulting iterable is as lean as the generator function: has only one property (`[Symbol.iterator]`) and doesn't hold internal iterable, it might (and probably will) contain reference to the iterable the generator function had captured in it's closure
- the resulting iterable is reusable (unlike the generator) - the `[Symbol.iterator]` property of the resulting iterable is actually the generator function (passed as argument), so each time a consumer acquires the iterator, it actually produces a new instance of the same generator (returned from the generator function)

Composition was achieved by wrapping the iterable in `TransformableIterable`, providing it with `map`, `flatMap`, `filter` and `reduce`, which can be chained together (as they all return an instance of `TransformableIterable`), but this kind of iterable is much lighter than an array (for instance)

`wrapIter(iterable)` (wrapping the `iterable` into `TransformableIterable`) is used in a similar way you would add a trait to a `struct` in Rust with the difference that, in case of `wrapIter`, any only the `[Symbol.iterator]` is taken from the input iterable, whereas the other methods the input might have are lost (e.g. `Map.prototype.keys`, etc.)

The resulting api is more/less the same as on arrays:
```ts
// Transformations using array methods
const arr = [0, 1, 2, 2]
const arrRes = arr
    .map(mapper)
    .filter(predicate)
    .flatMap(mapper)
    .reduce(reducer)

// For simplicity's sake we're using an array as an Iterable here
const iterable = wrapIter(arr)
const result = iterable
    .map(mapper)
    .filter(predicate)
    .flatMap(mapper)
    .reduce(reducer)
```
As you can see, the API is almost exactly the same (save wrapping with `wrapIter`)    

I've used an array as an example, but we can do this for any iterable:
```ts
const iterable = wrapIter(new Set(arr))
const result = iterable
    .map(mapper)
    .filter(predicate)
    .flatMap(mapper)
    .reduce(reducer)
```