### PR TITLE
Feature/receipts interface 1

### DIFF
--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -24,7 +24,9 @@
 		type RemoveTransactionsDetail,
 		ProgressBar,
 		BookDetailForm,
-		Slideover
+		Slideover,
+		Button,
+		ButtonColor
 	} from "@librocco/ui";
 	import type { BookEntry, NavMap } from "@librocco/db";
 
@@ -203,14 +205,17 @@
 							</div>
 						{/if}
 					</div>
-					<SelectMenu
-						id="note-state-picker"
-						class="w-[138px]"
-						options={noteStates}
-						bind:value={$state}
-						disabled={[...Object.values(NoteTempState), NoteState.Committed].includes($state)}
-						align="right"
-					/>
+					<div class="flex gap-x-4">
+						<Button color={ButtonColor.White} on:click={() => note?.printReceipt()}>Print receipt</Button>
+						<SelectMenu
+							id="note-state-picker"
+							class="w-[138px]"
+							options={noteStates}
+							bind:value={$state}
+							disabled={[...Object.values(NoteTempState), NoteState.Committed].includes($state)}
+							align="right"
+						/>
+					</div>
 				</div>
 				<ScanInput onAdd={handleAddTransaction} />
 			{/if}

--- a/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
@@ -25,7 +25,9 @@
 		ProgressBar,
 		Slideover,
 		BookDetailForm,
-		ScanInput
+		ScanInput,
+		Button,
+		ButtonColor
 	} from "@librocco/ui";
 
 	import type { BookEntry } from "@librocco/db";
@@ -182,14 +184,17 @@
 						</div>
 					{/if}
 				</div>
-				<SelectMenu
-					id="note-state-picker"
-					class="w-[138px]"
-					options={noteStates}
-					bind:value={$state}
-					disabled={[...Object.values(NoteTempState), NoteState.Committed].includes($state)}
-					align="right"
-				/>
+				<div class="flex gap-x-4">
+					<Button color={ButtonColor.White} on:click={() => note?.printReceipt}>Print receipt</Button>
+					<SelectMenu
+						id="note-state-picker"
+						class="w-[138px]"
+						options={noteStates}
+						bind:value={$state}
+						disabled={[...Object.values(NoteTempState), NoteState.Committed].includes($state)}
+						align="right"
+					/>
+				</div>
 			</div>
 			<ScanInput onAdd={handleAddTransaction} />
 		{/if}

--- a/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/outbound/[...id]/+page.svelte
@@ -185,7 +185,7 @@
 					{/if}
 				</div>
 				<div class="flex gap-x-4">
-					<Button color={ButtonColor.White} on:click={() => note?.printReceipt}>Print receipt</Button>
+					<Button color={ButtonColor.White} on:click={() => note?.printReceipt()}>Print receipt</Button>
 					<SelectMenu
 						id="note-state-picker"
 						class="w-[138px]"

--- a/pkg/db/src/enums.ts
+++ b/pkg/db/src/enums.ts
@@ -1,4 +1,12 @@
 export enum DocType {
 	Note = "note",
-	Warehouse = "warehouse"
+	Warehouse = "warehouse",
+	PrintJob = "print_job"
+}
+
+export enum PrintJobStatus {
+	Pending = "PENDING",
+	Processing = "PROCESSING",
+	Done = "DONE",
+	Error = "ERROR"
 }

--- a/pkg/db/src/implementations/version-1.2/db.ts
+++ b/pkg/db/src/implementations/version-1.2/db.ts
@@ -14,7 +14,8 @@ import {
 	NavEntry,
 	NavMap,
 	PluginInterfaceLookup,
-	LibroccoPlugin
+	LibroccoPlugin,
+	RecepitsInterface
 } from "@/types";
 import { DatabaseInterface, WarehouseInterface, WarehouseListRow, OutNoteListRow, InNoteListRow } from "./types";
 
@@ -27,6 +28,7 @@ import { newDbReplicator } from "./replicator";
 import { newView } from "./view";
 import { newStock } from "./stock";
 import { newPluginsInterface, PluginsInterface } from "./plugins";
+import { newReceiptsInterface } from "./receipts";
 
 import { scanDesignDocuments } from "@/utils/pouchdb";
 import { versionId } from "./utils";
@@ -165,6 +167,11 @@ class Database implements DatabaseInterface {
 
 	plugin<T extends keyof PluginInterfaceLookup>(type: T): LibroccoPlugin<PluginInterfaceLookup[T]> {
 		return this.#plugins.get(type);
+	}
+
+	receipts(): RecepitsInterface {
+		// TODO: We should add additional method to connect the printer
+		return newReceiptsInterface(this, "printer-1");
 	}
 	// #endregion instances
 

--- a/pkg/db/src/implementations/version-1.2/note.ts
+++ b/pkg/db/src/implementations/version-1.2/note.ts
@@ -371,6 +371,10 @@ class Note implements NoteInterface {
 		return addWarehouseNames(entries, warehouses);
 	}
 
+	printReceipt(): Promise<string> {
+		return this.#db.receipts().print(this);
+	}
+
 	/**
 	 * Creates streams for the note data. The streams are hot in a way that they will
 	 * emit the value from external source (i.e. db), but cold in a way that the db subscription is

--- a/pkg/db/src/implementations/version-1.2/receipts.ts
+++ b/pkg/db/src/implementations/version-1.2/receipts.ts
@@ -1,10 +1,12 @@
+import { wrapIter } from "@librocco/shared";
+
 import type { PrintJob, ReceiptData, RecepitsInterface } from "@/types";
 import type { DatabaseInterface, NoteData } from "./types";
 
 import { DocType, PrintJobStatus } from "@/enums";
 
-import { uniqueTimestamp, versionId } from "@/utils/misc";
-import { wrapIter } from "@librocco/shared";
+import { uniqueTimestamp } from "@/utils/misc";
+import { versionId } from "./utils";
 
 class Receipts implements RecepitsInterface {
 	#db: DatabaseInterface;

--- a/pkg/db/src/implementations/version-1.2/receipts.ts
+++ b/pkg/db/src/implementations/version-1.2/receipts.ts
@@ -1,0 +1,51 @@
+import type { PrintJob, ReceiptData, RecepitsInterface } from "@/types";
+import type { DatabaseInterface, NoteData } from "./types";
+
+import { DocType, PrintJobStatus } from "@/enums";
+
+import { uniqueTimestamp, versionId } from "@/utils/misc";
+import { wrapIter } from "@librocco/shared";
+
+class Receipts implements RecepitsInterface {
+	#db: DatabaseInterface;
+
+	// TODO: Printer id could be optional - if no ID, the printer is not registered, noop
+	#id: string;
+
+	constructor(db: DatabaseInterface, printerId: string) {
+		this.#db = db;
+		this.#id = printerId;
+	}
+
+	private constructPrintJob(receipt: ReceiptData): PrintJob {
+		const _id = versionId(`print_queue/${this.#id}/${uniqueTimestamp()}`);
+		return {
+			...receipt,
+			_id,
+			docType: DocType.PrintJob,
+			// TODO: Find a way to get the correct printer id
+			printer_id: this.#id,
+			status: PrintJobStatus.Pending
+		};
+	}
+
+	async print({ entries }: NoteData): Promise<string> {
+		const timestamp = Number(new Date());
+		const books = await this.#db.books().get(entries.map(({ isbn }) => isbn));
+		const items = wrapIter(entries)
+			.zip(books)
+			.map(([{ isbn, quantity }, { title, price } = { title: "", price: 0 }]) => ({ isbn, title, quantity, price }))
+			.array();
+		// In order to produce a correct total (two decimal places), we're doing the arithmetic over interegs and converting the result
+		// back to a float with two decimal places. This is to avoid floating point errors.
+		const total = items.reduce((acc, { quantity, price }) => acc + quantity * Math.floor(price * 100), 0) / 100;
+
+		const printJob = this.constructPrintJob({ items, total, timestamp });
+
+		await this.#db._pouch.put(printJob);
+
+		return printJob._id;
+	}
+}
+
+export const newReceiptsInterface = (db: DatabaseInterface, printerId: string): RecepitsInterface => new Receipts(db, printerId);

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -5,7 +5,7 @@ import PouchDB from "pouchdb";
 
 import { NoteState, debug } from "@librocco/shared";
 
-import type { DocType } from "./enums";
+import type { DocType, PrintJobStatus } from "./enums";
 
 import { NEW_WAREHOUSE } from "./constants";
 
@@ -154,6 +154,7 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 	 * An imperative query (single response) of note's transactions (as opposed to the entries stream - an observable stream).
 	 */
 	getEntries: EntriesQuery;
+	printReceipt(): Promise<string>;
 }
 
 /**
@@ -244,6 +245,32 @@ export interface Replicator {
 	sync: (url: string | PouchDB.Database, options: PouchDB.Replication.ReplicateOptions) => PouchDB.Replication.Sync<{}>;
 }
 // #endregion replication
+
+// #region receipts
+export interface ReceiptItem {
+	isbn: string;
+	title: string;
+	quantity: number;
+	price: number;
+}
+
+export interface ReceiptData {
+	items: ReceiptItem[];
+	total: number;
+	timestamp: number;
+}
+
+export interface PrintJob extends CouchDocument<ReceiptData> {
+	printer_id: string;
+	// TODO: Update the states when developing the functionality further
+	status: PrintJobStatus;
+	error?: string;
+}
+
+export interface RecepitsInterface {
+	print(note: NoteData): Promise<string>;
+}
+// #endregion receipts
 
 // #region db
 export type NavEntry<A = {}> = {
@@ -339,6 +366,7 @@ export interface DatabaseInterface<W extends WarehouseInterface = WarehouseInter
 	 */
 	books: () => BooksInterface;
 	plugin<T extends keyof PluginInterfaceLookup>(type: T): LibroccoPlugin<PluginInterfaceLookup[T]>;
+	receipts: () => RecepitsInterface;
 }
 
 /**


### PR DESCRIPTION
In sync with [this PR in the receipt printer server repo](https://github.com/librocco/receipt-printer/pull/2)

Creates a receipts interface, used to print the receipt for the note (and will probably be used to retrieve the receipts in the future). Current implementation (first pass):
- constructs a print job for receipt printing
- stores the print job in the db, under `v1/print_queue/<printer_id>/<job_id>` - the `printer_id` is hardcoded to `"printer-1"` and jobs are timestamped unique strings (so they appear in order, id generated using `timestampId` - the same helper we use for note/warehouse ids)
- adds a `"Print receipt"` button to note view to explicitly initialise the print job (in the future this will probably be removed, receipts printed automatically, or explicitly from receipts UI, TBD)