### PR TITLE
Extend warehouse delete confirmation:

### DIFF
--- a/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
@@ -26,6 +26,7 @@
 			<p class="text-base font-normal text-gray-600" use:melt={$description}>
 				<slot name="description" />
 			</p>
+			<slot name="confirmation" />
 		</div>
 	</slot>
 

--- a/apps/web-client/src/lib/components/FormControls/Input.svelte
+++ b/apps/web-client/src/lib/components/FormControls/Input.svelte
@@ -8,6 +8,7 @@
 		helpText?: string;
 		inputRef?: HTMLInputElement | null;
 		inputAction?: Action<HTMLElement, any> | (() => void);
+		error?: string;
 	}
 
 	let className = "";
@@ -16,6 +17,7 @@
 	export let name: string;
 
 	export let value: string = "";
+	export let error: string = "";
 
 	export let type = "text";
 	export let label = "";
@@ -43,6 +45,7 @@
 		"mx-[2px]",
 		"outline",
 		"outline-gray-900",
+		error ? "ring-2 ring-red-400 ring-offset-2 ring-offset-white !outline-none" : "",
 		"rounded-md",
 		"focus-within:outline-none",
 		"focus-within:ring-2",

--- a/apps/web-client/src/lib/forms/WarehouseDeleteForm.svelte
+++ b/apps/web-client/src/lib/forms/WarehouseDeleteForm.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { type createDialog } from "@melt-ui/svelte";
+	import { superForm, superValidateSync, type SuperForm } from "sveltekit-superforms/client";
+
+	import { Dialog, Input } from "$lib/components";
+	import { warehouseDeleteSchema } from "$lib/forms/schemas";
+
+	export let dialog: ReturnType<typeof createDialog>;
+	export let dialogTitle: string;
+	export let dialogDescription: string;
+
+	type Form = SuperForm<ReturnType<typeof warehouseDeleteSchema>, unknown>;
+
+	export let displayName: string;
+	const matchConfirm = displayName.toLowerCase().replaceAll(" ", "_");
+	const schema = warehouseDeleteSchema(matchConfirm);
+
+	export let options: Form["options"];
+	let data = { confirm: "" };
+
+	const form = superForm(superValidateSync(data, schema), options);
+
+	const { form: formStore, errors, constraints, enhance } = form;
+
+	$: error = $errors.confirm?.[0];
+	$: if (error) form.reset();
+</script>
+
+<form use:enhance method="POST">
+	<Dialog {dialog} type="delete">
+		<svelte:fragment slot="title">{dialogTitle}</svelte:fragment>
+		<svelte:fragment slot="description">{dialogDescription}</svelte:fragment>
+		<svelte:fragment slot="confirmation">
+			<Input
+				bind:value={$formStore.confirm}
+				class="mt-4"
+				label="Confirm by typing warehouse name"
+				helpText="Type '{matchConfirm}'"
+				name="confirm"
+				placeholder={matchConfirm}
+				{...$constraints.confirm}
+				autocomplete="off"
+				{error}
+			/>
+		</svelte:fragment>
+	</Dialog>
+</form>

--- a/apps/web-client/src/lib/forms/schemas.ts
+++ b/apps/web-client/src/lib/forms/schemas.ts
@@ -8,6 +8,12 @@ export const warehouseSchema = z.object({
 	discount: z.number()
 });
 
+export type WarehouseDeleteFormData = SuperValidated<ReturnType<typeof warehouseDeleteSchema>>["data"];
+export const warehouseDeleteSchema = (matchConfirm: string) =>
+	z.object({
+		confirm: z.literal(matchConfirm)
+	});
+
 export type BookFormData = SuperValidated<typeof bookSchema>["data"];
 export const bookSchema = z.object({
 	isbn: z.string(),


### PR DESCRIPTION
* Require the (lowercased) warehouse name input to confirm deletion
* Create WarehouseDeleteForm (wrapping the confirmation modal)
* Extend Dialog to accept 'confirmation' slot
* Extends the Input component to accept 'error' and show red ring on error