### PR TITLE
Allow for only positive quantity inputs in note transactions:

### DIFF
--- a/apps/e2e/integration/note-transactions/shared_tests.ts
+++ b/apps/e2e/integration/note-transactions/shared_tests.ts
@@ -254,26 +254,4 @@ export const runCommonTransactionTests = (view: ViewName) => {
 		await page.waitForTimeout(1000);
 		await statePicker.assertState(NoteTempState.Committing);
 	});
-
-	/**
-	 * @TODO : Unskip this when working on https://github.com/librocco/librocco/issues/288
-	 */
-	test.skip("should not allow committing a note with 0-quantity transaction(s)", async ({ page }) => {
-		const dashboard = getDashboard(page);
-
-		const content = dashboard.content();
-		const entries = content.entries(view);
-		const statePicker = content.statePicker();
-
-		// Add a transaction with 0 quantity
-		await content.scanField().add("1234567890");
-		await entries.row(0).field("quantity").set(0);
-
-		// Try and commit the note
-		await statePicker.select(NoteState.Committed);
-
-		/** @TODO This is a terrible way to assert this and is not really communicating anything, update when we have error display */
-		await page.waitForTimeout(1000);
-		await statePicker.assertState(NoteTempState.Committing);
-	});
 };

--- a/pkg/ui/src/InventoryTable/QuantityInput.svelte
+++ b/pkg/ui/src/InventoryTable/QuantityInput.svelte
@@ -40,8 +40,8 @@
 			}
 
 			const value = parseInt(input.value);
-			if (value < 0) {
-				input.value = "0";
+			if (value <= 0) {
+				input.value = "";
 			}
 			if (maxValue && value > maxValue) {
 				input.value = maxValue.toString();


### PR DESCRIPTION
* block all <= 0 values on input
* remove e2e test testing the behaviour (the behaviour is much simpler than e2e test made it out to be)

Fixes #314 