### PR TITLE
Enhancement/full text search stream

### DIFF
--- a/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/stock/[...id]/+page.svelte
@@ -68,8 +68,8 @@
 	// This is more/less inexpensive (around 2sec), considering it runs in the background.
 	let index: SearchIndex | undefined;
 	db?.books()
-		.getSearchIndex()
-		.then((ix) => (index = ix));
+		.streamSearchIndex()
+		.subscribe((ix) => (index = ix));
 
 	const warehouseCtx = new debug.DebugCtxWithTimer(`[WAREHOUSE_ENTRIES::${warehouse?._id}]`, { debug: false, logTimes: false });
 	$: warehouesStores = createWarehouseStores(warehouseCtx, warehouse, index);

--- a/pkg/db/src/implementations/version-1.2/db.ts
+++ b/pkg/db/src/implementations/version-1.2/db.ts
@@ -47,6 +47,8 @@ class Database implements DatabaseInterface {
 
 	#plugins: PluginsInterface;
 
+	#booksInterface?: BooksInterface;
+
 	constructor(db: PouchDB.Database) {
 		this._pouch = db;
 
@@ -165,7 +167,8 @@ class Database implements DatabaseInterface {
 	}
 
 	books(): BooksInterface {
-		return newBooksInterface(this);
+		// We're caching the books interface to avoid creating multiple instances
+		return this.#booksInterface ?? (this.#booksInterface = newBooksInterface(this));
 	}
 
 	warehouse(id?: string | typeof NEW_WAREHOUSE): WarehouseInterface {

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -416,7 +416,7 @@ export interface BooksInterface {
 	/**
 	 * Get search index for full-text search, built from relevant books
 	 */
-	getSearchIndex: () => Promise<SearchIndex>;
+	streamSearchIndex: () => Observable<SearchIndex>;
 }
 
 export interface NewDatabase {


### PR DESCRIPTION
- replaces `getSearchIndex` with `streamSearchIndex` (in `db.books` interface) so that we always have up-to-date search data
- caches the search index stream in books interface (and multicasts it):
  - no search index is cached (nor created) until necessary
  - when requested, if the stream exists, it is returned from `books.streamSearchIndex()`
  - if the no stream (nor search index) exists when requested, the stream is created and cached
  - the stream is multicast - however many consumers subscribe to the stream, the value is shared
  - when the subscriber count for search index stream reaches 0 it is reset (removed from memory until needed again)
- caches the books interface so that:
  - at most one books interface is created per db instance
  - doing `db.books()` for the first time creates the books interface and stores it in the db internally
  - each subsequent `db.books()` returns the already created books instance

All of these "caching" enhancements were made to preserve memory - prevent duplication of search index by reusing/multicasting