### PR TITLE
Reinstate the e2e tests in CI

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -18,29 +18,28 @@ jobs:
 
   db-test: #@ test_job("DB Tests", "pkg/db")
 
-  #! TODO: e2e need to be updated first to reflect UI-rehaul
-  #! e2e-test:
-  #!   timeout-minutes: 60
-  #!   runs-on: ubuntu-latest
-  #!  steps:
-  #!     - uses: actions/checkout@v3
-  #!     - uses: actions/setup-node@v3
-  #!       with:
-  #!         node-version: "20"
-  #!     -  #@ cache_node()
-  #!     -  #@ rush_add_path()
-  #!     -  #@ rush_install()
-  #!     -  #@ rush_build()
-  #!     - name: Build the app
-  #!       run: cd apps/web-client && rushx build:prod
-  #!     - name: Run Playwright tests
-  #!       run: cd apps/e2e && rushx test:ci
-  #!     - uses: actions/upload-artifact@v3
-  #!       if: always()
-  #!       with:
-  #!         name: playwright-test-results
-  #!         path: apps/e2e/test-results
-  #!         retention-days: 30
+  e2e-test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      -  #@ cache_node()
+      -  #@ rush_add_path()
+      -  #@ rush_install()
+      -  #@ rush_build()
+      - name: Build the app
+        run: cd apps/web-client && rushx build:prod
+      - name: Run Playwright tests
+        run: cd apps/e2e && rushx test:ci
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-test-results
+          path: apps/e2e/test-results
+          retention-days: 30
 
   lint-and-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -101,6 +101,39 @@ jobs:
       run: rush build
     - name: Run tests
       run: cd pkg/db && rushx test:ci
+  e2e-test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "20"
+    - name: Cache node modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.rush
+          ~/.pnpm-store
+          common/temp
+          **/node_modules
+        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+    - name: Add local rush scripts to PATH
+      run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
+    - name: Install packages
+      run: rush update
+    - name: Build packages
+      run: rush build
+    - name: Build the app
+      run: cd apps/web-client && rushx build:prod
+    - name: Run Playwright tests
+      run: cd apps/e2e && rushx test:ci
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-test-results
+        path: apps/e2e/test-results
+        retention-days: 30
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
We've removed the e2e check from the CI when the dashboard was updated, to be reinstated when the e2e tests get updated to reflect the new dashboard. That was done, so I'm reinstating the e2e tests CI check.

_note: the checks are failing, which is expected, as there's one e2e test for functionality that's not-yet-supported_