### PR TITLE
Remove unnecessary stream transmissions on note transaction(s) update:

### DIFF
--- a/pkg/db/src/implementations/version-1.2/stock.ts
+++ b/pkg/db/src/implementations/version-1.2/stock.ts
@@ -38,7 +38,9 @@ class Stock implements StockInterface {
 			...this.options,
 			include_docs: false,
 			since: "now",
-			live: true
+			live: true,
+			// We don't care about changes to non-committed notes (as they don't affect the stock)
+			filter: (doc) => doc.committed
 		});
 	}
 

--- a/pkg/db/src/implementations/version-1.2/utils.ts
+++ b/pkg/db/src/implementations/version-1.2/utils.ts
@@ -4,8 +4,18 @@ import { VolumeStock } from "@librocco/shared";
 
 import { EntriesStreamResult, NavMap, VolumeStockClient } from "@/types";
 
-type Params = [Iterable<VolumeStock>, { total: number; totalPages: number }, NavMap, ...any[]];
-type ParamsWithAvailableWarehouses = [Iterable<VolumeStock>, { total: number; totalPages: number }, NavMap, StockMap];
+export type TableData = {
+	/** Rows to display for a page */
+	rows: Iterable<VolumeStock>;
+	/** Stats used for pagination */
+	stats: {
+		total: number;
+		totalPages: number;
+	};
+};
+
+type Params = [TableData, NavMap, ...any[]];
+type ParamsWithAvailableWarehouses = [TableData, NavMap, StockMap];
 
 export function combineTransactionsWarehouses(opts: {
 	includeAvailableWarehouses: true;
@@ -13,13 +23,13 @@ export function combineTransactionsWarehouses(opts: {
 export function combineTransactionsWarehouses(opts?: { includeAvailableWarehouses: boolean }): (params: Params) => EntriesStreamResult;
 export function combineTransactionsWarehouses(opts?: { includeAvailableWarehouses: boolean }) {
 	return opts?.includeAvailableWarehouses
-		? ([entries, stats, warehouses, stock]: ParamsWithAvailableWarehouses): EntriesStreamResult => ({
+		? ([{ rows, stats }, warehouses, stock]: ParamsWithAvailableWarehouses): EntriesStreamResult => ({
 				...stats,
-				rows: [...addAvailableWarehouses(addWarehouseNames(entries, warehouses), warehouses, stock)]
+				rows: [...addAvailableWarehouses(addWarehouseNames(rows, warehouses), warehouses, stock)]
 		  })
-		: ([entries, stats, warehouses]: Params): EntriesStreamResult => ({
+		: ([{ rows, stats }, warehouses]: Params): EntriesStreamResult => ({
 				...stats,
-				rows: [...addWarehouseNames(entries, warehouses)]
+				rows: [...addWarehouseNames(rows, warehouses)]
 		  });
 }
 


### PR DESCRIPTION
* Constrain 'stock' stream transmissions to committed notes only
* Merge display 'rows' and 'stats' into s single stream - both derived from update to note's document stream but were causing two transmissions per update

When working on book fetching logic (the request, upsert and all), @fadwamahmoud found that when we reduce the updates (bulk them into `bulkDocs` instead of using `Promise.all`), we still get 3 transmissions per update (resulting in 3 requests for 3rd party data, if needed).

I've pin-pointed it to the way `entries` stream was implemented:
- the stream combined four streams: `entries` (display rows), `stats` (table stats for pagination, derived from note's total entries), warehouse names (doesn't affect this), stock (used to provide available warehouses)
- on each update to note's transactions, `entries`, `stats` and `stock` streams triggered the final transmission once 

Finally, I've applied the fixes mentioned in the commit message (and the top of this description) so that we get one transmission per update