### PR TITLE
book data fetching: minor fixups:

### DIFF
--- a/apps/web-client/src/lib/db/plugins.ts
+++ b/apps/web-client/src/lib/db/plugins.ts
@@ -1,3 +1,0 @@
-import { createBookDataExtensionPlugin } from "@librocco/book-data-extension";
-
-export const bookDataPlugin = createBookDataExtensionPlugin();

--- a/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
@@ -8,8 +8,6 @@
 	import { debug, testId } from "@librocco/shared";
 	import type { BookEntry } from "@librocco/db";
 
-	import { bookDataPlugin } from "$lib/db/plugins";
-
 	import {
 		Page,
 		PlaceholderBox,
@@ -247,7 +245,7 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await bookDataPlugin.fetchBookData([isbn]);
+							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
 
 							const [bookData] = result;
 							if (!bookData) {

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -19,7 +19,6 @@
 		NoWarehouseSelectedError,
 		isBookRow
 	} from "@librocco/db";
-	import { bookDataPlugin } from "$lib/db/plugins";
 
 	import type { PageData } from "./$types";
 
@@ -161,6 +160,20 @@
 	// #region transaction-actions
 	const handleAddTransaction = async (isbn: string) => {
 		await note.addVolumes({ isbn, quantity: 1 });
+
+		// First check if there exists a book entry in the db, if not, fetch book data using external sources
+		//
+		// Note: this is not terribly efficient, but it's the least ambiguous behaviour to implement
+		const [localBookData] = await db.books().get([isbn]);
+		if (localBookData) {
+			return;
+		}
+
+		// If book data retrieved from 3rd party source - store it for future use
+		const [thirdPartyBookData] = await db.plugin("book-fetcher").fetchBookData([isbn]);
+		if (thirdPartyBookData) {
+			await db.books().upsert([thirdPartyBookData]);
+		}
 	};
 
 	const updateRowWarehouse = async (e: CustomEvent<WarehouseChangeDetail>, data: InventoryTableData) => {
@@ -620,7 +633,7 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await bookDataPlugin.fetchBookData([isbn]);
+							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
 
 							const [bookData] = result;
 							if (!bookData) {

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -7,7 +7,6 @@
 	import { Search, FileEdit, X, Loader2 as Loader, Printer, MoreVertical } from "lucide-svelte";
 
 	import type { SearchIndex, BookEntry } from "@librocco/db";
-	import { bookDataPlugin } from "$lib/db/plugins";
 
 	import { ExtensionAvailabilityToast, PopoverWrapper, StockTable } from "$lib/components";
 	import { BookForm, bookSchema, type BookFormOptions } from "$lib/forms";
@@ -218,7 +217,7 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await bookDataPlugin.fetchBookData([isbn]);
+							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
 
 							const [bookData] = result;
 							if (!bookData) {


### PR DESCRIPTION
* remove all direct calls to bookdata-extension plugin (use db.plugin("book-fetcher") as single source of truth)
* when scanning a book:
	* check if book data exists first
	* if book data exists (however incomplete), don't fetch additional data (this can be done explicitly using book form)
	* fetch book data from 3rd party ONLY if no data present

The updates above :point_up: fix the problem of book data being overwritten (including the price) when adding new price as book data would **always** get fetched (regardless of there being some book data in the db)