### PR TITLE
Fix/note sorting

### DIFF
--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -73,7 +73,7 @@ test("should display notes, namespaced to warehouses, in the inbound note list",
 	await content.navigate("inbound-list");
 
 	// The notes should appear in the list
-	await inNoteList.assertElements([{ name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / Note 2" }]);
+	await inNoteList.assertElements([{ name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / Note 1" }]);
 
 	// Add another warehouse and a note to it
 	await dbHandle.evaluate((db) =>
@@ -86,7 +86,7 @@ test("should display notes, namespaced to warehouses, in the inbound note list",
 	);
 
 	// All notes should be namespaced to their respective warehouses
-	await inNoteList.assertElements([{ name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / Note 2" }, { name: "Warehouse 2 / Note 3" }]);
+	await inNoteList.assertElements([{ name: "Warehouse 2 / Note 3" }, { name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / Note 1" }]);
 });
 
 test("should delete the note on delete button click (after confirming the prompt)", async ({ page }) => {
@@ -113,7 +113,7 @@ test("should delete the note on delete button click (after confirming the prompt
 
 	// Wait for the notes to appear
 	await content.navigate("inbound-list");
-	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / Note 2" }]);
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / Note 1" }]);
 
 	// Delete the first note
 	await content.entityList("inbound-list").item(0).delete();
@@ -206,9 +206,9 @@ test("should assign default name to notes in sequential order (regardless of war
 	const entityList = content.entityList("inbound-list");
 
 	await entityList.assertElements([
-		{ name: "Warehouse 1 / New Note", numBooks: 0, updatedAt: note1UpdatedAt },
+		{ name: "Warehouse 2 / New Note (3)", numBooks: 0, updatedAt: note3UpdatedAt },
 		{ name: "Warehouse 1 / New Note (2)", numBooks: 0, updatedAt: note2UpdatedAt },
-		{ name: "Warehouse 2 / New Note (3)", numBooks: 0, updatedAt: note3UpdatedAt }
+		{ name: "Warehouse 1 / New Note", numBooks: 0, updatedAt: note1UpdatedAt }
 	]);
 });
 
@@ -231,17 +231,13 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await dbHandle.evaluate((db) => db.warehouse("warehouse-1").note("note-3").create());
 
 	// Rename the first two notes (leaving us with only "New Note (3)", having the default name)
-	await dbHandle.evaluate((db) =>
-		Promise.all([
-			db.warehouse("warehouse-1").note("note-1").setName({}, "Note 1"),
-			db.warehouse("warehouse-1").note("note-2").setName({}, "Note 2")
-		])
-	);
+	await dbHandle.evaluate((db) => db.warehouse("warehouse-1").note("note-1").setName({}, "Note 1"));
+	await dbHandle.evaluate((db) => db.warehouse("warehouse-1").note("note-2").setName({}, "Note 2"));
 
 	// Check names
 	await content
 		.entityList("inbound-list")
-		.assertElements([{ name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / New Note (3)" }]);
+		.assertElements([{ name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / New Note (3)" }]);
 
 	// TODO: the following should be refactored to use the dashboard (when the renaming functionality is in).
 	// For now we're using the db directly (not really e2e way).
@@ -251,26 +247,22 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await content
 		.entityList("inbound-list")
 		.assertElements([
-			{ name: "Warehouse 1 / Note 1" },
+			{ name: "Warehouse 1 / New Note (4)" },
 			{ name: "Warehouse 1 / Note 2" },
-			{ name: "Warehouse 1 / New Note (3)" },
-			{ name: "Warehouse 1 / New Note (4)" }
+			{ name: "Warehouse 1 / Note 1" },
+			{ name: "Warehouse 1 / New Note (3)" }
 		]);
 
 	// Rename the remaining notes with default names
-	await dbHandle.evaluate((db) =>
-		Promise.all([
-			db.warehouse("warehouse-1").note("note-3").setName({}, "Note 3"),
-			db.warehouse("warehouse-1").note("note-4").setName({}, "Note 4")
-		])
-	);
+	await dbHandle.evaluate((db) => db.warehouse("warehouse-1").note("note-3").setName({}, "Note 3"));
+	await dbHandle.evaluate((db) => db.warehouse("warehouse-1").note("note-4").setName({}, "Note 4"));
 	await content
 		.entityList("inbound-list")
 		.assertElements([
-			{ name: "Warehouse 1 / Note 1" },
-			{ name: "Warehouse 1 / Note 2" },
+			{ name: "Warehouse 1 / Note 4" },
 			{ name: "Warehouse 1 / Note 3" },
-			{ name: "Warehouse 1 / Note 4" }
+			{ name: "Warehouse 1 / Note 2" },
+			{ name: "Warehouse 1 / Note 1" }
 		]);
 
 	// Create a new note (should reset the sequence)
@@ -278,11 +270,11 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await content
 		.entityList("inbound-list")
 		.assertElements([
-			{ name: "Warehouse 1 / Note 1" },
-			{ name: "Warehouse 1 / Note 2" },
-			{ name: "Warehouse 1 / Note 3" },
+			{ name: "Warehouse 1 / New Note" },
 			{ name: "Warehouse 1 / Note 4" },
-			{ name: "Warehouse 1 / New Note" }
+			{ name: "Warehouse 1 / Note 3" },
+			{ name: "Warehouse 1 / Note 2" },
+			{ name: "Warehouse 1 / Note 1" }
 		]);
 });
 
@@ -310,19 +302,19 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 
 	// Naviate to the inbound list
 	await content.navigate("inbound-list");
-	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Note 1" }, { name: "Warehouse 1 / Note 2" }]);
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Note 2" }, { name: "Warehouse 1 / Note 1" }]);
 
-	// Navigate to first note
-	await content.entityList("inbound-list").item(0).edit();
+	// Navigate to note 1
+	await content.entityList("inbound-list").item(1).edit();
 
 	// Check title
 	await dashboard.view("inbound-note").waitFor();
 	await content.header().title().assert("Note 1");
 
-	// Navigate back to inbound page and to second note
+	// Navigate back to inbound page and to note 2
 	await dashboard.navigate("inventory");
 	await content.navigate("inbound-list");
-	await content.entityList("inbound-list").item(1).edit();
+	await content.entityList("inbound-list").item(0).edit();
 
 	// Check title
 	await dashboard.view("inbound-note").waitFor();
@@ -356,8 +348,8 @@ test("should display book count for each respective note in the list", async ({ 
 
 	// Both should display 0 books
 	await content.entityList("inbound-list").assertElements([
-		{ name: "Warehouse 1 / Note 1", numBooks: 0 },
-		{ name: "Warehouse 1 / Note 2", numBooks: 0 }
+		{ name: "Warehouse 1 / Note 2", numBooks: 0 },
+		{ name: "Warehouse 1 / Note 1", numBooks: 0 }
 	]);
 
 	// Add two books to first note
@@ -379,8 +371,8 @@ test("should display book count for each respective note in the list", async ({ 
 	);
 
 	await content.entityList("inbound-list").assertElements([
-		{ name: "Warehouse 1 / Note 1", numBooks: 2 },
-		{ name: "Warehouse 1 / Note 2", numBooks: 3 }
+		{ name: "Warehouse 1 / Note 2", numBooks: 3 },
+		{ name: "Warehouse 1 / Note 1", numBooks: 2 }
 	]);
 });
 

--- a/apps/e2e/integration/outbound_flow.spec.ts
+++ b/apps/e2e/integration/outbound_flow.spec.ts
@@ -50,7 +50,7 @@ test("should delete the note on delete button click (after confirming the prompt
 	);
 
 	// Wait for the notes to appear
-	await content.entityList("outbound-list").assertElements([{ name: "Note 1" }, { name: "Note 2" }]);
+	await content.entityList("outbound-list").assertElements([{ name: "Note 2" }, { name: "Note 1" }]);
 
 	// Delete the first note
 	await content.entityList("outbound-list").item(0).delete();
@@ -117,8 +117,8 @@ test("should assign default name to notes in sequential order", async ({ page })
 	await entityList.waitFor();
 
 	await entityList.assertElements([
-		{ name: "New Note", numBooks: 0, updatedAt: note1UpdatedAt },
-		{ name: "New Note (2)", numBooks: 0, updatedAt: note2UpdatedAt }
+		{ name: "New Note (2)", numBooks: 0, updatedAt: note2UpdatedAt },
+		{ name: "New Note", numBooks: 0, updatedAt: note1UpdatedAt }
 	]);
 });
 
@@ -137,12 +137,11 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await dbHandle.evaluate((db) => db.warehouse().note("note-3").create());
 
 	// Rename the first two notes (leaving us with only "New Note (3)", having the default name)
-	await dbHandle.evaluate((db) =>
-		Promise.all([db.warehouse().note("note-1").setName({}, "Note 1"), db.warehouse().note("note-2").setName({}, "Note 2")])
-	);
+	await dbHandle.evaluate((db) => db.warehouse().note("note-1").setName({}, "Note 1"));
+	await dbHandle.evaluate((db) => db.warehouse().note("note-2").setName({}, "Note 2"));
 
-	// Check names
-	await content.entityList("outbound-list").assertElements([{ name: "Note 1" }, { name: "Note 2" }, { name: "New Note (3)" }]);
+	// Check names (notes are sorted by updated at - newest first)
+	await content.entityList("outbound-list").assertElements([{ name: "Note 2" }, { name: "Note 1" }, { name: "New Note (3)" }]);
 
 	// TODO: the following should be refactored to use the dashboard (when the renaming functionality is in).
 	// For now we're using the db directly (not really e2e way).
@@ -151,21 +150,21 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await dbHandle.evaluate((db) => db.warehouse().note("note-4").create());
 	await content
 		.entityList("outbound-list")
-		.assertElements([{ name: "Note 1" }, { name: "Note 2" }, { name: "New Note (3)" }, { name: "New Note (4)" }]);
+		.assertElements([{ name: "New Note (4)" }, { name: "Note 2" }, { name: "Note 1" }, { name: "New Note (3)" }]);
 
 	// Rename the remaining notes with default names
-	await dbHandle.evaluate((db) =>
-		Promise.all([db.warehouse().note("note-3").setName({}, "Note 3"), db.warehouse().note("note-4").setName({}, "Note 4")])
-	);
+	await dbHandle.evaluate((db) => db.warehouse().note("note-3").setName({}, "Note 3"));
+	await dbHandle.evaluate((db) => db.warehouse().note("note-4").setName({}, "Note 4"));
+
 	await content
 		.entityList("outbound-list")
-		.assertElements([{ name: "Note 1" }, { name: "Note 2" }, { name: "Note 3" }, { name: "Note 4" }]);
+		.assertElements([{ name: "Note 4" }, { name: "Note 3" }, { name: "Note 2" }, { name: "Note 1" }]);
 
 	// Create a new note (should reset the sequence)
 	await dbHandle.evaluate((db) => db.warehouse().note("note-5").create());
 	await content
 		.entityList("outbound-list")
-		.assertElements([{ name: "Note 1" }, { name: "Note 2" }, { name: "Note 3" }, { name: "Note 4" }, { name: "New Note" }]);
+		.assertElements([{ name: "New Note" }, { name: "Note 4" }, { name: "Note 3" }, { name: "Note 2" }, { name: "Note 1" }]);
 });
 
 test("should navigate to note page on 'edit' button click", async ({ page }) => {
@@ -189,18 +188,18 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 			.create()
 			.then((n) => n.setName({}, "Note 2"))
 	);
-	await content.entityList("outbound-list").assertElements([{ name: "Note 1" }, { name: "Note 2" }]);
+	await content.entityList("outbound-list").assertElements([{ name: "Note 2" }, { name: "Note 1" }]);
 
-	// Navigate to first note
-	await content.entityList("outbound-list").item(0).edit();
+	// Navigate to note 1
+	await content.entityList("outbound-list").item(1).edit();
 
 	// Check title
 	await dashboard.view("outbound-note").waitFor();
 	await content.header().title().assert("Note 1");
 
-	// Navigate back to outbond page and to second note
+	// Navigate back to outbond page and to note 2
 	await dashboard.navigate("outbound");
-	await content.entityList("outbound-list").item(1).edit();
+	await content.entityList("outbound-list").item(0).edit();
 
 	// Check title
 	await dashboard.view("outbound-note").waitFor();
@@ -232,8 +231,8 @@ test("should display book count for each respective note in the list", async ({ 
 
 	// Both should display 0 books
 	await content.entityList("outbound-list").assertElements([
-		{ name: "Note 1", numBooks: 0 },
-		{ name: "Note 2", numBooks: 0 }
+		{ name: "Note 2", numBooks: 0 },
+		{ name: "Note 1", numBooks: 0 }
 	]);
 
 	// Add two books to first note
@@ -255,8 +254,8 @@ test("should display book count for each respective note in the list", async ({ 
 	);
 
 	await content.entityList("outbound-list").assertElements([
-		{ name: "Note 1", numBooks: 2 },
-		{ name: "Note 2", numBooks: 3 }
+		{ name: "Note 2", numBooks: 3 },
+		{ name: "Note 1", numBooks: 2 }
 	]);
 });
 

--- a/apps/web-client/src/lib/utils/misc.ts
+++ b/apps/web-client/src/lib/utils/misc.ts
@@ -19,6 +19,16 @@ export const comparePaths = (...paths: [string, string]) => {
 	return trimmed[0] === trimmed[1];
 };
 
+export const compareNotes = <N extends { updatedAt?: string | Date | null }>({ updatedAt: a }: N, { updatedAt: b }: N) => {
+	if (!a) return 1;
+	if (!b) return -1;
+
+	const _a = typeof a === "string" ? a : a.toISOString();
+	const _b = typeof b === "string" ? b : b.toISOString();
+
+	return _a < _b ? 1 : -1;
+};
+
 export const mapMergeBookWarehouseData =
 	(ctx: debug.DebugCtx, entries: Iterable<any>, warehouseListStream: Observable<WarehouseDataMap>) =>
 	(books: Observable<Iterable<BookEntry | undefined>>): Observable<DailySummaryStore> =>

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -17,6 +17,7 @@
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
+	import { compareNotes } from "$lib/utils/misc";
 
 	import { appPath } from "$lib/paths";
 
@@ -35,6 +36,7 @@
 					.filter(([warehouseId]) => !warehouseId.includes("0-all"))
 					.flatMap(([warehouseId, { displayName, notes }]) => wrapIter(notes).map((note) => [displayName || warehouseId, note] as const))
 					.array()
+					.sort(([, [, a]], [, [, b]]) => compareNotes(a, b))
 			)
 		)!;
 	const inNoteList = readableFromStream(inNoteListCtx, inNoteListStream, []);

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -18,6 +18,7 @@
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { readableFromStream } from "$lib/utils/streams";
+	import { compareNotes } from "$lib/utils/misc";
 
 	import { appPath } from "$lib/paths";
 
@@ -27,8 +28,7 @@
 	const outNoteListStream = db
 		?.stream()
 		.outNoteList(outNoteListCtx)
-		/** @TODO we could probably wrap the Map to be ArrayLike (by having 'm.length' = 'm.size') */
-		.pipe(map((m) => [...m]));
+		.pipe(map((m) => [...m].sort(([, a], [, b]) => compareNotes(a, b))));
 	const outNoteList = readableFromStream(outNoteListCtx, outNoteListStream, []);
 
 	let initialized = false;

--- a/pkg/db/src/types/inventory.ts
+++ b/pkg/db/src/types/inventory.ts
@@ -244,7 +244,7 @@ export interface HistoryInterface {
 // #region db
 export type NavEntry<A = {}> = {
 	displayName: string;
-	updatedAt?: Date;
+	updatedAt?: string;
 	totalBooks?: number;
 } & A;
 


### PR DESCRIPTION
Fixes #439 

Sorted by `updatedAt` - this seemed the simplest, we can also sort by created date, but would have to add an additional `createdAt` field @silviot let me know your thoughts.