### PR TITLE
Fix: web app svelte config to discover proto routes during build:prod

### DIFF
--- a/apps/web-client/src/lib/components/Breadcrumbs/utils.ts
+++ b/apps/web-client/src/lib/components/Breadcrumbs/utils.ts
@@ -1,3 +1,4 @@
+import { PROTO_PATHS } from "$lib/paths";
 import type { Breadcrumb } from "./types";
 
 interface BreadcrumbSegment {
@@ -9,9 +10,6 @@ type WarehouseSegments = [warehouse: BreadcrumbSegment];
 type InboundSegments = [warehouse: BreadcrumbSegment, note: BreadcrumbSegment];
 type OutboundSegments = [note: BreadcrumbSegment];
 
-// TEMP
-const basepath = "/preview/proto";
-
 export function createBreadcrumbs(type: "warehouse", ...segments: WarehouseSegments): Breadcrumb[];
 export function createBreadcrumbs(type: "inbound", ...segments: InboundSegments): Breadcrumb[];
 export function createBreadcrumbs(type: "outbound", ...segments: OutboundSegments): Breadcrumb[];
@@ -20,7 +18,7 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 		case "warehouse": {
 			const [{ id, displayName }] = segments as WarehouseSegments;
 			const label = displayName || id;
-			return [{ label: "Warehouses", href: `${basepath}/inventory/warehouses` }, { label }];
+			return [{ label: "Warehouses", href: PROTO_PATHS.WAREHOUSES }, { label }];
 		}
 
 		case "inbound": {
@@ -28,8 +26,8 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 			const warehouseLabel = warehouse.displayName || warehouse.id;
 			const noteLabel = note.displayName || note.id;
 			return [
-				{ label: "Inbound", href: `${basepath}/inventory/inbound` },
-				{ label: warehouseLabel, href: `${basepath}/inventory/warehouses/${warehouse.id}` },
+				{ label: "Inbound", href: PROTO_PATHS.INBOUND },
+				{ label: warehouseLabel, href: `${PROTO_PATHS.WAREHOUSES}/${warehouse.id}` },
 				{ label: noteLabel }
 			];
 		}
@@ -37,7 +35,7 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 		case "outbound": {
 			const [{ id, displayName }] = segments as OutboundSegments;
 			const label = displayName || id;
-			return [{ label: "Outbound", href: `${basepath}/outbound` }, { label }];
+			return [{ label: "Outbound", href: PROTO_PATHS.OUTBOUND }, { label }];
 		}
 	}
 }

--- a/apps/web-client/src/lib/paths.ts
+++ b/apps/web-client/src/lib/paths.ts
@@ -3,10 +3,10 @@ import { base } from "$app/paths";
 const basepath = `${base}/proto`;
 
 export const PROTO_PATHS = {
-	STOCK: `${basepath}/stock`,
-	WAREHOUSES: `${basepath}/inventory/warehouses`,
-	INVENTORY: `${basepath}/inventory`,
-	INBOUND: `${basepath}/inventory/inbound`,
-	OUTBOUND: `${basepath}/outbound`,
-	SETTINGS: `${basepath}/settings`
+	STOCK: `${basepath}/stock/`,
+	WAREHOUSES: `${basepath}/inventory/warehouses/`,
+	INVENTORY: `${basepath}/inventory/`,
+	INBOUND: `${basepath}/inventory/inbound/`,
+	OUTBOUND: `${basepath}/outbound/`,
+	SETTINGS: `${basepath}/settings/`
 };

--- a/apps/web-client/svelte.config.js
+++ b/apps/web-client/svelte.config.js
@@ -14,6 +14,15 @@ const config = {
 		adapter: adapter(),
 		prerender: {
 			entries: [
+				// TODO: update once rehaul is finished
+				"/proto/inventory/inbound/",
+				"/proto/inventory/inbound/1/",
+				"/proto/inventory/warehouses/",
+				"/proto/inventory/warehouses/1/",
+				"/proto/stock/",
+				"/proto/outbound/",
+				"/proto/outbound/1/",
+				"/proto/settings/",
 				"/",
 				"/inventory",
 				"/inventory/",


### PR DESCRIPTION
Quick update to the web app `svelte.config` so that `build:prod` works. Should help CI jobs pass while we finish up rehaul. This will need to be updated anyway once we finish.

Note: its not perfect. If you want to check out the rebuild while its in progress, you have to go to exactly `http://127.0.0.1:4173/preview/proto/stock/` otherwise there's a chance you'll be bounced back to the old routes.