### PR TITLE
autoscan hook: dispatch an empty 'input' event to the target element when flushing (cancelled) captured input

### DIFF
--- a/apps/web-client/src/lib/actions/scan.ts
+++ b/apps/web-client/src/lib/actions/scan.ts
@@ -101,4 +101,7 @@ const flush = (target: HTMLInputElement | undefined, value: string) => {
 	if (!target) return;
 	// Append the buffer value to the target
 	target.value += value;
+	// Dispatch an empty event to trigger the 'input' event on target element with its current value
+	// TODO: This behaves a bit awkwardly if we want to replace a selected part of text
+	target.dispatchEvent(new KeyboardEvent("input"));
 };


### PR DESCRIPTION
### The problem:
Trying to input price value (and I've later found any value) into the book form behaves awkwardly.

### Diagnostic:
- when inputing value, not event (`input`) is dispatched, **only** if one were to push backspace, would the event be dispatched
- the cause for this :point_up: is autoscan capturing the input (backspace key press is not captured, only number input)
- if the autoscan is off, everything works as expected

### The (partial) fix:
- autoscan is not broken per se - it will still flush the captured sequence of keys to the input, but won't trigger any events
- to remedy this ☝️ we're dispatching an empty `input` event after flushing the value to the target element (if the sequence is not recognised as scan sequence)

### Not fixed (TODO): 
- there's some weird behaviour if we want to overwrite the current price by selecting and typing over (as is the regular workflow), the input behaves awkwardly - this is not-so-ideal-UX, but the underlaying functionality (saving the input once it's set to the appropriate value) behaves exactly as expected
- the solution for this might be to ditch the autoscan altogether and introduce a scan mode:
  - user focuses the scan input
  - we add an overlay (visuall focusing only the scan element)
  - after each scan, the volume is added, scan element cleared and refocused
  - on click away from scan, we exit the scan mode and go business as usual