### PR TITLE
Update actions/checkout: v2 → v3

### DIFF
--- a/.github/workflow.templates/test-job.lib.yml
+++ b/.github/workflow.templates/test-job.lib.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
   checks: write
 steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
   - uses: actions/setup-node@v3
     with:
       node-version: "20"

--- a/.github/workflow.templates/workflow-templates.yml
+++ b/.github/workflow.templates/workflow-templates.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check Github Actions templates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run script to generate Github Actions
         run: ./.github/build-workflows.sh
       - name: Check if there are any changes

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       checks: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: "20"
@@ -50,7 +50,7 @@ jobs:
       contents: read
       checks: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: "20"
@@ -80,7 +80,7 @@ jobs:
       contents: read
       checks: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: "20"
@@ -110,7 +110,7 @@ jobs:
       contents: read
       checks: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: "20"

--- a/.github/workflows/workflow-templates.yml
+++ b/.github/workflows/workflow-templates.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check Github Actions templates
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run script to generate Github Actions
       run: ./.github/build-workflows.sh
     - name: Check if there are any changes


### PR DESCRIPTION
The main reasons for this PR are:

* `e2e-tests` is currently failing on a few PRs. I'd like to investigate if it's failing on `main` too
* [Yesterday's run](https://github.com/librocco/librocco/actions/runs/8873810362) of the playwright matrix showed some warnings about older versions of actions we're using