### PR TITLE
Feat/outbound note reconciliation

### DIFF
--- a/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
@@ -23,7 +23,7 @@
 			<h2 class="text-lg font-semibold text-gray-800" use:melt={$title}>
 				<slot name="title" />
 			</h2>
-			<p class="text-base font-normal text-gray-600" use:melt={$description}>
+			<p class="whitespace-pre-line text-base font-normal text-gray-600" use:melt={$description}>
 				<slot name="description" />
 			</p>
 

--- a/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/Dialog.svelte
@@ -19,7 +19,7 @@
 	use:melt={$content}
 >
 	<slot name="content">
-		<div class="flex max-w-sm grow flex-col items-start gap-y-2">
+		<div class="flex max-w-lg grow flex-col items-start gap-y-2">
 			<h2 class="text-lg font-semibold text-gray-800" use:melt={$title}>
 				<slot name="title" />
 			</h2>

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/OutboundTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/OutboundTable.svelte
@@ -54,8 +54,12 @@
 			{@const { rowIx, isbn, authors = "N/A", quantity, price, year = "N/A", title = "N/A", publisher = "", warehouseDiscount } = row}
 			{@const { warehouseId, availableWarehouses } = row}
 			{@const quantityInWarehouse = availableWarehouses?.get(warehouseId)?.quantity || 0}
+			<!-- If a book is available in multiple warehouses (and no warehouse selected), we require action - bg is yellow -->
+			{@const requiresAction = !warehouseId && availableWarehouses?.size > 1}
+			<!-- If a book is out of stock in curren warehouse - paint the row red - this also catches books with no warehouse selected, but no stock in any warehouse -->
 			{@const outOfStock = quantityInWarehouse < quantity}
-			<tr class={outOfStock ? "out-of-stock" : ""} use:table.tableRow={{ position: rowIx }}>
+			<!-- Require action takes precedence over out of stock -->
+			<tr class={requiresAction ? "requires-action" : outOfStock ? "out-of-stock" : ""} use:table.tableRow={{ position: rowIx }}>
 				<th scope="row" data-property="book" class="table-cell-max">
 					<BookHeadCell data={{ isbn, title, authors, year }} />
 				</th>

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/OutboundTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/OutboundTable.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
 
+	import type { NavEntry } from "@librocco/db";
+
+	import type { OutboundTableData } from "../types";
+
 	import type { createTable } from "$lib/actions";
 
 	import { HeadCol } from "../Cells";
@@ -12,10 +16,9 @@
 	import WarehouseSelect from "$lib/components/WarehouseSelect/WarehouseSelect.svelte";
 
 	import { createOutboundTableEvents, type OutboundTableEvents } from "./events";
-	import type { OutboundTableData } from "../types";
-	import { availableWarehouses } from "$lib/__testData__/rowData";
 
 	export let table: ReturnType<typeof createTable<OutboundTableData>>;
+	export let warehouseList: Iterable<[string, NavEntry]>;
 
 	const { table: tableAction } = table;
 	$: ({ rows } = $table);
@@ -76,7 +79,7 @@
 					{year}
 				</td>
 				<td data-property="warehouseName" class="table-cell-max">
-					<WarehouseSelect on:change={(event) => editWarehouse(event, row)} data={row} {rowIx} />
+					<WarehouseSelect {warehouseList} on:change={(event) => editWarehouse(event, row)} data={row} {rowIx} />
 				</td>
 				{#if $$slots["row-actions"]}
 					<td class="table-cell-fit">

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/table.css
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/table.css
@@ -14,6 +14,10 @@ tbody tr.out-of-stock {
 	@apply !border border-red-300 bg-red-200/80;
 }
 
+tbody tr.requires-action {
+	@apply bg-yellow-200/80;
+}
+
 th,
 td {
 	@apply py-4 px-3;

--- a/apps/web-client/src/lib/components/Tables/stories/InventoryTables.story.svelte
+++ b/apps/web-client/src/lib/components/Tables/stories/InventoryTables.story.svelte
@@ -10,7 +10,7 @@
 
 	import { createTable } from "$lib/actions";
 
-	import { rows, outNoteRows } from "$lib/__testData__/rowData";
+	import { rows, availableWarehouses, outNoteRows } from "$lib/__testData__/rowData";
 
 	export let Hst: Hst;
 
@@ -51,6 +51,7 @@
 
 	<Hst.Variant title="Outbound">
 		<OutboundTable
+			warehouseList={availableWarehouses}
 			table={outboundTable}
 			on:edit-row-warehouse={({ detail }) => logEvent("Edit Warehouse", detail)}
 			on:edit-row-quantity={({ detail }) => logEvent("Edit Quantity", detail)}

--- a/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
+++ b/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
@@ -93,7 +93,7 @@
 		{#each options as warehouse}
 			{@const { label, value } = warehouse}
 			<div
-				class="data-[highlighted]:bg-teal-500 data-[highlighted]:text-white relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10"
+				class="relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10 data-[highlighted]:bg-teal-500 data-[highlighted]:text-white"
 				{...$option(warehouse)}
 				use:option
 			>

--- a/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
+++ b/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher, onMount, tick } from "svelte";
 
 	import { createSelect } from "@melt-ui/svelte";
-	import { Check, ChevronsUpDown } from "lucide-svelte";
+	import { Check, ChevronsUpDown, RefreshCcwDot } from "lucide-svelte";
 
 	import { testId } from "@librocco/shared";
 	import type { NavEntry } from "@librocco/db";
@@ -93,7 +93,7 @@
 		{#each options as warehouse}
 			{@const { label, value } = warehouse}
 			<div
-				class="relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10 data-[highlighted]:bg-teal-500 data-[highlighted]:text-white"
+				class="data-[highlighted]:bg-teal-500 data-[highlighted]:text-white relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10"
 				{...$option(warehouse)}
 				use:option
 			>
@@ -102,6 +102,14 @@
 				<div class="check {$isSelected(value) ? 'block' : 'hidden'}">
 					<Check size={18} />
 				</div>
+
+				<!-- An icon signifying that the book doesn't exist in the given warehouse - will need reconciliation -->
+				<!-- We're not showing this if the warehouse is selected (the highlight takes precedance) -->
+				{#if !$isSelected(value)}
+					<div>
+						<RefreshCcwDot size={18} class={availableWarehouses.has(value) ? "hidden" : "block"} />
+					</div>
+				{/if}
 			</div>
 		{/each}
 	</div>

--- a/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
+++ b/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
@@ -5,12 +5,14 @@
 	import { Check, ChevronsUpDown } from "lucide-svelte";
 
 	import { testId } from "@librocco/shared";
+	import type { NavEntry } from "@librocco/db";
 
 	import type { WarehouseChangeDetail } from "./types";
 	import type { OutboundTableData } from "$lib/components/Tables/types";
 
 	export let data: OutboundTableData;
 	export let rowIx: number;
+	export let warehouseList: Iterable<[string, NavEntry]> = new Map<string, { displayName: string }>();
 
 	const dispatch = createEventDispatcher<{ change: WarehouseChangeDetail }>();
 	const dispatchChange = (warehouseId: string) => dispatch("change", { warehouseId });
@@ -36,8 +38,8 @@
 
 	$: ({ warehouseId, warehouseName, availableWarehouses = new Map<string, { displayName: string; quantity: number }>() } = data);
 
-	const mapWarehousesToOptions = (warehouses: OutboundTableData["availableWarehouses"]) =>
-		[...warehouses].map(([value, { displayName }]) => ({ value, label: displayName }));
+	const mapWarehousesToOptions = (warehouseList: Iterable<[string, NavEntry]>) =>
+		[...warehouseList].map(([value, { displayName }]) => ({ value, label: displayName }));
 
 	/**
 	 * If the warehouse is already selected (warehouseId and warehouseName are not undefined), then set the value
@@ -49,73 +51,58 @@
 		if (availableWarehouses.size !== 1) return;
 
 		const availableWarehouse = availableWarehouses.keys().next().value;
-		if (availableWarehouse !== warehouseId) {
+		if (!warehouseId) {
 			// Tick isn't necessary here, but it's much easier when testing
 			tick().then(() => dispatchChange(availableWarehouse));
 		}
 	});
 
-	$: options = mapWarehousesToOptions(availableWarehouses);
+	// We're allowing all warehouses for selection.
+	// Out of stock situations are handled in the row (painting it red) or
+	// when committing the note (prompting for reconciliation)
+	$: options = mapWarehousesToOptions(warehouseList);
 </script>
 
-{#if options.length > 1}
-	<!-- svelte-ignore a11y-label-has-associated-control - $label contains the 'for' attribute -->
-	<label class="hidden" {...$label} use:label>Select a warehouse to withdraw book {rowIx} from</label>
-	<button
-		data-testid={testId("dropdown-control")}
-		data-open={open}
-		class="flex w-full gap-x-2 rounded border-2 border-gray-500 bg-white p-2 shadow focus:border-teal-500 focus:outline-none focus:ring-0"
-		{...$trigger}
-		use:trigger
-		aria-label="Warehouse"
-	>
-		<span class="rounded-full p-0.5 {$selectedLabel !== '' ? 'bg-teal-400' : 'bg-red-400'}" />
-		{#if $selectedLabel}
-			<span class="truncate">
-				{$selectedLabel}
-			</span>
-		{:else}
-			<span class="truncate text-gray-400">Select a warehouse</span>
-		{/if}
-		<ChevronsUpDown size={18} class="ml-auto shrink-0 self-end" />
-	</button>
-	{#if $open}
-		<div
-			data-testid={testId("dropdown-menu")}
-			class="z-10 flex max-h-[300px] flex-col gap-y-1.5 overflow-y-auto rounded-lg bg-white p-1 shadow-md focus:!ring-0"
-			{...$menu}
-			use:menu
-		>
-			{#each options as warehouse}
-				{@const { label, value } = warehouse}
-				<div
-					class="relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10 data-[highlighted]:bg-teal-500 data-[highlighted]:text-white"
-					{...$option(warehouse)}
-					use:option
-				>
-					{label}
-
-					<div class="check {$isSelected(value) ? 'block' : 'hidden'}">
-						<Check size={18} />
-					</div>
-				</div>
-			{/each}
-		</div>
+<!-- svelte-ignore a11y-label-has-associated-control - $label contains the 'for' attribute -->
+<label class="hidden" {...$label} use:label>Select a warehouse to withdraw book {rowIx} from</label>
+<button
+	data-testid={testId("dropdown-control")}
+	data-open={open}
+	class="flex w-full gap-x-2 rounded border-2 border-gray-500 bg-white p-2 shadow focus:border-teal-500 focus:outline-none focus:ring-0"
+	{...$trigger}
+	use:trigger
+	aria-label="Warehouse"
+>
+	<span class="rounded-full p-0.5 {$selectedLabel !== '' ? 'bg-teal-400' : 'bg-red-400'}" />
+	{#if $selectedLabel}
+		<span class="truncate">
+			{$selectedLabel}
+		</span>
+	{:else}
+		<span class="truncate text-gray-400">Select a warehouse</span>
 	{/if}
-{:else}
-	<div class="flex gap-x-2 rounded bg-gray-100 p-2">
-		<span class="rounded-full bg-teal-400 p-0.5" />
-		<button
-			data-testid={testId("dropdown-control")}
-			data-open={open}
-			disabled
-			class="flex w-full gap-x-2 px-2 focus:border-teal-500 focus:outline-none focus:ring-0"
-			use:trigger
-			aria-label="Warehouse"
-		>
-			<span class="truncate">
-				{$selectedLabel}
-			</span>
-		</button>
+	<ChevronsUpDown size={18} class="ml-auto shrink-0 self-end" />
+</button>
+{#if $open}
+	<div
+		data-testid={testId("dropdown-menu")}
+		class="z-10 flex max-h-[300px] flex-col gap-y-1.5 overflow-y-auto rounded-lg bg-white p-1 shadow-md focus:!ring-0"
+		{...$menu}
+		use:menu
+	>
+		{#each options as warehouse}
+			{@const { label, value } = warehouse}
+			<div
+				class="relative flex cursor-pointer items-center justify-between rounded p-1 text-gray-600 focus:z-10 data-[highlighted]:bg-teal-500 data-[highlighted]:text-white"
+				{...$option(warehouse)}
+				use:option
+			>
+				{label}
+
+				<div class="check {$isSelected(value) ? 'block' : 'hidden'}">
+					<Check size={18} />
+				</div>
+			</div>
+		{/each}
 	</div>
 {/if}

--- a/apps/web-client/src/lib/dialogs.ts
+++ b/apps/web-client/src/lib/dialogs.ts
@@ -1,4 +1,4 @@
-import type { VolumeStock } from "@librocco/shared";
+import type { OutOfStockTransaction } from "@librocco/db";
 
 export interface DialogContent {
 	onConfirm: (closeDialog: () => void) => void;
@@ -20,7 +20,7 @@ export const dialogDescription = {
 	deleteWarehouse: (bookCount: number) => `Once you delete this warehouse ${bookCount} books will be removed from your stock`,
 	commitInbound: (bookCount: number, warehouseName: string) => `${bookCount} books will be added to ${warehouseName}`,
 	commitOutbound: (bookCount: number) => `${bookCount} books will be removed from your stock`,
-	reconcileOutbound: (invalidTransactions: (VolumeStock & { warehouseName: string; available: number })[]) =>
+	reconcileOutbound: (invalidTransactions: OutOfStockTransaction[]) =>
 		[
 			"Some quantities of books are greater than the available stock for their respective warehouse.",
 			"By confirming this action, the available stock will be updated to allow for the transactions to be committed.",

--- a/apps/web-client/src/lib/dialogs.ts
+++ b/apps/web-client/src/lib/dialogs.ts
@@ -1,5 +1,7 @@
+import type { VolumeStock } from "@librocco/shared";
+
 export interface DialogContent {
-	onConfirm: () => void;
+	onConfirm: (closeDialog: () => void) => void;
 	title: string;
 	description: string;
 }
@@ -8,6 +10,7 @@ export const dialogTitle = {
 	delete: (entity: string) => `Permenantly delete ${entity}?`,
 	commitInbound: (entity: string) => `Commit inbound ${entity}?`,
 	commitOutbound: (entity: string) => `Commit outbound ${entity}?`,
+	reconcileOutbound: () => "Stock mismatch",
 	editBook: () => "Edit book details",
 	editWarehouse: () => "Update book details"
 };
@@ -17,6 +20,16 @@ export const dialogDescription = {
 	deleteWarehouse: (bookCount: number) => `Once you delete this warehouse ${bookCount} books will be removed from your stock`,
 	commitInbound: (bookCount: number, warehouseName: string) => `${bookCount} books will be added to ${warehouseName}`,
 	commitOutbound: (bookCount: number) => `${bookCount} books will be removed from your stock`,
+	reconcileOutbound: (invalidTransactions: (VolumeStock & { warehouseName: string; available: number })[]) =>
+		[
+			"Some quantities of books are greater than the available stock for their respective warehouse.",
+			"By confirming this action, the available stock will be updated to allow for the transactions to be committed.",
+			"Please review the following transactions and confirm if you want to proceed:",
+			...invalidTransactions.map(
+				({ isbn, warehouseName, quantity, available }) =>
+					`  isbn: ${isbn}, quantity: ${quantity} in ${warehouseName} (available: ${available})`
+			)
+		].join("\n"),
 	editBook: () => "Update book details",
 	editWarehouse: () => "Update warehouse details"
 };

--- a/apps/web-client/src/lib/dialogs.ts
+++ b/apps/web-client/src/lib/dialogs.ts
@@ -1,5 +1,3 @@
-import type { OutOfStockTransaction } from "@librocco/db";
-
 export interface DialogContent {
 	onConfirm: (closeDialog: () => void) => void;
 	title: string;
@@ -7,29 +5,41 @@ export interface DialogContent {
 }
 
 export const dialogTitle = {
+	// Misc
 	delete: (entity: string) => `Permenantly delete ${entity}?`,
+
+	// Inbond
 	commitInbound: (entity: string) => `Commit inbound ${entity}?`,
+
+	// Outbound
 	commitOutbound: (entity: string) => `Commit outbound ${entity}?`,
+	noWarehouseSelected: () => "No warehouse(s) selected",
 	reconcileOutbound: () => "Stock mismatch",
+
+	// BookForm
 	editBook: () => "Edit book details",
+
+	// WarehouseForm
 	editWarehouse: () => "Update book details"
 };
 
 export const dialogDescription = {
+	// Misc
 	deleteNote: () => "Once you delete this note, you will not be able to access it again",
 	deleteWarehouse: (bookCount: number) => `Once you delete this warehouse ${bookCount} books will be removed from your stock`,
+
+	// Inbound
 	commitInbound: (bookCount: number, warehouseName: string) => `${bookCount} books will be added to ${warehouseName}`,
+
+	// Outbound
 	commitOutbound: (bookCount: number) => `${bookCount} books will be removed from your stock`,
-	reconcileOutbound: (invalidTransactions: OutOfStockTransaction[]) =>
-		[
-			"Some quantities of books are greater than the available stock for their respective warehouse.",
-			"By confirming this action, the available stock will be updated to allow for the transactions to be committed.",
-			"Please review the following transactions and confirm if you want to proceed:",
-			...invalidTransactions.map(
-				({ isbn, warehouseName, quantity, available }) =>
-					`  isbn: ${isbn}, quantity: ${quantity} in ${warehouseName} (available: ${available})`
-			)
-		].join("\n"),
+	noWarehouseSelected: () => "Can't commit the note as some transactions don't have any warehouse selected",
+	reconcileOutbound: () =>
+		"Some quantities reqested are greater than available in stock and will need to be reconciled in order to proceed.",
+
+	// BookForm
 	editBook: () => "Update book details",
+
+	// WarehouseForm
 	editWarehouse: () => "Update warehouse details"
 };

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -46,13 +46,14 @@
 	});
 
 	// TODO: This way of deleting notes is rather slow - update the db interface to allow for more direct approach
-	const handleDeleteNote = (noteId: string) => async () => {
+	const handleDeleteNote = (noteId: string) => async (closeDialog: () => void) => {
 		const result = await db?.findNote(noteId);
 
 		if (!result) {
 			return;
 		}
 		await result.note.delete({});
+		closeDialog();
 		toastSuccess(noteToastMessages("Note").noteDeleted);
 	};
 
@@ -147,14 +148,7 @@
 
 			<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }} />
 			<div class="fixed left-[50%] top-[50%] z-50 flex max-w-2xl translate-x-[-50%] translate-y-[-50%]">
-				<Dialog
-					{dialog}
-					type="delete"
-					onConfirm={async (closeDialog) => {
-						await onConfirm();
-						closeDialog();
-					}}
-				>
+				<Dialog {dialog} type="delete" {onConfirm}>
 					<svelte:fragment slot="title">{title}</svelte:fragment>
 					<svelte:fragment slot="description">{description}</svelte:fragment>
 				</Dialog>

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -78,13 +78,15 @@
 		}
 	}
 
-	const handleCommitSelf = async () => {
+	const handleCommitSelf = async (closeDialog: () => void) => {
 		await note.commit({});
+		closeDialog();
 		toastSuccess(noteToastMessages("Note").inNoteCommited);
 	};
 
-	const handleDeleteSelf = async () => {
+	const handleDeleteSelf = async (closeDialog: () => void) => {
 		await note.delete({});
+		closeDialog();
 		toastSuccess(noteToastMessages("Note").noteDeleted);
 	};
 	// #region note-actions
@@ -441,14 +443,7 @@
 			</div>
 		{:else}
 			<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-				<Dialog
-					{dialog}
-					{type}
-					onConfirm={async (closeDialog) => {
-						await onConfirm();
-						closeDialog();
-					}}
-				>
+				<Dialog {dialog} {type} {onConfirm}>
 					<svelte:fragment slot="title">{dialogTitle}</svelte:fragment>
 					<svelte:fragment slot="description">{dialogDescription}</svelte:fragment>
 				</Dialog>

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -38,9 +38,10 @@
 	});
 
 	// TODO: This way of deleting notes is rather slow - update the db interface to allow for more direct approach
-	const handleDeleteNote = (noteId: string) => async () => {
+	const handleDeleteNote = (noteId: string) => async (closeDialog: () => void) => {
 		const { note } = await db?.findNote(noteId);
 		await note?.delete({});
+		closeDialog();
 		toastSuccess(noteToastMessages("Note").noteDeleted);
 	};
 
@@ -159,14 +160,7 @@
 
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }} />
 		<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-			<Dialog
-				{dialog}
-				type="delete"
-				onConfirm={async (closeDialog) => {
-					await onConfirm();
-					closeDialog();
-				}}
-			>
+			<Dialog {dialog} type="delete" {onConfirm}>
 				<svelte:fragment slot="title">{title}</svelte:fragment>
 				<svelte:fragment slot="description">{description}</svelte:fragment>
 			</Dialog>

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -470,6 +470,8 @@
 							<li>{isbn}</li>
 						{/each}
 					</ul>
+					<!-- A small hack to hide the 'Confirm' button as there's nothing to confirm -->
+					<svelte:fragment slot="confirm-button"><span /></svelte:fragment>
 				</Dialog>
 			</div>
 			<!-- No warehouse selecter dialog end -->

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -8,9 +8,9 @@
 
 	import { goto } from "$app/navigation";
 
-	import { NoteState, filter, testId } from "@librocco/shared";
+	import { NoteState, filter, testId, type VolumeStock } from "@librocco/shared";
 
-	import type { BookEntry, NavEntry, OutOfStockError, OutOfStockTransaction } from "@librocco/db";
+	import { OutOfStockError, type BookEntry, type NavEntry, type OutOfStockTransaction, NoWarehouseSelectedError } from "@librocco/db";
 	import { bookDataPlugin } from "$lib/db/plugins";
 
 	import type { PageData } from "./$types";
@@ -89,12 +89,18 @@
 		}
 	}
 
+	const openNoWarehouseSelectedDialog = (invalidTransactions: VolumeStock[]) => {
+		dialogContent = {
+			type: "no-warehouse-selected",
+			invalidTransactions
+		};
+		open.set(true);
+	};
+
 	const openReconciliationDialog = (invalidTransactions: OutOfStockTransaction[]) => {
 		dialogContent = {
-			onConfirm: handleReconcileAndCommitSelf,
-			title: dialogTitle.reconcileOutbound(),
-			description: dialogDescription.reconcileOutbound(invalidTransactions),
-			type: "delete"
+			type: "reconcile",
+			invalidTransactions
 		};
 		open.set(true);
 	};
@@ -105,11 +111,13 @@
 			closeDialog();
 			toastSuccess(noteToastMessages("Note").outNoteCommited);
 		} catch (err) {
-			const invalidTransactions = (err as OutOfStockError).invalidTransactions.map((t) => ({
-				...t,
-				warehouseName: $warehouseList.get(t.warehouseId)?.displayName || "unkwnown"
-			}));
-			openReconciliationDialog(invalidTransactions);
+			if (err instanceof NoWarehouseSelectedError) {
+				return openNoWarehouseSelectedDialog(err.invalidTransactions);
+			}
+			if (err instanceof OutOfStockError) {
+				return openReconciliationDialog(err.invalidTransactions);
+			}
+			throw err;
 		}
 	};
 
@@ -230,7 +238,10 @@
 		states: { open }
 	} = dialog;
 
-	let dialogContent: DialogContent & { type: "commit" | "delete" | "edit-row" };
+	let dialogContent:
+		| ({ type: "commit" | "delete" | "edit-row" } & DialogContent)
+		| { type: "no-warehouse-selected"; invalidTransactions: VolumeStock[] }
+		| { type: "reconcile"; invalidTransactions: OutOfStockTransaction[] };
 </script>
 
 <Page view="outbound-note" loaded={!loading}>
@@ -444,64 +455,107 @@
 
 <div use:melt={$portalled}>
 	{#if $open}
-		{@const { type, onConfirm, title: dialogTitle, description: dialogDescription } = dialogContent}
-
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }} />
-		{#if type === "edit-row"}
-			<div
-				use:melt={$content}
-				class="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 overflow-y-auto bg-white
-				shadow-lg focus:outline-none"
-				in:fly|global={{
-					x: 350,
-					duration: 150,
-					opacity: 1
-				}}
-				out:fly|global={{
-					x: 350,
-					duration: 100
-				}}
-			>
-				<div class="flex w-full flex-row justify-between bg-gray-50 px-6 py-4">
-					<div>
-						<h2 use:melt={$title} class="mb-0 text-lg font-medium text-black">{dialogTitle}</h2>
-						<p use:melt={$description} class="mb-5 mt-2 leading-normal text-zinc-600">{dialogDescription}</p>
-					</div>
-					<button use:melt={$close} aria-label="Close" class="self-start rounded p-3 text-gray-500 hover:text-gray-900">
-						<X class="square-4" />
-					</button>
-				</div>
-				<div class="px-6">
-					<BookForm
-						data={bookFormData}
-						publisherList={$publisherList}
-						options={{
-							SPA: true,
-							dataType: "json",
-							validators: bookSchema,
-							validationMethod: "submit-only",
-							onUpdated
-						}}
-						onCancel={() => open.set(false)}
-						onFetch={async (isbn, form) => {
-							const result = await bookDataPlugin.fetchBookData(isbn);
+		{#if dialogContent.type === "no-warehouse-selected"}
+			<!-- No warehouse selecter dialog -->
+			{@const { invalidTransactions } = dialogContent}
 
-							if (result) {
-								const [bookData] = result;
-								form.update((data) => ({ ...data, ...bookData }));
-							}
-							// TODO: handle loading and errors
-						}}
-					/>
-				</div>
-			</div>
-		{:else}
 			<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-				<Dialog {dialog} {type} onConfirm={dialogContent.onConfirm}>
-					<svelte:fragment slot="title">{dialogTitle}</svelte:fragment>
-					<svelte:fragment slot="description">{dialogDescription}</svelte:fragment>
+				<Dialog {dialog} type="delete" onConfirm={() => {}}>
+					<svelte:fragment slot="title">{dialogTitle.noWarehouseSelected()}</svelte:fragment>
+					<svelte:fragment slot="description">{dialogDescription.noWarehouseSelected()}</svelte:fragment>
+					<h3 class="mt-4 mb-2 font-semibold">Please select a warehouse for each of the following transactions:</h3>
+					<ul class="pl-2">
+						{#each invalidTransactions as { isbn }}
+							<li>{isbn}</li>
+						{/each}
+					</ul>
 				</Dialog>
 			</div>
+			<!-- No warehouse selecter dialog end -->
+		{:else if dialogContent.type === "reconcile"}
+			<!-- Note reconciliation dialog -->
+			{@const { invalidTransactions } = dialogContent}
+
+			<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
+				<Dialog {dialog} type="delete" onConfirm={handleReconcileAndCommitSelf}>
+					<svelte:fragment slot="title">{dialogTitle.reconcileOutbound()}</svelte:fragment>
+					<svelte:fragment slot="description">{dialogDescription.reconcileOutbound()}</svelte:fragment>
+					<h3 class="mt-4 mb-2 font-semibold">Please review the following tranasctions:</h3>
+					<ul class="pl-2">
+						{#each invalidTransactions as { isbn, warehouseName, quantity, available }}
+							<li class="mb-2">
+								<p><span class="font-semibold">{isbn}</span> in <span class="font-semibold">{warehouseName}:</span></p>
+								<p class="pl-2">requested quantity: {quantity}</p>
+								<p class="pl-2">available: {available}</p>
+								<p class="pl-2">
+									quantity for reconciliation: <span class="font-semibold">{quantity - available}</span>
+								</p>
+							</li>
+						{/each}
+					</ul>
+				</Dialog>
+			</div>
+			<!-- Note reconciliation dialog end -->
+		{:else}
+			{@const { type, title: dialogTitle, description: dialogDescription } = dialogContent}
+
+			{#if type === "edit-row"}
+				<div
+					use:melt={$content}
+					class="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 overflow-y-auto bg-white
+				shadow-lg focus:outline-none"
+					in:fly|global={{
+						x: 350,
+						duration: 150,
+						opacity: 1
+					}}
+					out:fly|global={{
+						x: 350,
+						duration: 100
+					}}
+				>
+					<div class="flex w-full flex-row justify-between bg-gray-50 px-6 py-4">
+						<div>
+							<h2 use:melt={$title} class="mb-0 text-lg font-medium text-black">{dialogTitle}</h2>
+							<p use:melt={$description} class="mb-5 mt-2 leading-normal text-zinc-600">{dialogDescription}</p>
+						</div>
+						<button use:melt={$close} aria-label="Close" class="self-start rounded p-3 text-gray-500 hover:text-gray-900">
+							<X class="square-4" />
+						</button>
+					</div>
+					<div class="px-6">
+						<BookForm
+							data={bookFormData}
+							publisherList={$publisherList}
+							options={{
+								SPA: true,
+								dataType: "json",
+								validators: bookSchema,
+								validationMethod: "submit-only",
+								onUpdated
+							}}
+							onCancel={() => open.set(false)}
+							onFetch={async (isbn, form) => {
+								const result = await bookDataPlugin.fetchBookData(isbn);
+
+								if (result) {
+									const [bookData] = result;
+									form.update((data) => ({ ...data, ...bookData }));
+								}
+								// TODO: handle loading and errors
+							}}
+						/>
+					</div>
+				</div>
+			{:else}
+				<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
+					<Dialog {dialog} {type} onConfirm={dialogContent.onConfirm}>
+						<svelte:fragment slot="title">{dialogTitle}</svelte:fragment>
+						<svelte:fragment slot="description">{dialogDescription}</svelte:fragment>
+					</Dialog>
+				</div>
+			{/if}
 		{/if}
 	{/if}
 </div>

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -8,9 +8,9 @@
 
 	import { goto } from "$app/navigation";
 
-	import { NoteState, filter, testId, type VolumeStock } from "@librocco/shared";
+	import { NoteState, filter, testId } from "@librocco/shared";
 
-	import type { BookEntry, NavEntry, OutOfStockError, VolumeStockClient } from "@librocco/db";
+	import type { BookEntry, NavEntry, OutOfStockError, OutOfStockTransaction } from "@librocco/db";
 	import { bookDataPlugin } from "$lib/db/plugins";
 
 	import type { PageData } from "./$types";
@@ -89,7 +89,7 @@
 		}
 	}
 
-	const openReconciliationDialog = (invalidTransactions: (VolumeStock & { warehouseName: string; available: number })[]) => {
+	const openReconciliationDialog = (invalidTransactions: OutOfStockTransaction[]) => {
 		dialogContent = {
 			onConfirm: handleReconcileAndCommitSelf,
 			title: dialogTitle.reconcileOutbound(),

--- a/pkg/db/src/errors.ts
+++ b/pkg/db/src/errors.ts
@@ -1,10 +1,12 @@
 import { VolumeStock } from "@librocco/shared";
 
+import { OutOfStockTransaction } from "./types";
+
 export class TransactionWarehouseMismatchError extends Error {
 	parentWarehouse: string;
-	invalidTransactions: Omit<VolumeStock, "quantity">[];
+	invalidTransactions: VolumeStock[];
 
-	constructor(parentWarehouse: string, invalidTransactions: Omit<VolumeStock, "quantity">[]) {
+	constructor(parentWarehouse: string, invalidTransactions: VolumeStock[]) {
 		const message = `Trying to commit a note containing transactions belonging to a different warehouse than the note itself.
     Note's parent warehouse: '${parentWarehouse}'
     Invalid transactions:
@@ -17,9 +19,20 @@ export class TransactionWarehouseMismatchError extends Error {
 	}
 }
 
-interface OutOfStockTransaction extends VolumeStock {
-	available: number;
+export class NoWarehouseSelectedError extends Error {
+	invalidTransactions: VolumeStock[];
+
+	constructor(invalidTransactions: VolumeStock[]) {
+		const message = `Trying to commit a note containing transactions with no warehouse selected.
+    Invalid transactions:
+    ${invalidTransactions.map(({ isbn }) => `ISBN: '${isbn}'`).join(`
+    `)}`;
+
+		super(message);
+		this.invalidTransactions = invalidTransactions;
+	}
 }
+
 export class OutOfStockError extends Error {
 	invalidTransactions: OutOfStockTransaction[];
 

--- a/pkg/db/src/types/inventory.ts
+++ b/pkg/db/src/types/inventory.ts
@@ -25,6 +25,11 @@ export interface EntriesStreamResult {
 }
 
 export type EntriesQuery = (ctx: debug.DebugCtx) => Promise<Iterable<VolumeStockClient>>;
+
+export interface OutOfStockTransaction extends VolumeStock {
+	warehouseName: string;
+	available: number;
+}
 // #endregion misc
 
 // #region note

--- a/pkg/db/src/types/inventory.ts
+++ b/pkg/db/src/types/inventory.ts
@@ -40,6 +40,7 @@ export type NoteData<A extends Record<string, any> = {}> = CouchDocument<
 		committed: boolean;
 		displayName: string;
 		updatedAt: string | null;
+		reconciliationNote?: boolean;
 	} & A
 >;
 
@@ -67,6 +68,11 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 	// Note specific methods
 	/** Set name updates the `displayName` of the note. */
 	setName: (ctx: debug.DebugCtx, name: string) => Promise<NoteInterface<A>>;
+	/**
+	 * Marks the note as a 'reconciliationNote' - an inbound note used to reconcile the state
+	 * in case an outbound note contains some out-of-stock books (but they exist in physical state).
+	 */
+	setReconciliationNote: (ctx: debug.DebugCtx, value: boolean) => Promise<NoteInterface<A>>;
 	/**
 	 * Add volumes accepts an array of volume stock entries and adds them to the note.
 	 * If any transactions (for a given isbn and warehouse) already exist, the quantity gets aggregated.
@@ -102,6 +108,7 @@ export interface NoteProto<A extends Record<string, any> = {}> {
 	 */
 	getEntries: EntriesQuery;
 	printReceipt(): Promise<string>;
+	reconcile: (ctx: debug.DebugCtx) => Promise<NoteInterface<A>>;
 }
 
 /**

--- a/pkg/shared/src/StockMap.ts
+++ b/pkg/shared/src/StockMap.ts
@@ -74,6 +74,10 @@ export class StockMap implements VolumeStockMap {
 		return res;
 	}
 
+	getQuantity(key: [string, string]) {
+		return this.get(key)?.quantity || 0;
+	}
+
 	clear() {
 		this.#internal.clear();
 	}

--- a/pkg/shared/src/types.ts
+++ b/pkg/shared/src/types.ts
@@ -7,7 +7,7 @@ export interface VolumeStock {
 
 export type VolumeStockInput = VolumeStock & { noteType: "inbound" | "outbound" };
 
-export type StockKey = [string, string];
+export type StockKey = [isbn: string, warehouseId: string];
 export type StockElement = { quantity: number };
 export type StockEntry = [StockKey, StockElement];
 export type VolumeStockMap = Map<StockKey, StockElement>;


### PR DESCRIPTION
Closes T-358

When the user tries to commit the outbound note the check is performed:
- if there's at least one transaction without warehouse specified, the 'no-warehouse-selected' modal is displayed
- if all warehouses are specified, but some transactions are our of stock - an out-of-stock dialog is displayed (prompting the user for reconciliation and commit)
- if user confirms the out-of-stock (reconciliation) dialog, an inbound note with `reconciliationNote: true` is created in the background (balancing out the out-of-stock transactions of the outbound note in question)

The db tests and e2e tests have been updated to test / expect this behaviour.

This is flow is rather hard to communicate (to technical people), and it's even harder to communicate to your average cash-register operator, so I'm fairly certain we will need some UX updates communicating the changes made, and changes to be made **if the dialog is confirmed**