### PR TITLE
Fix/transaction update bug

### DIFF
--- a/pkg/db/src/__tests__/tests.ts
+++ b/pkg/db/src/__tests__/tests.ts
@@ -225,6 +225,19 @@ export const noteTransactionOperations: TestFunction = async (db) => {
 		]);
 	});
 
+	// Updating transaction with not-matched 'matchTxn' should be a noop
+	await note.updateTransaction(
+		{ isbn: "11111111", warehouseId: versionId("wh3") },
+		{ isbn: "11111111", quantity: 10, warehouseId: versionId(wh1._id) }
+	);
+	const entriesSnapshot = await note
+		.getEntries({})
+		.then((entries) => [...entries].map((e) => volumeStockClientToVolumeStockClientOld({ ...e, availableWarehouses: new Map() })));
+	expect([...entriesSnapshot]).toEqual([
+		{ isbn: "0123456789", quantity: 5, warehouseId: versionId(wh1._id), warehouseName: "Warehouse 1", availableWarehouses },
+		{ isbn: "11111111", quantity: 18, warehouseId: versionId(wh1._id), warehouseName: "Warehouse 1", availableWarehouses }
+	]);
+
 	// Remove transaction should remove the transaction (and not confuse it with the same isbn, but different warehouse)
 	await note.removeTransactions({ isbn: "0123456789", warehouseId: wh1._id }, { isbn: "11111111", warehouseId: "wh3" });
 	await waitFor(() => {

--- a/pkg/ui/src/InventoryTable/TdWarehouseSelect.svelte
+++ b/pkg/ui/src/InventoryTable/TdWarehouseSelect.svelte
@@ -25,7 +25,14 @@
 
 	const combobox = createCombobox({ label: `Select ${rowIx} warehouse`, selected: data.warehouseId });
 
-	$: dispatchChange($combobox.selected);
+	// To prevent excess updates, we're keeping track of the latest value
+	// and dispatching update only when the value changes.
+	//
+	// This would normally be handled by the fact that the value is string (a value comparable primitive),
+	// but since the value is part of an object (state of combobox store), the reactive block is ran on each store
+	// update.
+	let selected = data.warehouseId;
+	$: selected !== $combobox.selected && dispatchChange((selected = $combobox.selected));
 
 	$: ({ warehouseId, warehouseName, availableWarehouses = new Map<string, { displayName: string }>() } = data);
 


### PR DESCRIPTION
Fixes #263 

I've been logging the debug process, findings and, finally the fix in the issue discussion ☝️ 

The fixes applied:
- `note.updateTransaction` is noop if transaction is not matched (`matchTxn` doesn't exist in note's `entries`), as described in the issue discussion - **this part is tested**
- the UI (`OutNoteTable`) dispatches one (and only one) update when the warehouse is updated, and only if the warehouse is updated - **I was unable to reproduce this in tests so I've relied on click-through-testing-it-out**