### PR TITLE
Wire in the scanning functionality on inbound/outbound note views:

### DIFF
--- a/apps/web-client/src/lib/actions/scan.ts
+++ b/apps/web-client/src/lib/actions/scan.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { writable } from "svelte/store";
+
+export const MAXIMUM_SCANNER_KEY_GAP = 50;
+
+interface ScanState {
+	buffer: string;
+	timeout: NodeJS.Timeout;
+	target: HTMLInputElement | null;
+}
+
+const initialState: ScanState = {
+	buffer: "",
+	timeout: null,
+	target: null
+};
+
+export const scan = (node?: HTMLInputElement, onSubmit?: (value: string) => void) => {
+	const store = (() => {
+		const store = writable<ScanState>(initialState);
+
+		// Reset resets the store to initial state.
+		// Optionally, we can pass in a 'sideEffect' function that will be ran with the state (before reset) as an argument.
+		const reset = (sideEffect: (state: ScanState) => void = () => {}) => store.update((state) => (sideEffect(state), initialState));
+
+		// Cancel is ran when timeout runs out - interpreted as input being human input, rather than a scan.
+		// When ran, it will 'flush' the buffer to the element the event was directed towards.
+		const cancel = () => reset(({ buffer, target }) => flush(target, buffer));
+
+		return Object.assign(store, { reset, cancel });
+	})();
+
+	const handleSubmit = onSubmit
+		? (e: KeyboardEvent) => {
+				if (e.key !== "Enter") return;
+				e.preventDefault();
+				onSubmit(node.value);
+		  }
+		: () => {};
+
+	const handleKeydown = (e: KeyboardEvent) => {
+		// We're only interested in number inputs (as isbn)
+		if (!/[0-9]/.test(e.key)) return;
+
+		// Capture the event
+		e.preventDefault();
+
+		store.update((state) => {
+			if (state.timeout) {
+				clearTimeout(state.timeout);
+			}
+
+			const buffer = state.buffer + e.key;
+			const timeout = setTimeout(store.cancel, MAXIMUM_SCANNER_KEY_GAP);
+
+			// If we receive 3 or more consecutive inputs with
+			// frequency of using a scanner, we can safely assume the input is comming from a scanner
+			if (buffer.length >= 3) {
+				// Reset the value of scan input field
+				// as we're flushing a full buffer each time
+				node.value = "";
+				// Flush the full buffer to the scan input field
+				flush(node, buffer);
+
+				return {
+					// There's not target for flush on cancellation as we're in the scan mode
+					// and all of the input keys get flushed to scan input element automatically
+					target: null,
+					buffer,
+					timeout
+				};
+			}
+
+			return {
+				// If the event target is an input element,
+				// store its reference to flush the input to it if cancelled (i.e. not a scan input).
+				target: e.target instanceof HTMLInputElement ? e.target : null,
+				buffer,
+				timeout
+			};
+		});
+	};
+
+	window.addEventListener("keydown", handleKeydown);
+	window.addEventListener("keydown", handleSubmit);
+
+	return {
+		destroy() {
+			window.removeEventListener("keydown", handleKeydown);
+			window.removeEventListener("keydown", handleSubmit);
+		}
+	};
+};
+
+// Flush takes in a target element and the buffer value, appends the value to target element's,
+// internal value, triggering an input event and focusing the target.
+//
+// If no target is passed in, noop.
+const flush = (target: HTMLInputElement | undefined, value: string) => {
+	if (!target) return;
+	// Append the buffer value to the target
+	target.value += value;
+	// Dispatch the input event (to trigger any listeners)
+	target.dispatchEvent(new Event("input"));
+	// Focus the target
+	target.focus();
+};

--- a/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/inventory/inbound/[...id]/+page.svelte
@@ -43,6 +43,8 @@
 	import { createNoteStores } from "$lib/stores/inventory";
 	import { newBookFormStore } from "$lib/stores/book_form";
 
+	import { scan } from "$lib/actions/scan";
+
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
 	import { comparePaths } from "$lib/utils/misc";
@@ -151,21 +153,13 @@
 	// #region temp
 	const handlePrint = () => {};
 
-	// TEMP: This is a quick and dirty implmeentation: replace with scan action
-	let scanValue = "";
-	const handleScanConfirm = (e: KeyboardEvent) => {
-		if (e.key === "Enter") {
-			handleAddTransaction(scanValue);
-			scanValue = "";
-		}
-	};
 	// #endregion temp
 </script>
 
 <Page>
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		<QrCode {...iconProps} />
-		<input on:keydown={handleScanConfirm} bind:value={scanValue} placeholder="Scan to add books" {...inputProps} />
+		<input use:scan={handleAddTransaction} placeholder="Scan to add books" {...inputProps} />
 	</svelte:fragment>
 
 	<svelte:fragment slot="heading">

--- a/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/proto/outbound/[...id]/+page.svelte
@@ -42,6 +42,8 @@
 	import { createNoteStores } from "$lib/stores/inventory";
 	import { newBookFormStore } from "$lib/stores/book_form";
 
+	import { scan } from "$lib/actions/scan";
+
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
 	import { comparePaths } from "$lib/utils/misc";
@@ -158,22 +160,13 @@
 
 	// #region temp
 	const handlePrint = () => {};
-
-	// TEMP: This is a quick and dirty implmeentation: replace with scan action
-	let scanValue = "";
-	const handleScanConfirm = (e: KeyboardEvent) => {
-		if (e.key === "Enter") {
-			handleAddTransaction(scanValue);
-			scanValue = "";
-		}
-	};
 	// #endregion temp
 </script>
 
 <Page>
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		<QrCode {...iconProps} />
-		<input on:keydown={handleScanConfirm} bind:value={scanValue} placeholder="Scan to add books" {...inputProps} />
+		<input use:scan={handleAddTransaction} placeholder="Scan to add books" {...inputProps} />
 	</svelte:fragment>
 
 	<svelte:fragment slot="heading">


### PR DESCRIPTION
* Copy + update the scan action from 'ScanInput' component (update to allow 'Enter' submit)
* Use the action on "naked" input elements in new inbound/outbound views (without wrapping into form for easy and consistent styling)

Closes T-283