### PR TITLE
Setup ci-debug workflow

### DIFF
--- a/.github/workflow.templates/ci-debug.yml
+++ b/.github/workflow.templates/ci-debug.yml
@@ -1,0 +1,35 @@
+#@ load("cache.lib.yml", "cache_node")
+#@ load("rush.lib.yml", "rush_add_path")
+#@ load("rush.lib.yml", "rush_install")
+#@ load("rush.lib.yml", "rush_build")
+
+name: Checks
+
+"on":
+    push:
+        branches:
+            - "ci-debug/*"
+
+jobs:
+    upterm-session:
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "16"
+            -  #@ cache_node()
+            -  #@ rush_add_path()
+            -  #@ rush_install()
+            -  #@ rush_build()
+            - name: Build the app
+              run: cd apps/web-client && rushx build:prod
+            - name: Setup upterm (debug) session
+              uses: lhotari/action-upterm@v1
+            - uses: actions/upload-artifact@v3
+              if: always()
+              with:
+                  name: ci-debug-artifacts
+                  path: ci-debug-artifacts/
+                  retention-days: 30

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -7,7 +7,9 @@
 name: Checks
 
 "on":
-    - push
+    push:
+        branches-ignore:
+            - "ci-debug/*"
 
 jobs:
     js-search-test: #@ test_job("JS-Search Tests", "pkg/js-search", "jest-junit")

--- a/.github/workflow.templates/workflow-templates.yml
+++ b/.github/workflow.templates/workflow-templates.yml
@@ -1,21 +1,23 @@
 name: Github Actions templates
 
 "on":
-  push:
-    paths:
-      - '.github/workflow.templates/*'
-      - '.github/workflows/*'
+    push:
+        paths:
+            - ".github/workflow.templates/*"
+            - ".github/workflows/*"
+        branches-ignore:
+            - "ci-debug/*"
 
 jobs:
-  check-template-generation:
-    name: Check Github Actions templates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run script to generate Github Actions
-        run: ./.github/build-workflows.sh
-      - name: Check if there are any changes
-        run: |
-          git status
-          git diff
-          git status | grep "working tree clean" || false && echo Did you forget to run build-workflows.sh?
+    check-template-generation:
+        name: Check Github Actions templates
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run script to generate Github Actions
+              run: ./.github/build-workflows.sh
+            - name: Check if there are any changes
+              run: |
+                  git status
+                  git diff
+                  git status | grep "working tree clean" || false && echo Did you forget to run build-workflows.sh?

--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -1,0 +1,39 @@
+name: Checks
+"on":
+  push:
+    branches:
+    - ci-debug/*
+jobs:
+  upterm-session:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "16"
+    - name: Cache node modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.rush
+          ~/.pnpm-store
+          common/temp
+          **/node_modules
+        key: ${{ runner.os }}-modules-node16-v3-${{ hashFiles('**/pnpm-lock.yaml') }}
+    - name: Add local rush scripts to PATH
+      run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
+    - name: Install packages
+      run: rush update
+    - name: Build packages
+      run: rush build
+    - name: Build the app
+      run: cd apps/web-client && rushx build:prod
+    - name: Setup upterm (debug) session
+      uses: lhotari/action-upterm@v1
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ci-debug-artifacts
+        path: ci-debug-artifacts/
+        retention-days: 30

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,6 +1,8 @@
 name: Checks
 "on":
-- push
+  push:
+    branches-ignore:
+    - ci-debug/*
 jobs:
   js-search-test:
     name: JS-Search Tests

--- a/.github/workflows/workflow-templates.yml
+++ b/.github/workflows/workflow-templates.yml
@@ -4,6 +4,8 @@ name: Github Actions templates
     paths:
     - .github/workflow.templates/*
     - .github/workflows/*
+    branches-ignore:
+    - ci-debug/*
 jobs:
   check-template-generation:
     name: Check Github Actions templates

--- a/ci-debug-artifacts/README.md
+++ b/ci-debug-artifacts/README.md
@@ -1,0 +1,5 @@
+# CI-Debug Artifacts
+
+This folder is used for any uploadable artifacts from ci-debug session.
+
+If you wish to save any artifacts for later download/inspection during the ci-debug session, store them here and the files will be available for download (under the workflow summary) after the workflow finishes.


### PR DESCRIPTION
Sets up a workflow which runs only on branches prepended with `ci-debug/*` (same branches are ignored by other workflows). 
The mentioned branches can be used to debug the CI using SSH