### PR TITLE
Fix/paths

### DIFF
--- a/apps/web-client/src/lib/components/Breadcrumbs/utils.ts
+++ b/apps/web-client/src/lib/components/Breadcrumbs/utils.ts
@@ -1,5 +1,6 @@
-import { PROTO_PATHS } from "$lib/paths";
 import type { Breadcrumb } from "./types";
+
+import { appPath } from "$lib/paths";
 
 interface BreadcrumbSegment {
 	id: string;
@@ -18,7 +19,7 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 		case "warehouse": {
 			const [{ id, displayName }] = segments as WarehouseSegments;
 			const label = displayName || id;
-			return [{ label: "Warehouses", href: PROTO_PATHS.WAREHOUSES }, { label }];
+			return [{ label: "Warehouses", href: appPath("warehouses") }, { label }];
 		}
 
 		case "inbound": {
@@ -26,8 +27,8 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 			const warehouseLabel = warehouse.displayName || warehouse.id;
 			const noteLabel = note.displayName || note.id;
 			return [
-				{ label: "Inbound", href: PROTO_PATHS.INBOUND },
-				{ label: warehouseLabel, href: `${PROTO_PATHS.WAREHOUSES}/${warehouse.id}` },
+				{ label: "Inbound", href: appPath("inbound") },
+				{ label: warehouseLabel, href: appPath("warehouses", warehouse.id) },
 				{ label: noteLabel }
 			];
 		}
@@ -35,7 +36,7 @@ export function createBreadcrumbs(type: "warehouse" | "inbound" | "outbound", ..
 		case "outbound": {
 			const [{ id, displayName }] = segments as OutboundSegments;
 			const label = displayName || id;
-			return [{ label: "Outbound", href: PROTO_PATHS.OUTBOUND }, { label }];
+			return [{ label: "Outbound", href: appPath("outbound") }, { label }];
 		}
 	}
 }

--- a/apps/web-client/src/lib/components/Page.svelte
+++ b/apps/web-client/src/lib/components/Page.svelte
@@ -5,27 +5,27 @@
 
 	import { TooltipWrapper } from "$lib/components";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	export const links = [
 		{
 			label: "Stock",
-			href: PROTO_PATHS.STOCK,
+			href: appPath("stock"),
 			icon: Search
 		},
 		{
 			label: "Manage inventory",
-			href: PROTO_PATHS.INVENTORY,
+			href: appPath("inventory"),
 			icon: Library
 		},
 		{
 			label: "Outbound",
-			href: PROTO_PATHS.OUTBOUND,
+			href: appPath("outbound"),
 			icon: Package
 		},
 		{
 			label: "Settings",
-			href: PROTO_PATHS.SETTINGS,
+			href: appPath("settings"),
 			icon: Settings
 		}
 	];

--- a/apps/web-client/src/lib/paths.ts
+++ b/apps/web-client/src/lib/paths.ts
@@ -2,11 +2,25 @@ import { base } from "$app/paths";
 
 const basepath = `${base}/proto`;
 
-export const PROTO_PATHS = {
-	STOCK: `${basepath}/stock/`,
-	WAREHOUSES: `${basepath}/inventory/warehouses/`,
-	INVENTORY: `${basepath}/inventory/`,
-	INBOUND: `${basepath}/inventory/inbound/`,
-	OUTBOUND: `${basepath}/outbound/`,
-	SETTINGS: `${basepath}/settings/`
+const PROTO_PATHS = {
+	stock: `${basepath}/stock/`,
+	warehouses: `${basepath}/inventory/warehouses/`,
+	inventory: `${basepath}/inventory/`,
+	inbound: `${basepath}/inventory/inbound/`,
+	outbound: `${basepath}/outbound/`,
+	settings: `${basepath}/settings/`
 };
+
+/**
+ * We're using this util to construct app paths. This is preferable to using constants as it
+ * allows us to construct paths with dynamic segments, while performing some additional sanitization:
+ * - requires the first segment to be the location key (e.g. "stock", "inventory", etc.)
+ * - joins all of the segments with "/"
+ * - ensures that the path ends with "/" (adds a trailing slash if neecessary)
+ * - ensutres that there are no double slashes in the path
+ * (often a result of joining constants + dynamis segments, e.g. `${base}/stock/${id}` -> base might or might not end with a slash)
+ * @param location - the location key (e.g. "stock", "inventory", etc.)
+ * @param segments - the dynamic segments of the path
+ */
+export const appPath = (location: keyof typeof PROTO_PATHS, ...segments: string[]) =>
+	[PROTO_PATHS[location], ...segments].join("/").concat("/").replaceAll("//", "/");

--- a/apps/web-client/src/routes/proto/inventory/+layout.svelte
+++ b/apps/web-client/src/routes/proto/inventory/+layout.svelte
@@ -12,18 +12,18 @@
 
 	import { toastSuccess, warehouseToastMessages } from "$lib/toasts";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	const tabs = [
 		{
 			icon: Building,
 			label: "Warehouses",
-			href: PROTO_PATHS.WAREHOUSES
+			href: appPath("warehouses")
 		},
 		{
 			icon: CopyPlus,
 			label: "Inbound",
-			href: PROTO_PATHS.INBOUND
+			href: appPath("inbound")
 		}
 	];
 
@@ -39,7 +39,7 @@
 	const handleCreateWarehouse = async () => {
 		const warehouse = await db.warehouse(NEW_WAREHOUSE).create();
 		toastSuccess(warehouseToastMessages("Warehouse").warehouseCreated);
-		await goto(`${PROTO_PATHS.WAREHOUSES}/${warehouse._id}`);
+		await goto(appPath("warehouses", warehouse._id));
 	};
 </script>
 

--- a/apps/web-client/src/routes/proto/inventory/+layout.ts
+++ b/apps/web-client/src/routes/proto/inventory/+layout.ts
@@ -4,7 +4,7 @@ import type { NoteInterface, WarehouseInterface } from "@librocco/db";
 
 import type { LayoutLoad } from "./$types";
 
-import { PROTO_PATHS } from "$lib/paths";
+import { appPath } from "$lib/paths";
 
 export const load: LayoutLoad = async ({
 	route,
@@ -15,7 +15,7 @@ export const load: LayoutLoad = async ({
 
 	// If no location provided, use '/warehouses' as default
 	if (!location) {
-		throw redirect(307, PROTO_PATHS.WAREHOUSES);
+		throw redirect(307, appPath("warehouses"));
 	}
 
 	// await db init in ../layout.ts
@@ -37,7 +37,7 @@ export const load: LayoutLoad = async ({
 		const warehouse = await db.warehouse(warehouseId).get();
 
 		if (!warehouse) {
-			throw redirect(307, PROTO_PATHS.WAREHOUSES);
+			throw redirect(307, appPath("warehouses"));
 		}
 
 		return { warehouse };
@@ -46,7 +46,7 @@ export const load: LayoutLoad = async ({
 	// In note view ('inbound/outbount') we need both the note and the warehouse (and db.findNote returns exactly that)
 	const findNoteRes = await db.findNote(docId);
 	if (!findNoteRes) {
-		throw redirect(307, PROTO_PATHS.INBOUND);
+		throw redirect(307, appPath("inbound"));
 	}
 	return findNoteRes;
 };

--- a/apps/web-client/src/routes/proto/inventory/+layout.ts
+++ b/apps/web-client/src/routes/proto/inventory/+layout.ts
@@ -46,7 +46,7 @@ export const load: LayoutLoad = async ({
 	// In note view ('inbound/outbount') we need both the note and the warehouse (and db.findNote returns exactly that)
 	const findNoteRes = await db.findNote(docId);
 	if (!findNoteRes) {
-		throw redirect(307, PROTO_PATHS.OUTBOUND);
+		throw redirect(307, PROTO_PATHS.INBOUND);
 	}
 	return findNoteRes;
 };

--- a/apps/web-client/src/routes/proto/inventory/+page.ts
+++ b/apps/web-client/src/routes/proto/inventory/+page.ts
@@ -1,9 +1,11 @@
-import { base } from "$app/paths";
-import { PROTO_PATHS } from "$lib/paths";
 import { redirect, type Load } from "@sveltejs/kit";
+
+import { base } from "$app/paths";
+
+import { appPath } from "$lib/paths";
 
 export const load: Load = async ({ url }) => {
 	if ([`${base}/proto/inventory`, `${base}/proto/inventory/`].includes(url.pathname)) {
-		throw redirect(307, PROTO_PATHS.WAREHOUSES);
+		throw redirect(307, appPath("warehouses"));
 	}
 };

--- a/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/+page.svelte
@@ -14,7 +14,7 @@
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	// Db will be undefined only on server side. If in browser,
 	// it will be defined immediately, but `db.init` is ran asynchronously.
@@ -54,7 +54,7 @@
 		description="Get started by adding a new note with the appropriate warehouse"
 		class="center-absolute"
 	>
-		<a href={PROTO_PATHS.WAREHOUSES} class="mx-auto inline-block items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
+		<a href={appPath("warehouses")} class="mx-auto inline-block items-center gap-2 rounded-md bg-teal-500  py-[9px] pl-[15px] pr-[17px]"
 			><span class="text-green-50">Back to warehouses</span></a
 		>
 	</PlaceholderBox>
@@ -65,7 +65,7 @@
 			{@const displayName = `${warehouseName} / ${noteName}`}
 			{@const updatedAt = generateUpdatedAtString(note.updatedAt)}
 			{@const totalBooks = note.totalBooks}
-			{@const href = `${PROTO_PATHS.INBOUND}/${noteId}`}
+			{@const href = appPath("inbound", noteId)}
 
 			<EntityListRow {totalBooks} {displayName}>
 				<svelte:fragment slot="actions">

--- a/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
@@ -49,7 +49,7 @@
 
 	import { links } from "$lib/data";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	export let data: PageData;
 
@@ -84,7 +84,7 @@
 	// When the note is committed or deleted, automatically redirect to 'inbound' page.
 	$: {
 		if ($state === NoteState.Committed || $state === NoteState.Deleted) {
-			goto(PROTO_PATHS.INBOUND);
+			goto(appPath("inbound"));
 			const message = $state === NoteState.Committed ? toasts.outNoteCommited : toasts.noteDeleted;
 			toastSuccess(message);
 		}

--- a/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
@@ -191,7 +191,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrint}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -199,7 +199,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handleDeleteSelf}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 					>
 						<Trash2 class="text-white" size={20} /><span class="text-white">Delete</span>
 					</div>

--- a/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
@@ -14,7 +14,7 @@
 
 	import { readableFromStream } from "$lib/utils/streams";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	const db = getDB();
 
@@ -42,7 +42,7 @@
 	const handleCreateNote = (warehouseId: string) => async () => {
 		const note = await db?.warehouse(warehouseId).note().create();
 		toastSuccess(noteToastMessages("Note").inNoteCreated);
-		await goto(`${PROTO_PATHS.INBOUND}/${note._id}`);
+		await goto(appPath("inbound", note._id));
 	};
 </script>
 
@@ -59,7 +59,7 @@
 		{#each $warehouseList as [warehouseId, warehouse]}
 			{@const displayName = warehouse.displayName || warehouseId}
 			{@const totalBooks = warehouse.totalBooks}
-			{@const href = `${PROTO_PATHS.WAREHOUSES}/${warehouseId}`}
+			{@const href = appPath("warehouses", warehouseId)}
 
 			<EntityListRow {displayName} {totalBooks}>
 				<svelte:fragment slot="actions">

--- a/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/+page.svelte
@@ -76,7 +76,7 @@
 								{...item}
 								use:item.action
 								on:m-click={() => console.log("TODO: open warehouse edit modal")}
-								class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+								class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 							>
 								<Edit class="text-gray-400" size={20} />
 								<span class="text-gray-700">Edit</span>
@@ -88,7 +88,7 @@
 								{href}
 								{...item}
 								use:item.action
-								class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+								class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 							>
 								<Table2 class="text-gray-400" size={20} />
 								<span class="text-gray-700">View Stock</span>
@@ -98,7 +98,7 @@
 								{...item}
 								use:item.action
 								on:m-click={handleDeleteWarehouse(warehouseId)}
-								class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+								class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 							>
 								<Trash2 class="text-white" size={20} />
 								<span class="text-white">Delete</span>

--- a/apps/web-client/src/routes/proto/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/warehouses/[...id]/+page.svelte
@@ -41,7 +41,7 @@
 	import { comparePaths } from "$lib/utils/misc";
 
 	import { links } from "$lib/data";
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	export let data: PageData;
 
@@ -82,7 +82,7 @@
 	const handleCreateNote = async () => {
 		loading = true;
 		const note = await warehouse?.note().create();
-		await goto(`${PROTO_PATHS.INBOUND}/${note._id}`);
+		await goto(appPath("inbound", note._id));
 		toastSuccess(noteToastMessages("Note").inNoteCreated);
 	};
 	// #endregion warehouse-actions

--- a/apps/web-client/src/routes/proto/outbound/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/+page.svelte
@@ -15,7 +15,7 @@
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
 
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	const db = getDB();
 
@@ -44,7 +44,7 @@
 	const handleCreateNote = async () => {
 		const note = await db.warehouse().note().create();
 		toastSuccess(noteToastMessages("Note").outNoteCreated);
-		await goto(`${PROTO_PATHS.OUTBOUND}/${note._id}`);
+		await goto(appPath("outbound", note._id));
 	};
 </script>
 
@@ -80,7 +80,7 @@
 					{@const displayName = note.displayName || noteId}
 					{@const updatedAt = generateUpdatedAtString(note.updatedAt)}
 					{@const totalBooks = note.totalBooks}
-					{@const href = `${PROTO_PATHS.OUTBOUND}/${noteId}`}
+					{@const href = appPath("outbound", noteId)}
 
 					<EntityListRow {displayName} {totalBooks}>
 						<svelte:fragment slot="actions">

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
@@ -199,7 +199,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrint}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -207,7 +207,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handleDeleteSelf}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 					>
 						<Trash2 class="text-white" size={20} /><span class="text-white">Delete</span>
 					</div>

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
@@ -48,7 +48,7 @@
 
 	import { links } from "$lib/data";
 	import { Breadcrumbs, DropdownWrapper, Page, PlaceholderBox, createBreadcrumbs } from "$lib/components";
-	import { PROTO_PATHS } from "$lib/paths";
+	import { appPath } from "$lib/paths";
 
 	export let data: PageData;
 
@@ -93,7 +93,7 @@
 	// When the note is committed or deleted, automatically redirect to 'outbound' page.
 	$: {
 		if ($state === NoteState.Committed || $state === NoteState.Deleted) {
-			goto(PROTO_PATHS.OUTBOUND);
+			goto(appPath("outbound"));
 
 			const message = $state === NoteState.Committed ? toasts.outNoteCommited : toasts.noteDeleted;
 

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.ts
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.ts
@@ -4,7 +4,7 @@ import type { NoteLookupResult, NoteInterface, WarehouseInterface } from "@libro
 
 import type { PageLoad } from "./$types";
 
-import { PROTO_PATHS } from "$lib/paths";
+import { appPath } from "$lib/paths";
 
 export const load: PageLoad = async ({ params, parent }): Promise<Partial<NoteLookupResult<NoteInterface, WarehouseInterface>>> => {
 	// await db init in ../layout.ts
@@ -20,7 +20,7 @@ export const load: PageLoad = async ({ params, parent }): Promise<Partial<NoteLo
 
 	const findNoteRes = await db.findNote(docId);
 	if (!findNoteRes) {
-		throw redirect(307, PROTO_PATHS.OUTBOUND);
+		throw redirect(307, appPath("outbound"));
 	}
 	return findNoteRes;
 };


### PR DESCRIPTION
A quick fix: Replaces `PROTO_PATHS` lookup with `appPath` function, e.g.:

Instead of `PROTO_PATHS.WAREHOUSES + "/" + warehouse._id` -> `appPath("warehouses", warehouse._id)`

Additionally, the `appPath` takes care of appending the trailing slash as well as removing possible double slashes