### PR TITLE
Feature/UI rehaul 2

### DIFF
--- a/apps/web-client/src/lib/components/EntityList/EntityList.svelte
+++ b/apps/web-client/src/lib/components/EntityList/EntityList.svelte
@@ -1,1 +1,1 @@
-<ul class="w-full select-none divide-y divide-gray-300 px-6"><slot /></ul>
+<ul class="h-full w-full select-none divide-y divide-gray-300 overflow-y-auto px-6"><slot /></ul>

--- a/apps/web-client/src/lib/components/EntityList/EntityListRow.svelte
+++ b/apps/web-client/src/lib/components/EntityList/EntityListRow.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
 	import { Library } from "lucide-svelte";
-	import { createEventDispatcher } from "svelte";
 
 	export let displayName: string;
 	export let totalBooks = 0;
-
-	const dispatch = createEventDispatcher<{ delete: void }>();
-	const handleDelete = () => {
-		dispatch("delete");
-	};
 </script>
 
 <li class="flex items-center justify-between py-4 px-6">

--- a/apps/web-client/src/lib/components/Page.svelte
+++ b/apps/web-client/src/lib/components/Page.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
 	import { BookCopy, Library, Package, Search, Settings } from "lucide-svelte";
 
-	import { base } from "$app/paths";
 	import { page } from "$app/stores";
 
-	const basepath = `${base}/proto`;
+	import { PROTO_PATHS } from "$lib/paths";
 
 	export const links = [
 		{
 			label: "Stock",
-			href: `${basepath}/stock/`,
+			href: PROTO_PATHS.STOCK,
 			icon: Search
 		},
 		{
 			label: "Manage inventory",
-			href: `${basepath}/inventory/`,
+			href: PROTO_PATHS.INVENTORY,
 			icon: Library
 		},
 		{
 			label: "Outbound",
-			href: `${basepath}/outbound/`,
+			href: PROTO_PATHS.OUTBOUND,
 			icon: Package
 		},
 		{
 			label: "Settings",
-			href: `${basepath}/settings/`,
+			href: PROTO_PATHS.SETTINGS,
 			icon: Settings
 		}
 	];

--- a/apps/web-client/src/lib/components/Page.svelte
+++ b/apps/web-client/src/lib/components/Page.svelte
@@ -58,7 +58,7 @@
 	<!-- Sidenav end -->
 
 	<!-- Main content -->
-	<div class="relative flex h-full w-full flex-col overflow-hidden bg-gray-50">
+	<div class="relative flex h-screen w-full flex-col overflow-hidden bg-gray-50">
 		<!-- Top bar input -->
 		<div
 			class="relative flex h-[66px] w-full items-center bg-white px-4 shadow-[0px_1px_2px_0px_rgba(0,0,0,0.6),0px_1px_3px_0px_rgba(0,0,0,0.1)] focus-within:ring-2 focus-within:ring-inset"
@@ -77,10 +77,8 @@
 		</header>
 		<!-- Heading section end -->
 
-		<slot />
-
 		<!-- Main section -->
-		<main class="relative h-full w-full border-t bg-white">
+		<main class="relative h-full w-full overflow-hidden border-t bg-white">
 			<slot name="main" />
 		</main>
 		<!-- Main section end -->

--- a/apps/web-client/src/lib/paths.ts
+++ b/apps/web-client/src/lib/paths.ts
@@ -1,0 +1,12 @@
+import { base } from "$app/paths";
+
+const basepath = `${base}/proto`;
+
+export const PROTO_PATHS = {
+	STOCK: `${basepath}/stock`,
+	WAREHOUSES: `${basepath}/inventory/warehouses`,
+	INVENTORY: `${basepath}/inventory`,
+	INBOUND: `${basepath}/inventory/inbound`,
+	OUTBOUND: `${basepath}/outbound`,
+	SETTINGS: `${basepath}/settings`
+};

--- a/apps/web-client/src/lib/utils/time.ts
+++ b/apps/web-client/src/lib/utils/time.ts
@@ -1,5 +1,6 @@
-export const generateUpdatedAtString = (updatedAt: Date) =>
-	updatedAt.toLocaleDateString("en", {
+export const generateUpdatedAtString = (updatedAt?: Date | string) =>
+	updatedAt &&
+	new Date(updatedAt).toLocaleDateString("en", {
 		year: "numeric",
 		month: "short",
 		day: "numeric",

--- a/apps/web-client/src/routes/proto/inventory/+layout.svelte
+++ b/apps/web-client/src/routes/proto/inventory/+layout.svelte
@@ -67,21 +67,23 @@
 		</svelte:fragment>
 
 		<svelte:fragment slot="main">
-			<div class="flex gap-x-8 border-b border-gray-300 px-6">
-				{#each tabs as { label, icon, href }}
-					{@const active = $page.url.pathname.startsWith(href)}
-					<svelte:element
-						this={active ? "div" : "a"}
-						class="flex gap-x-2 py-4 {active ? 'select-none border-b border-indigo-600 text-indigo-500' : 'text-gray-500'}"
-						{href}
-					>
-						<svelte:component this={icon} size={20} />
-						<span class="text-sm font-medium leading-5">{label}</span>
-					</svelte:element>
-				{/each}
-			</div>
+			<div class="flex h-full w-full flex-col overflow-hidden">
+				<div class="flex flex-shrink-0 gap-x-8 border-b border-gray-300 px-6">
+					{#each tabs as { label, icon, href }}
+						{@const active = $page.url.pathname.startsWith(href)}
+						<svelte:element
+							this={active ? "div" : "a"}
+							class="flex gap-x-2 py-4 {active ? 'select-none border-b border-indigo-600 text-indigo-500' : 'text-gray-500'}"
+							{href}
+						>
+							<svelte:component this={icon} size={20} />
+							<span class="text-sm font-medium leading-5">{label}</span>
+						</svelte:element>
+					{/each}
+				</div>
 
-			<slot />
+				<slot />
+			</div>
 		</svelte:fragment>
 	</Page>
 {/if}

--- a/apps/web-client/src/routes/proto/inventory/+layout.svelte
+++ b/apps/web-client/src/routes/proto/inventory/+layout.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
 	import { Building, Plus, Search, CopyPlus } from "lucide-svelte";
 
-	import { base } from "$app/paths";
 	import { page } from "$app/stores";
 
 	import { Page } from "$lib/components";
+
+	import { PROTO_PATHS } from "$lib/paths";
 
 	const tabs = [
 		{
 			icon: Building,
 			label: "Warehouses",
-			href: `${base}/proto/inventory/warehouses`
+			href: PROTO_PATHS.WAREHOUSES
 		},
 		{
 			icon: CopyPlus,
 			label: "Inbound",
-			href: `${base}/proto/inventory/inbound`
+			href: PROTO_PATHS.INBOUND
 		}
 	];
 </script>

--- a/apps/web-client/src/routes/proto/inventory/+layout.svelte
+++ b/apps/web-client/src/routes/proto/inventory/+layout.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { Building, Plus, Search, CopyPlus } from "lucide-svelte";
 
+	import { NEW_WAREHOUSE } from "@librocco/db";
+
 	import { page } from "$app/stores";
+	import { goto } from "$app/navigation";
 
 	import { Page } from "$lib/components";
+
+	import { getDB } from "$lib/db";
+
+	import { toastSuccess, warehouseToastMessages } from "$lib/toasts";
 
 	import { PROTO_PATHS } from "$lib/paths";
 
@@ -19,6 +26,21 @@
 			href: PROTO_PATHS.INBOUND
 		}
 	];
+
+	// Db will be undefined only on server side. If in browser,
+	// it will be defined immediately, but `db.init` is ran asynchronously.
+	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
+	const db = getDB();
+
+	/**
+	 * Handle create warehouse is an `on:click` handler used to create a new warehouse
+	 * _(and navigate to the newly created warehouse page)_.
+	 */
+	const handleCreateWarehouse = async () => {
+		const warehouse = await db.warehouse(NEW_WAREHOUSE).create();
+		toastSuccess(warehouseToastMessages("Warehouse").warehouseCreated);
+		await goto(`${PROTO_PATHS.WAREHOUSES}/${warehouse._id}`);
+	};
 </script>
 
 <!-- The existence of id param indicates we're either on 'warehouses/[...id]' or 'inbound/[...id]' page (both of which render the layout on their own) -->
@@ -34,7 +56,10 @@
 		<svelte:fragment slot="heading">
 			<div class="flex w-full items-center justify-between">
 				<h1 class="text-2xl font-bold leading-7 text-gray-900">Inventory</h1>
-				<button class="flex items-center gap-2 rounded-md border border-gray-300 bg-white py-[9px] pl-[15px] pr-[17px]">
+				<button
+					on:click={handleCreateWarehouse}
+					class="flex items-center gap-2 rounded-md border border-gray-300 bg-white py-[9px] pl-[15px] pr-[17px]"
+				>
 					<span><Plus size={20} /></span>
 					<span class="text-sm font-medium leading-5 text-gray-700">New warehouse</span>
 				</button>

--- a/apps/web-client/src/routes/proto/inventory/+layout.ts
+++ b/apps/web-client/src/routes/proto/inventory/+layout.ts
@@ -1,0 +1,52 @@
+import { redirect } from "@sveltejs/kit";
+
+import type { NoteInterface, WarehouseInterface } from "@librocco/db";
+
+import type { LayoutLoad } from "./$types";
+
+import { PROTO_PATHS } from "$lib/paths";
+
+export const load: LayoutLoad = async ({
+	route,
+	params,
+	parent
+}): Promise<Partial<{ note: NoteInterface; warehouse: WarehouseInterface }>> => {
+	const [, , , location] = route.id.split("/"); // e.g [ '', 'proto',  'inventory', 'warehouses', '[...id]' ]
+
+	// If no location provided, use '/warehouses' as default
+	if (!location) {
+		throw redirect(307, PROTO_PATHS.WAREHOUSES);
+	}
+
+	// await db init in ../layout.ts
+	const { db } = await parent();
+
+	// This should re-run on change to path, as far as I understand: https://kit.svelte.dev/docs/load#invalidation
+	const docId = params?.id;
+
+	// If db is not returned (we're not in the browser environment, no need for additional loading).
+	// Additionally, if no docId is provided, we're on the list page, so no need for additional loading.
+	if (!db || !docId) {
+		return {};
+	}
+
+	// If we're on the warehouse stock page, we're only interested in the warehouse
+	if (location === "warehouses" && docId) {
+		const warehouseId = docId?.trim().replace(/^\//, "").replace(/\/$/, "");
+
+		const warehouse = await db.warehouse(warehouseId).get();
+
+		if (!warehouse) {
+			throw redirect(307, PROTO_PATHS.WAREHOUSES);
+		}
+
+		return { warehouse };
+	}
+
+	// In note view ('inbound/outbount') we need both the note and the warehouse (and db.findNote returns exactly that)
+	const findNoteRes = await db.findNote(docId);
+	if (!findNoteRes) {
+		throw redirect(307, PROTO_PATHS.OUTBOUND);
+	}
+	return findNoteRes;
+};

--- a/apps/web-client/src/routes/proto/inventory/+page.ts
+++ b/apps/web-client/src/routes/proto/inventory/+page.ts
@@ -1,9 +1,9 @@
 import { base } from "$app/paths";
+import { PROTO_PATHS } from "$lib/paths";
 import { redirect, type Load } from "@sveltejs/kit";
 
 export const load: Load = async ({ url }) => {
-	console.log("Bump");
 	if ([`${base}/proto/inventory`, `${base}/proto/inventory/`].includes(url.pathname)) {
-		throw redirect(307, `${base}/proto/inventory/warehouses`);
+		throw redirect(307, PROTO_PATHS.WAREHOUSES);
 	}
 };

--- a/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
@@ -3,11 +3,11 @@
 
 	import { Badge, BadgeColor } from "@librocco/ui/Badge";
 
-	import { base } from "$app/paths";
-
 	import { EntityList, EntityListRow, PlaceholderBox } from "$lib/components";
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
+
+	import { PROTO_PATHS } from "$lib/paths";
 
 	interface Note {
 		id: string;
@@ -54,9 +54,7 @@
 		description="Get started by adding a new note with the appropriate warehouse"
 		class="center-absolute"
 	>
-		<a
-			href="{base}/proto/inventory/warehouses"
-			class="mx-auto inline-block items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
+		<a href={PROTO_PATHS.WAREHOUSES} class="mx-auto inline-block items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
 			><span class="text-green-50">Back to warehouses</span></a
 		>
 	</PlaceholderBox>
@@ -67,7 +65,7 @@
 			{@const noteName = note.displayName || note.id}
 			{@const displayName = `${warehouseName} / ${noteName}`}
 			{@const updatedAt = note.updatedAt || undefined}
-			{@const href = `${base}/proto/inventory/inbound/${note.id}`}
+			{@const href = `${PROTO_PATHS.INBOUND}/${note.id}`}
 
 			<EntityListRow {...note} {displayName}>
 				<svelte:fragment slot="actions">

--- a/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
@@ -1,54 +1,54 @@
 <script lang="ts">
 	import { Trash } from "lucide-svelte";
+	import { map } from "rxjs";
 
 	import { Badge, BadgeColor } from "@librocco/ui/Badge";
+	import { wrapIter } from "@librocco/shared";
 
 	import { EntityList, EntityListRow, PlaceholderBox } from "$lib/components";
 
+	import { getDB } from "$lib/db";
+
+	import { noteToastMessages, toastSuccess } from "$lib/toasts";
+
 	import { generateUpdatedAtString } from "$lib/utils/time";
+	import { readableFromStream } from "$lib/utils/streams";
 
 	import { PROTO_PATHS } from "$lib/paths";
 
-	interface Note {
-		id: string;
-		displayName?: string;
-		updatedAt?: Date;
-		totalBooks?: number;
-		warehouse: {
-			id: string;
-			displayName?: string;
-		};
-	}
-	const notes: Note[] = [
-		{
-			id: "note-1",
-			displayName: "New Note",
-			updatedAt: new Date(),
-			totalBooks: 0,
-			warehouse: {
-				id: "warehouse-1",
-				displayName: "Warehouse 1"
-			}
-		},
-		{
-			id: "note-2",
-			displayName: "New Note (2)",
-			warehouse: {
-				id: "warehouse-2"
-			}
-		},
-		{
-			id: "note-3",
-			updatedAt: new Date(),
-			totalBooks: 3,
-			warehouse: {
-				id: "warehouse-3"
-			}
-		}
-	];
+	// Db will be undefined only on server side. If in browser,
+	// it will be defined immediately, but `db.init` is ran asynchronously.
+	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
+	const db = getDB();
+
+	const inNoteListCtx = { name: "[IN_NOTE_LIST]", debug: false };
+	const inNoteList = readableFromStream(
+		inNoteListCtx,
+		db
+			?.stream()
+			.inNoteList(inNoteListCtx)
+			.pipe(
+				map((m) =>
+					wrapIter(m)
+						.filter(([warehouseId]) => !warehouseId.includes("0-all"))
+						.flatMap(([warehouseId, { displayName, notes }]) => wrapIter(notes).map((note) => [displayName || warehouseId, note] as const))
+						.array()
+				)
+			),
+		[]
+	);
+
+	// TODO: This way of deleting notes is rather slow - update the db interface to allow for more direct approach
+	const handleDeleteNote = (noteId: string) => async () => {
+		const { note } = await db?.findNote(noteId);
+		await note?.delete({});
+		toastSuccess(noteToastMessages("Note").noteDeleted);
+	};
 </script>
 
-{#if !notes.length}
+<!-- The Page layout is rendered by the parent (inventory) '+layout.svelte', with inbound and warehouse page rendering only their respective entity lists -->
+
+{#if !$inNoteList.length}
 	<PlaceholderBox
 		title="No open notes"
 		description="Get started by adding a new note with the appropriate warehouse"
@@ -60,17 +60,17 @@
 	</PlaceholderBox>
 {:else}
 	<EntityList>
-		{#each notes as note}
-			{@const warehouseName = note.warehouse.displayName || note.warehouse.id}
-			{@const noteName = note.displayName || note.id}
+		{#each $inNoteList as [warehouseName, [noteId, note]]}
+			{@const noteName = note.displayName || noteId}
 			{@const displayName = `${warehouseName} / ${noteName}`}
-			{@const updatedAt = note.updatedAt || undefined}
-			{@const href = `${PROTO_PATHS.INBOUND}/${note.id}`}
+			{@const updatedAt = generateUpdatedAtString(note.updatedAt)}
+			{@const totalBooks = note.totalBooks}
+			{@const href = `${PROTO_PATHS.INBOUND}/${noteId}`}
 
-			<EntityListRow {...note} {displayName}>
+			<EntityListRow {totalBooks} {displayName}>
 				<svelte:fragment slot="actions">
-					{#if updatedAt}
-						<Badge label="Last updated: {generateUpdatedAtString(updatedAt)}" color={BadgeColor.Success} />
+					{#if note.updatedAt}
+						<Badge label="Last updated: {updatedAt}" color={BadgeColor.Success} />
 					{:else}
 						<!-- Inside 'flex justify-between' container, we want the following box (buttons) to be pushed to the end, even if there's no badge -->
 						<div />
@@ -80,7 +80,7 @@
 						<a {href} class="rounded-md bg-pink-50 px-[17px] py-[9px]"
 							><span class="text-sm font-medium leading-5 text-pink-700">Edit</span></a
 						>
-						<button class="rounded-md border border-gray-300 bg-white py-[9px] pl-[17px] pr-[15px]"
+						<button on:click={handleDeleteNote(noteId)} class="rounded-md border border-gray-300 bg-white py-[9px] pl-[17px] pr-[15px]"
 							><Trash class="border-gray-500" size={20} /></button
 						>
 					</div>

--- a/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { Edit, BarChart, Trash2 } from "lucide-svelte";
 
-	import { Dropdown, EntityListRow, PlaceholderBox } from "$lib/components";
+	import { Dropdown, EntityList, EntityListRow, PlaceholderBox } from "$lib/components";
 
-	import EntityList from "$lib/components/EntityList/EntityList.svelte";
-	import { base } from "$app/paths";
+	import { PROTO_PATHS } from "$lib/paths";
 
 	interface Warehouse {
 		id: string;
@@ -54,7 +53,7 @@
 								><Edit class="text-gray-400" size={20} /><span class="text-gray-700">Edit</span></button
 							>
 							<a
-								href="{base}/proto/inventory/warehouses/{warehouse.id}"
+								href="{PROTO_PATHS.WAREHOUSES}/{warehouse.id}"
 								class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 								><BarChart class="text-gray-400" size={20} /><span class="text-gray-700">View Stock</span></a
 							>

--- a/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
@@ -1,34 +1,54 @@
 <script lang="ts">
+	import { map } from "rxjs";
 	import { Edit, BarChart, Trash2 } from "lucide-svelte";
+
+	import { filter } from "@librocco/shared";
+
+	import { goto } from "$app/navigation";
 
 	import { Dropdown, EntityList, EntityListRow, PlaceholderBox } from "$lib/components";
 
+	import { getDB } from "$lib/db";
+
+	import { noteToastMessages, toastSuccess } from "$lib/toasts";
+
+	import { readableFromStream } from "$lib/utils/streams";
+
 	import { PROTO_PATHS } from "$lib/paths";
 
-	interface Warehouse {
-		id: string;
-		displayName?: string;
-		totalBooks?: number;
-	}
+	const db = getDB();
 
-	const warehouses: Warehouse[] = [
-		{
-			id: "warehouse-1",
-			displayName: "New Warehouse",
-			totalBooks: 0
-		},
-		{
-			id: "warehouse-2",
-			displayName: "New Warehouse (2)"
-		},
-		{
-			id: "warehouse-3",
-			totalBooks: 3
-		}
-	];
+	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
+	const warehouseList = readableFromStream(
+		warehouseListCtx,
+		db
+			?.stream()
+			.warehouseMap(warehouseListCtx)
+			/** @TODO we could probably wrap the Map to be ArrayLike (by having 'm.length' = 'm.size') */
+			.pipe(map((m) => [...filter(m, ([warehouseId]) => !warehouseId.includes("0-all"))])),
+		[]
+	);
+
+	const handleDeleteWarehouse = (warehouseId: string) => async () => {
+		await db?.warehouse(warehouseId).delete();
+		// TODO: There should be a 'Warehouse deleted' toast
+		// toastSuccess(warehouseToastMessages("Warehouse").);
+	};
+
+	/**
+	 * Handle create note is an `on:click` handler used to create a new inbound note in the provided warehouse.
+	 * _(and navigate to the newly created note page)_.
+	 */
+	const handleCreateNote = (warehouseId: string) => async () => {
+		const note = await db?.warehouse(warehouseId).note().create();
+		toastSuccess(noteToastMessages("Note").inNoteCreated);
+		await goto(`${PROTO_PATHS.INBOUND}/${note._id}`);
+	};
 </script>
 
-{#if !warehouses.length}
+<!-- The Page layout is rendered by the parent (inventory) '+layout.svelte', with inbound and warehouse page rendering only their respective entity lists -->
+
+{#if !$warehouseList.length}
 	<PlaceholderBox title="New warehouse" description="Get started by adding a new warehouse" class="center-absolute">
 		<button class="mx-auto flex items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
 			><span class="text-green-50">New warehouse</span></button
@@ -36,15 +56,18 @@
 	</PlaceholderBox>
 {:else}
 	<EntityList>
-		{#each warehouses as warehouse}
-			{@const displayName = warehouse.displayName || warehouse.id}
-			<EntityListRow {...warehouse} {displayName}>
+		{#each $warehouseList as [warehouseId, warehouse]}
+			{@const displayName = warehouse.displayName || warehouseId}
+			{@const totalBooks = warehouse.totalBooks}
+			{@const href = `${PROTO_PATHS.WAREHOUSES}/${warehouseId}`}
+
+			<EntityListRow {displayName} {totalBooks}>
 				<svelte:fragment slot="actions">
 					<!-- Inside 'flex justify-between' container, we want the following box (buttons) to be pushed to the end -->
 					<div />
 
 					<div class="flex items-center justify-end gap-3">
-						<button class="rounded-md bg-teal-500 px-[17px] py-[9px]"
+						<button on:click={handleCreateNote(warehouseId)} class="rounded-md bg-teal-500 px-[17px] py-[9px]"
 							><span class="text-sm font-medium leading-5 text-green-50">New note</span></button
 						>
 
@@ -52,12 +75,12 @@
 							<button class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 								><Edit class="text-gray-400" size={20} /><span class="text-gray-700">Edit</span></button
 							>
-							<a
-								href="{PROTO_PATHS.WAREHOUSES}/{warehouse.id}"
-								class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+							<a {href} class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 								><BarChart class="text-gray-400" size={20} /><span class="text-gray-700">View Stock</span></a
 							>
-							<button class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+							<button
+								on:click={handleDeleteWarehouse(warehouseId)}
+								class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
 								><Trash2 class="text-white" size={20} /><span class="text-white">Delete</span></button
 							>
 						</Dropdown>

--- a/apps/web-client/src/routes/proto/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/[...id]/+page.svelte
@@ -5,14 +5,109 @@
 
 	import { page } from "$app/stores";
 
-	$: id = $page.params.id.split("/").filter(Boolean).pop();
-	$: displayName = id
-		.replace(/-/g, " ")
-		.split(" ")
-		.map((word) => word[0].toUpperCase() + word.slice(1))
-		.join(" ");
+	import { map } from "rxjs";
+	import { goto } from "$app/navigation";
+	import { base } from "$app/paths";
 
-	$: breadcrumbs = createBreadcrumbs("warehouse", { id, displayName });
+	import { writable } from "svelte/store";
+
+	import {
+		InventoryPage,
+		Pagination,
+		InventoryTable,
+		createTable,
+		Header,
+		TextEditable,
+		SidebarItem,
+		SideBarNav,
+		NewEntitySideNavButton,
+		ProgressBar,
+		Slideover,
+		BookDetailForm,
+		DiscountInput
+	} from "@librocco/ui";
+	import type { BookEntry, SearchIndex } from "@librocco/db";
+	import { debug } from "@librocco/shared";
+
+	import type { PageData } from "./$types";
+
+	import { getDB } from "$lib/db";
+	import { noteToastMessages, toastSuccess, warehouseToastMessages } from "$lib/toasts";
+
+	import { createWarehouseStores } from "$lib/stores/inventory";
+	import { newBookFormStore } from "$lib/stores/book_form";
+
+	import { readableFromStream } from "$lib/utils/streams";
+	import { comparePaths } from "$lib/utils/misc";
+
+	import { links } from "$lib/data";
+	import { PROTO_PATHS } from "$lib/paths";
+
+	export let data: PageData;
+
+	// Db will be undefined only on server side. If in browser,
+	// it will be defined immediately, but `db.init` is ran asynchronously.
+	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
+	const db = getDB();
+
+	const publisherListCtx = { name: "[PUBLISHER_LIST::INBOUND]", debug: false };
+	const publisherList = readableFromStream(publisherListCtx, db?.books().streamPublishers(publisherListCtx), []);
+
+	// We display loading state before navigation (in case of creating new note/warehouse)
+	// and reset the loading state when the data changes (should always be truthy -> thus, loading false).
+	$: loading = !data;
+
+	$: warehouse = data.warehouse;
+
+	// Create a search index for books in the db. Each time the books change, we recreate the index.
+	// This is more/less inexpensive (around 2sec), considering it runs in the background.
+	let index: SearchIndex | undefined;
+	db?.books()
+		.streamSearchIndex()
+		.subscribe((ix) => (index = ix));
+
+	const warehouseCtx = new debug.DebugCtxWithTimer(`[WAREHOUSE_ENTRIES::${warehouse?._id}]`, { debug: false, logTimes: false });
+	$: warehouesStores = createWarehouseStores(warehouseCtx, warehouse, index);
+
+	$: displayName = warehouesStores.displayName;
+	$: entries = warehouesStores.entries;
+
+	$: toasts = warehouseToastMessages(warehouse?.displayName);
+
+	// #region warehouse-actions
+	/**
+	 * Handle create warehouse is an `no:click` handler used to create the new warehouse
+	 * _(and navigate to the newly created warehouse page)_.
+	 */
+	const handleCreateNote = async () => {
+		loading = true;
+		const note = await warehouse?.note().create();
+		await goto(`${PROTO_PATHS.INBOUND}/${note._id}`);
+		toastSuccess(noteToastMessages("Note").inNoteCreated);
+	};
+	// #endregion warehouse-actions
+
+	// #region table
+	const tableOptions = writable({
+		data: $entries
+	});
+
+	const table = createTable(tableOptions);
+
+	$: tableOptions.set({ data: $entries });
+	// #endregion table
+
+	// #region book-form
+	$: bookForm = newBookFormStore();
+
+	const handleBookFormSubmit = async (book: BookEntry) => {
+		await db.books().upsert([book]);
+		toastSuccess(toasts.bookDataUpdated(book.isbn));
+		bookForm.close();
+	};
+	// #endregion book-form
+
+	$: breadcrumbs = createBreadcrumbs("warehouse", { id: warehouse?._id, displayName: warehouse?.displayName });
 </script>
 
 <Page>
@@ -23,14 +118,22 @@
 
 	<svelte:fragment slot="heading">
 		<Breadcrumbs class="mb-3" links={breadcrumbs} />
-		<h1 class="mb-2 text-2xl font-bold leading-7 text-gray-900">{displayName}</h1>
+		<h1 class="mb-2 text-2xl font-bold leading-7 text-gray-900">{$displayName}</h1>
 	</svelte:fragment>
 
 	<svelte:fragment slot="main">
-		<PlaceholderBox title="Add new inbound note" description="Get started by adding a new note" class="center-absolute">
-			<button class="mx-auto flex items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
-				><span class="text-green-50">New note</span></button
-			>
-		</PlaceholderBox>
+		{#if loading}
+			<ProgressBar class="absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2" />
+		{:else if !$entries.length}
+			<PlaceholderBox title="Add new inbound note" description="Get started by adding a new note" class="center-absolute">
+				<button on:click={handleCreateNote} class="mx-auto flex items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
+					><span class="text-green-50">New note</span></button
+				>
+			</PlaceholderBox>
+		{:else}
+			<div class="h-full overflow-y-scroll">
+				<InventoryTable {table} onEdit={bookForm.open} />
+			</div>
+		{/if}
 	</svelte:fragment>
 </Page>

--- a/apps/web-client/src/routes/proto/outbound/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { Plus, Search, Trash } from "lucide-svelte";
 
-	import { base } from "$app/paths";
-
 	import { EntityListRow, Page, PlaceholderBox } from "$lib/components";
 
 	import EntityList from "$lib/components/EntityList/EntityList.svelte";
 	import { Badge, BadgeColor } from "@librocco/ui/Badge";
 	import { generateUpdatedAtString } from "$lib/utils/time";
+
+	import { PROTO_PATHS } from "$lib/paths";
 
 	interface Note {
 		id: string;
@@ -62,7 +62,7 @@
 				{#each notes as note}
 					{@const displayName = note.displayName || note.id}
 					{@const updatedAt = note.updatedAt || undefined}
-					{@const href = `${base}/proto/outbound/${note.id}`}
+					{@const href = `${PROTO_PATHS.OUTBOUND}/${note.id}`}
 
 					<EntityListRow {...note} {displayName}>
 						<svelte:fragment slot="actions">

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
@@ -1,48 +1,204 @@
 <script lang="ts">
 	import { Printer, QrCode, Trash2 } from "lucide-svelte";
-
-	import { Badge, BadgeColor } from "@librocco/ui";
-
-	import { Page, PlaceholderBox, Breadcrumbs, createBreadcrumbs, Dropdown } from "$lib/components";
-
-	import { generateUpdatedAtString } from "$lib/utils/time";
+	import { map } from "rxjs";
+	import { writable } from "svelte/store";
 
 	import { page } from "$app/stores";
+	import { goto } from "$app/navigation";
 
-	$: id = $page.params.id.split("/").filter(Boolean).pop();
-	$: displayName = id
-		.replace(/-/g, " ")
-		.split(" ")
-		.map((word) => word[0].toUpperCase() + word.slice(1))
-		.join(" ");
+	import { NoteState, NoteTempState } from "@librocco/shared";
+	import {
+		InventoryPage,
+		Pagination,
+		Badge,
+		BadgeColor,
+		OutNoteTable,
+		createTable,
+		Header,
+		SelectMenu,
+		TextEditable,
+		SideBarNav,
+		SidebarItem,
+		NewEntitySideNavButton,
+		type TransactionUpdateDetail,
+		type RemoveTransactionsDetail,
+		ProgressBar,
+		Slideover,
+		BookDetailForm,
+		ScanInput,
+		Button,
+		ButtonColor
+	} from "@librocco/ui";
 
-	$: breadcrumbs = createBreadcrumbs("outbound", { id, displayName });
+	import type { BookEntry } from "@librocco/db";
+
+	import { noteStates } from "$lib/enums/inventory";
+
+	import type { PageData } from "./$types";
+
+	import { getDB } from "$lib/db";
+	import { toastSuccess, noteToastMessages } from "$lib/toasts";
+
+	import { createNoteStores } from "$lib/stores/inventory";
+	import { newBookFormStore } from "$lib/stores/book_form";
+
+	import { generateUpdatedAtString } from "$lib/utils/time";
+	import { readableFromStream } from "$lib/utils/streams";
+	import { comparePaths } from "$lib/utils/misc";
+
+	import { links } from "$lib/data";
+	import { Breadcrumbs, Dropdown, Page, PlaceholderBox, createBreadcrumbs } from "$lib/components";
+	import { PROTO_PATHS } from "$lib/paths";
+
+	export let data: PageData;
+
+	// Db will be undefined only on server side. If in browser,
+	// it will be defined immediately, but `db.init` is ran asynchronously.
+	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
+	const db = getDB();
+
+	const outNoteListCtx = { name: "[OUT_NOTE_LIST]", debug: false };
+	const outNoteList = readableFromStream(
+		outNoteListCtx,
+		db
+			?.stream()
+			.outNoteList(outNoteListCtx)
+			/** @TODO we could probably wrap the Map to be ArrayLike (by having 'm.length' = 'm.size') */
+			.pipe(map((m) => [...m])),
+		[]
+	);
+
+	const publisherListCtx = { name: "[PUBLISHER_LIST::INBOUND]", debug: false };
+	const publisherList = readableFromStream(publisherListCtx, db?.books().streamPublishers(publisherListCtx), []);
+
+	// We display loading state before navigation (in case of creating new note/warehouse)
+	// and reset the loading state when the data changes (should always be truthy -> thus, loading false).
+	$: loading = !data;
+
+	$: note = data.note;
+
+	$: noteStores = createNoteStores(note);
+
+	$: displayName = noteStores.displayName;
+	$: state = noteStores.state;
+	$: updatedAt = noteStores.updatedAt;
+	$: currentPage = noteStores.currentPage;
+	$: paginationData = noteStores.paginationData;
+	$: entries = noteStores.entries;
+
+	$: toasts = noteToastMessages(note?.displayName);
+
+	// #region note-actions
+	//
+	// When the note is committed or deleted, automatically redirect to 'outbound' page.
+	$: {
+		if ($state === NoteState.Committed || $state === NoteState.Deleted) {
+			goto(PROTO_PATHS.OUTBOUND);
+
+			const message = $state === NoteState.Committed ? toasts.outNoteCommited : toasts.noteDeleted;
+
+			toastSuccess(message);
+		}
+	}
+
+	const handleCommitSelf = async () => {
+		await note.commit({});
+		toastSuccess(noteToastMessages("Note").inNoteCommited);
+	};
+
+	const handleDeleteSelf = async () => {
+		await note.delete({});
+		toastSuccess(noteToastMessages("Note").noteDeleted);
+	};
+	// #region note-actions
+
+	// #region table
+	const tableOptions = writable({
+		data: $entries
+	});
+
+	const table = createTable(tableOptions);
+
+	$: tableOptions.set({ data: $entries });
+	// #endregion table
+
+	// #region transaction-actions
+	const handleAddTransaction = async (isbn: string) => {
+		await note.addVolumes({ isbn, quantity: 1 });
+		toastSuccess(toasts.volumeAdded(isbn));
+		bookForm.close();
+	};
+
+	const handleTransactionUpdate = async ({ detail }: CustomEvent<TransactionUpdateDetail>) => {
+		const { matchTxn, updateTxn } = detail;
+
+		await note.updateTransaction(matchTxn, { quantity: matchTxn.quantity, warehouseId: "", ...updateTxn });
+
+		// TODO: This doesn't seem to work / get called?
+		toastSuccess(toasts.volumeUpdated(matchTxn.isbn));
+	};
+
+	const handleRemoveTransactions = async (e: CustomEvent<RemoveTransactionsDetail>) => {
+		await note.removeTransactions(...e.detail);
+		toastSuccess(toasts.volumeRemoved(e.detail.length));
+	};
+	// #region transaction-actions
+
+	// #region book-form
+	$: bookForm = newBookFormStore();
+
+	const handleBookFormSubmit = async (book: BookEntry) => {
+		await db.books().upsert([book]);
+		toastSuccess(toasts.bookDataUpdated(book.isbn));
+		bookForm.close();
+	};
+	// #endregion book-form
+
+	$: breadcrumbs = note?._id ? createBreadcrumbs("outbound", { id: note._id, displayName: $displayName }) : [];
+
+	// #region temp
+	const handlePrint = () => {};
+
+	// TEMP: This is a quick and dirty implmeentation: replace with scan action
+	let scanValue = "";
+	const handleScanConfirm = (e: KeyboardEvent) => {
+		if (e.key === "Enter") {
+			handleAddTransaction(scanValue);
+			scanValue = "";
+		}
+	};
+	// #endregion temp
 </script>
 
 <Page>
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		<QrCode {...iconProps} />
-		<input placeholder="Scan to add books" {...inputProps} />
+		<input on:keydown={handleScanConfirm} bind:value={scanValue} placeholder="Scan to add books" {...inputProps} />
 	</svelte:fragment>
 
 	<svelte:fragment slot="heading">
 		<Breadcrumbs class="mb-3" links={breadcrumbs} />
 		<div class="flex w-full items-center justify-between">
 			<div>
-				<h1 class="mb-2 text-2xl font-bold leading-7 text-gray-900">{displayName}</h1>
-				<Badge label="Last updated: {generateUpdatedAtString(new Date())}" color={BadgeColor.Success} />
+				<h1 class="mb-2 text-2xl font-bold leading-7 text-gray-900">{$displayName}</h1>
+
+				<div class="h-5">
+					{#if $updatedAt}
+						<Badge label="Last updated: {generateUpdatedAtString($updatedAt)}" color={BadgeColor.Success} />
+					{/if}
+				</div>
 			</div>
 
 			<div class="flex items-center gap-x-3">
-				<button class="rounded-md bg-teal-500 px-[17px] py-[9px] text-green-50 active:bg-teal-400">
+				<button on:click={handleCommitSelf} class="rounded-md bg-teal-500 px-[17px] py-[9px] text-green-50 active:bg-teal-400">
 					<span class="text-sm font-medium leading-5 text-green-50">Commit</span>
 				</button>
 
 				<Dropdown>
-					<button class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+					<button on:click={handlePrint} class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 						><Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span></button
 					>
-					<button class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+					<button on:click={handleDeleteSelf} class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
 						><Trash2 class="text-white" size={20} /><span class="text-white">Delete</span></button
 					>
 				</Dropdown>
@@ -51,8 +207,19 @@
 	</svelte:fragment>
 
 	<svelte:fragment slot="main">
-		<PlaceholderBox title="Scan to add books" description="Plugin your barcode scanner and pull the trigger" class="center-absolute">
-			<QrCode slot="icon" let:iconProps {...iconProps} />
-		</PlaceholderBox>
+		{#if loading}
+			<ProgressBar class="absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2" />
+		{:else if !$entries.length}
+			<PlaceholderBox title="Scan to add books" description="Plugin your barcode scanner and pull the trigger" class="center-absolute">
+				<QrCode slot="icon" let:iconProps {...iconProps} />
+			</PlaceholderBox>
+		{:else}
+			<OutNoteTable
+				{table}
+				onEdit={bookForm.open}
+				on:transactionupdate={handleTransactionUpdate}
+				on:removetransactions={handleRemoveTransactions}
+			/>
+		{/if}
 	</svelte:fragment>
 </Page>

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.ts
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.ts
@@ -1,0 +1,26 @@
+import { redirect } from "@sveltejs/kit";
+
+import type { NoteLookupResult, NoteInterface, WarehouseInterface } from "@librocco/db";
+
+import type { PageLoad } from "./$types";
+
+import { PROTO_PATHS } from "$lib/paths";
+
+export const load: PageLoad = async ({ params, parent }): Promise<Partial<NoteLookupResult<NoteInterface, WarehouseInterface>>> => {
+	// await db init in ../layout.ts
+	const { db } = await parent();
+
+	// This should re-run on change to path, as far as I understand: https://kit.svelte.dev/docs/load#invalidation
+	const docId = params?.id;
+
+	// If db is not returned (we're not in the browser environment, no need for additional loading)
+	if (!db) {
+		return {};
+	}
+
+	const findNoteRes = await db.findNote(docId);
+	if (!findNoteRes) {
+		throw redirect(307, PROTO_PATHS.OUTBOUND);
+	}
+	return findNoteRes;
+};

--- a/pkg/db/src/implementations/version-1.2/designDocuments.ts
+++ b/pkg/db/src/implementations/version-1.2/designDocuments.ts
@@ -78,7 +78,12 @@ export const listDeisgnDocument: DesignDocument = {
 
 				const note = doc as NoteData;
 
-				emit(doc._id, { displayName: doc.displayName, committed: note.committed });
+				emit(doc._id, {
+					displayName: doc.displayName,
+					committed: note.committed,
+					updatedAt: note.updatedAt,
+					totalBooks: note.entries.length
+				});
 			}.toString()
 		},
 		inbound: {
@@ -93,7 +98,13 @@ export const listDeisgnDocument: DesignDocument = {
 					return;
 				}
 
-				emit(doc._id, { type: doc.docType, displayName: doc.displayName, committed: note.committed });
+				emit(doc._id, {
+					type: doc.docType,
+					displayName: doc.displayName,
+					committed: note.committed,
+					updatedAt: note.updatedAt,
+					totalBooks: note.entries.length
+				});
 			}.toString()
 		},
 		publishers: {

--- a/pkg/db/src/implementations/version-1.2/types.ts
+++ b/pkg/db/src/implementations/version-1.2/types.ts
@@ -15,7 +15,8 @@ import {
 	MapReduceRes,
 	PluginInterfaceLookup,
 	LibroccoPlugin,
-	WarehouseDataMap
+	WarehouseDataMap,
+	NavEntry
 } from "@/types";
 import { DocType } from "@/enums";
 
@@ -47,9 +48,9 @@ export interface ViewInterface<R extends MapReduceRow, M extends CouchDocument> 
 }
 
 // View response types
-export type WarehouseListRow = MapReduceRow<string, Pick<WarehouseData, "displayName" | "discountPercentage">>;
-export type OutNoteListRow = MapReduceRow<string, { displayName?: string; committed?: boolean }>;
-export type InNoteListRow = MapReduceRow<string, { displayName?: string; committed?: boolean; type: DocType }>;
+export type WarehouseListRow = MapReduceRow<string, NavEntry<Pick<WarehouseData, "discountPercentage">>>;
+export type OutNoteListRow = MapReduceRow<string, NavEntry<{ committed?: boolean }>>;
+export type InNoteListRow = MapReduceRow<string, NavEntry<{ committed?: boolean; type: DocType }>>;
 export type PublishersListRow = MapReduceRow<string, number>;
 
 // Plugins

--- a/pkg/db/src/types.ts
+++ b/pkg/db/src/types.ts
@@ -286,6 +286,8 @@ export interface RecepitsInterface {
 // #region db
 export type NavEntry<A = {}> = {
 	displayName: string;
+	updatedAt?: Date;
+	totalBooks?: number;
 } & A;
 
 /**
@@ -295,7 +297,7 @@ export type NavMap<A = {}> = Map<string, NavEntry<A>>;
 /**
  * A map of warehouses and their respective data
  */
-export type WarehouseDataMap = Map<string, Pick<WarehouseData, "displayName" | "discountPercentage">>;
+export type WarehouseDataMap = NavMap<Pick<WarehouseData, "displayName" | "discountPercentage">>;
 
 /**
  * A map of inbound note entries: { warehouseId => { displayName, notes: NavMap } }


### PR DESCRIPTION
First pass of wiring in the db and functionality for the updated dashboard:

- tackles the page loading, warehouse/note creation/deletion, committing of notes
- uses old table components for stock/note book list displays
- sets up "scanning" (to work as an input-only) field

### TODOs:

- wire in the scanning functionality (use the action form the ui package)
- extract reusable styles (buttons, replace entity list/entity list row with style classes)
- add warehouse discount to the display list
- remove pagination (probably create a copy of entries stream and update - so as to not break the existing functionality just yet)
- calculate total books for warehouse display
- update Dropdown
- add confirmation prompts:
  - delete
  - commit
- search redirect + functionality
- add 'deleteNote' to db interface directly
