### PR TITLE
Enhancement/history view touchups

### DIFF
--- a/apps/web-client/src/lib/stores/inventory/history_entries.ts
+++ b/apps/web-client/src/lib/stores/inventory/history_entries.ts
@@ -114,8 +114,9 @@ export const createPastNotesStore: CreatePastNotesStores = (ctx, db, date: strin
 							const noteType = txn.noteType;
 							const warehouseName = noteType === "outbound" ? "Outbound" : txn.warehouseName;
 							const books = acc.books + txn.quantity;
-							const totalCoverPrice = acc.totalCoverPrice + txn.price * txn.quantity;
-							const totalDiscountedPrice = acc.totalDiscountedPrice + Math.floor(txn.price * txn.quantity * (100 - txn.discount)) / 100;
+							const totalCoverPrice = acc.totalCoverPrice + (txn.price || 0) * txn.quantity;
+							const totalDiscountedPrice =
+								acc.totalDiscountedPrice + Math.floor((txn.price || 0) * txn.quantity * (100 - txn.discount)) / 100;
 							return { id, date, displayName, noteType, warehouseName, books, totalCoverPrice, totalDiscountedPrice };
 						},
 						{ books: 0, totalCoverPrice: 0, totalDiscountedPrice: 0 } as PastNoteEntry

--- a/apps/web-client/src/lib/types/inventory.ts
+++ b/apps/web-client/src/lib/types/inventory.ts
@@ -65,6 +65,7 @@ export interface DailySummaryStore {
 export interface BookHistoryStores {
 	transactions: Readable<(PastTransaction & { warehouseName: string })[]>;
 	bookData: Readable<BookEntry>;
+	stock: Readable<{ warehouseId: string; quantity: number; warehouseName: string }[]>;
 }
 
 export interface PastNoteEntry {

--- a/apps/web-client/src/lib/utils/time.ts
+++ b/apps/web-client/src/lib/utils/time.ts
@@ -1,9 +1,14 @@
-export const generateUpdatedAtString = (updatedAt?: Date | string) =>
+export const generateUpdatedAtString = (updatedAt?: Date | string, mode?: "time-only") =>
 	updatedAt &&
-	new Date(updatedAt).toLocaleDateString("en", {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "numeric"
-	});
+	(mode === "time-only"
+		? new Date(updatedAt).toLocaleTimeString("en", {
+				hour: "2-digit",
+				minute: "numeric"
+		  })
+		: new Date(updatedAt).toLocaleDateString("en", {
+				year: "numeric",
+				month: "short",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "numeric"
+		  }));

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -18,6 +18,7 @@
 	import { getDB } from "$lib/db";
 
 	import { appPath } from "$lib/paths";
+	import { generateUpdatedAtString } from "$lib/utils/time";
 
 	export let data: PageData;
 
@@ -187,7 +188,9 @@
 
 						{#if committedAt}
 							<div class="col-span-10 row-span-1 xs:col-span-6 lg:col-span-3 lg:row-span-2">
-								<span class={`badge badge-sm ${noteType === "inbound" ? "badge-green" : "badge-red"}`}>Comitted At: {committedAt}</span>
+								<span class={`badge badge-sm ${noteType === "inbound" ? "badge-green" : "badge-red"}`}
+									>Comitted At: {generateUpdatedAtString(committedAt, "time-only")}</span
+								>
 							</div>
 						{/if}
 					</li>

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fade } from "svelte/transition";
 	import { melt, createDatePicker } from "@melt-ui/svelte";
-	import { Library, Calendar, ChevronRight, ChevronLeft } from "lucide-svelte";
+	import { Library, Calendar, ChevronRight, ChevronLeft, ArrowLeft, ArrowRight } from "lucide-svelte";
 	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
 
 	import { entityListView, testId } from "@librocco/shared";
@@ -134,13 +134,14 @@
 		<!-- Start entity list contaier -->
 
 		<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
-		<ul class={testId("entity-list-container")} data-view={entityListView("outbound-list")} data-loaded={true}>
+		<div class={testId("entity-list-container")} data-view={entityListView("outbound-list")} data-loaded={true}>
 			{#if !$dailySummary?.bookList?.length}
 				<!-- Start entity list placeholder -->
 				<PlaceholderBox title="No Books on that date" description="Try selecting a different date." class="center-absolute" />
 				<!-- End entity list placeholder -->
 			{:else}
-				<!-- Start entity list -->
+				<h2 class="px-4 py-4 pt-8 text-xl font-semibold">Stats</h2>
+
 				<div class="flex flex-row text-sm">
 					<div class="badge badge-green m-2 p-2 font-bold">
 						Inbound Book Count: {$dailySummary.stats.totalInboundBookCount}
@@ -152,6 +153,7 @@
 						Inbound Discounted Price : {$dailySummary.stats.totalInboundDiscountedPrice.toFixed(2)}
 					</div>
 				</div>
+
 				<div class="flex flex-row text-sm">
 					<div class="badge badge-red m-2 p-2 font-bold">
 						Outbound Book Count: {$dailySummary.stats.totalOutboundBookCount}
@@ -164,40 +166,65 @@
 					</div>
 				</div>
 
-				{#each $dailySummary.bookList as entry}
-					{@const title = entry.title}
-					{@const quantity = entry.quantity}
-					{@const warehouseName = entry.warehouseName}
-					{@const committedAt = entry.date}
-					{@const noteType = entry.noteType}
-					{@const noteName = entry.noteDisplayName}
-					{@const noteId = entry.noteId}
+				<h2 class="px-4 py-4 pt-8 text-xl font-semibold">Transactions</h2>
 
-					<li class="entity-list-row grid grid-flow-col grid-cols-12 items-center">
-						<div class="max-w-1/2 col-span-10 row-span-1 w-full xs:col-span-6 lg:row-span-2">
-							<p class="entity-list-text-lg text-gray-900">{title}</p>
+				<ul class="w-full divide-y divide-gray-300">
+					{#each $dailySummary.bookList as entry}
+						{@const isbn = entry.isbn}
+						{@const title = entry.title}
+						{@const quantity = entry.quantity}
+						{@const warehouseName = entry.warehouseName}
+						{@const committedAt = entry.date}
+						{@const noteType = entry.noteType}
+						{@const noteName = entry.noteDisplayName}
+						{@const noteId = entry.noteId}
 
-							<div class="flex items-center">
-								<Library class="mr-1 text-gray-700" size={20} />
-								<span class="entity-list-text-sm text-gray-500">{quantity} books - </span>
-								<span class="entity-list-text-sm text-gray-500"> {warehouseName}</span> (<a href={appPath("history/notes", noteId)}
-									><span>{noteName}</span></a
-								>)
-							</div>
-						</div>
+						<!--<div class="w-full text-gray-700">
+								<p class="mt-2 mb-1 text-sm font-semibold leading-none text-gray-900">{isbn}</p>
+								<p class="mb-1 text-2xl">{title}</p>
+							</div>-->
 
-						{#if committedAt}
-							<div class="col-span-10 row-span-1 xs:col-span-6 lg:col-span-3 lg:row-span-2">
-								<span class={`badge badge-sm ${noteType === "inbound" ? "badge-green" : "badge-red"}`}
-									>Comitted At: {generateUpdatedAtString(committedAt, "time-only")}</span
+						<li
+							class="entity-list-row grid w-full w-full grid-cols-2 items-center gap-y-3 gap-x-4 py-6 text-gray-800 sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
+						>
+							<p class="text-xl font-medium leading-none text-gray-900 lg:col-span-3 xl:col-span-2">{isbn}</p>
+							<p class="col-span-2 overflow-hidden whitespace-nowrap text-xl font-medium lg:col-span-5 xl:col-span-3">
+								{title || ""}
+							</p>
+							<p class="lg:order-4 xl:order-none xl:col-span-2">
+								<span class="badge badge-md {noteType === 'inbound' ? 'badge-green' : 'badge-red'}">
+									Committed: {generateUpdatedAtString(committedAt, "time-only")}
+								</span>
+							</p>
+
+							<div class="col-span-2 flex items-center lg:col-span-4 lg:col-start-9 xl:col-span-4 xl:col-start-9">
+								<div class="flex items-center">
+									<Library class="mr-1" size={20} />
+									<p class="entity-list-text-sm">{warehouseName}</p>
+								</div>
+
+								<a
+									href={appPath("history/notes", noteId)}
+									class="{noteType === 'outbound'
+										? 'text-red-700'
+										: 'text-green-700'} mx-4 flex items-center rounded-sm border bg-gray-50 py-0.5 px-3 hover:font-semibold"
 								>
+									{#if noteType === "inbound"}
+										<p><ArrowLeft size={16} /></p>
+										<p>{quantity}</p>
+									{:else}
+										<p>{quantity}</p>
+										<p><ArrowRight size={16} /></p>
+									{/if}
+									<p class="ml-2">{noteName}</p>
+								</a>
 							</div>
-						{/if}
-					</li>
-				{/each}
+						</li>
+					{/each}
+				</ul>
 				<!-- End entity list -->
 			{/if}
-		</ul>
+		</div>
 		<!-- End entity list contaier -->
 	</svelte:fragment>
 </HistoryPage>

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -33,16 +33,15 @@
 	$: entries = bookSearch.entries;
 
 	// Create search element actions (and state) and bind the state to the search state of the search store
-	const { input, dropdown, value, open } = createSearchDropdown();
+	const { input, dropdown, value, open } = createSearchDropdown({ onConfirmSelection: (isbn) => goto(appPath("history/isbn", isbn)) });
 	$: $search = $value;
-	// #endregion search
 	// #endregion search
 </script>
 
 <HistoryPage view="history/isbn">
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		<Search {...iconProps} />
-		<input use:input placeholder="Search" {...inputProps} />
+		<input autofocus use:input placeholder="Search" {...inputProps} />
 	</svelte:fragment>
 
 	<svelte:fragment slot="heading">

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -3,7 +3,7 @@
 
 	import { page } from "$app/stores";
 
-	import type { BookEntry, SearchIndex } from "@librocco/db";
+	import type { BookEntry, SearchIndex, VolumeStockClient } from "@librocco/db";
 	import { entityListView, testId } from "@librocco/shared";
 
 	import { appPath } from "$lib/paths";
@@ -27,6 +27,7 @@
 
 	$: bookData = stores.bookData;
 	$: transactions = stores.transactions;
+	$: stock = stores.stock;
 
 	const createMetaString = ({ authors, year, publisher }: Partial<Pick<BookEntry, "authors" | "year" | "publisher">>) =>
 		[authors, year, publisher].filter(Boolean).join(", ");
@@ -63,77 +64,102 @@
 			<!--text-2xl font-bold leading-7 text-gray-900-->
 			<h1 class="mt-2 mb-1 text-sm font-semibold leading-none text-gray-900">{isbn}</h1>
 			{#if $bookData}
-				<p class="mb-1 text-2xl">
+				<p class="mb-1 min-h-[32px] text-2xl">
 					{#if $bookData.title}<span class="font-bold">{$bookData.title}, </span>{/if}
 					{#if $bookData.authors}<span>{$bookData.authors}</span>{/if}
 				</p>
-				<p>{`${$bookData.year}, ` || ""}{$bookData.publisher || ""}</p>
+				<p>
+					{#if $bookData.year}{`${$bookData.year}, ` || ""}{/if}
+					{#if $bookData.publisher}{$bookData.publisher || ""}{/if}
+				</p>
 			{/if}
 		</div>
 	</svelte:fragment>
 
 	<svelte:fragment slot="main">
-		<!-- Start entity list contaier -->
+		<div class="overflow-y-auto">
+			<!-- Start entity list contaier -->
 
-		<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
-		<div class={testId("entity-list-container")} data-view={entityListView("outbound-list")} data-loaded={true}>
-			{#if !$transactions?.length}
-				<!-- Start entity list placeholder -->
-				<PlaceholderBox
-					title="No transactions found"
-					description="There seems to be no record for transactions of the given isbn volumes going in or out"
-					class="center-absolute"
-				/>
-				<!-- End entity list placeholder -->
-			{:else}
-				<ul class="grid w-full grid-cols-12 divide-y">
-					{#each $transactions as txn}
-						{@const quantity = txn.quantity}
-						{@const noteId = txn.noteId}
-						{@const noteName = txn.noteDisplayName}
-						{@const noteType = txn.noteType}
-						{@const committedAt = txn.date}
-						{@const warehouseName = txn.warehouseName}
+			<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
+			<div class={testId("entity-list-container")} data-view={entityListView("outbound-list")} data-loaded={true}>
+				<div class="border-b border-gray-300">
+					<h2 class="border-b border-gray-300 px-4 py-4 pt-8 text-xl font-semibold">Stock</h2>
 
-						<li class="col-span-12 grid grid-cols-12">
-							<div class="entity-list-row col-span-8 grid grid-cols-8 items-center text-gray-800">
-								<p class="col-span-2">
-									{generateUpdatedAtString(committedAt)}
+					<div class="divide grid grid-cols-4 gap-x-24 gap-y-4 p-4">
+						{#each $stock as s}
+							<div class="flex items-center justify-between">
+								<p class="flex items-center">
+									<Library class="mr-1" size={20} />
+									<span class="entity-list-text-sm mr-4">{s.warehouseName}</span>
 								</p>
 
-								<div class="col-span-2 flex items-center">
-									<Library class="mr-1" size={20} />
-									<p class="entity-list-text-sm">{warehouseName}</p>
-								</div>
+								<p class="rounded border border-gray-500 bg-gray-100 py-0.5 px-2">{s.quantity}</p>
+							</div>
+						{/each}
+					</div>
+				</div>
 
-								<a href={appPath("history/notes", noteId)} class="col-span-4 flex items-center">
-									<div class="{noteType === 'outbound' ? 'badge-red' : 'badge-green'} mx-4 flex items-center rounded-sm px-3">
-										{#if noteType === "inbound"}
-											<p><ArrowLeft size={16} /></p>
-											<p>{quantity}</p>
-										{:else}
-											<p>{quantity}</p>
-											<p><ArrowRight size={16} /></p>
-										{/if}
+				{#if !$transactions?.length}
+					<!-- Start entity list placeholder -->
+					<PlaceholderBox
+						title="No transactions found"
+						description="There seems to be no record for transactions of the given isbn volumes going in or out"
+						class="center-absolute"
+					/>
+					<!-- End entity list placeholder -->
+				{:else}
+					<div class="sticky top-0">
+						<h2 class="border-b border-gray-300 bg-white px-4 py-4 pt-8 text-xl font-semibold">Transactions</h2>
+					</div>
+					<ul class="grid w-full grid-cols-12 divide-y">
+						{#each $transactions as txn}
+							{@const quantity = txn.quantity}
+							{@const noteId = txn.noteId}
+							{@const noteName = txn.noteDisplayName}
+							{@const noteType = txn.noteType}
+							{@const committedAt = txn.date}
+							{@const warehouseName = txn.warehouseName}
+
+							<li class="col-span-12 grid grid-cols-12">
+								<div class="entity-list-row col-span-8 grid grid-cols-8 items-center text-gray-800">
+									<p class="col-span-2">
+										{generateUpdatedAtString(committedAt)}
+									</p>
+
+									<div class="col-span-2 flex items-center">
+										<Library class="mr-1" size={20} />
+										<p class="entity-list-text-sm">{warehouseName}</p>
 									</div>
 
-									<p>{noteName}</p>
-								</a>
-							</div>
-						</li>
-					{/each}
-				</ul>
-				<!-- End entity list -->
-			{/if}
-		</div>
+									<a href={appPath("history/notes", noteId)} class="col-span-4 flex items-center">
+										<div class="{noteType === 'outbound' ? 'badge-red' : 'badge-green'} mx-4 flex items-center rounded-sm px-3">
+											{#if noteType === "inbound"}
+												<p><ArrowLeft size={16} /></p>
+												<p>{quantity}</p>
+											{:else}
+												<p>{quantity}</p>
+												<p><ArrowRight size={16} /></p>
+											{/if}
+										</div>
 
-		<!-- End entity list contaier -->
+										<p>{noteName}</p>
+									</a>
+								</div>
+							</li>
+						{/each}
+					</ul>
+					<!-- End entity list -->
+				{/if}
+			</div>
+
+			<!-- End entity list contaier -->
+		</div>
 	</svelte:fragment>
 </HistoryPage>
 
 {#if $open && $entries?.length}
 	<div use:dropdown>
-		<ul class="w-full divide-y overflow-y-auto rounded border bg-white shadow-2xl">
+		<ul class="w-full divide-y overflow-y-auto rounded border border-gray-300 bg-white shadow-2xl">
 			{#each $entries as { isbn, title, authors, year, publisher }}
 				<li on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))} class="w-full cursor-pointer px-4 py-3">
 					<p class="mt-2 text-sm font-semibold leading-none text-gray-900">{isbn}</p>

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -22,7 +22,7 @@
 
 	$: isbn = $page.params.isbn;
 
-	const dailySummaryCtx = { name: "[BOOK_HISTORY]", debug: true };
+	const dailySummaryCtx = { name: "[BOOK_HISTORY]", debug: false };
 	$: stores = createBookHistoryStores(dailySummaryCtx, db, isbn);
 
 	$: bookData = stores.bookData;
@@ -45,7 +45,7 @@
 	$: entries = bookSearch.entries;
 
 	// Create search element actions (and state) and bind the state to the search state of the search store
-	const { input, dropdown, value, open } = createSearchDropdown();
+	const { input, dropdown, value, open } = createSearchDropdown({ onConfirmSelection: (isbn) => goto(appPath("history/isbn", isbn)) });
 	$: $search = $value;
 	// #endregion search
 </script>
@@ -53,7 +53,9 @@
 <HistoryPage view="history/isbn">
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		<Search {...iconProps} />
-		<input use:input placeholder="Search" {...inputProps} />
+		{#key isbn}
+			<input autofocus use:input placeholder="Search" {...inputProps} />
+		{/key}
 	</svelte:fragment>
 
 	<svelte:fragment slot="heading">

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -144,25 +144,29 @@
 					{@const totalBooks = note.books}
 					{@const href = appPath("history/notes", note.id)}
 
-					<div class="entity-list-row group">
-						<div class="flex flex-col gap-y-2">
-							<a {href} class="entity-list-text-lg text-gray-900 hover:underline focus:underline">{displayName}</a>
+					<div class="group entity-list-row">
+						<div class="block w-full">
+							<a {href} class="entity-list-text-lg mb-2 block text-gray-900 hover:underline focus:underline">{displayName}</a>
 
-							<div class="flex flex-col items-start gap-y-2">
-								<div class="flex gap-x-0.5">
+							<div class="grid w-full grid-cols-4 items-start gap-2 lg:grid-cols-8">
+								<div class="order-1 col-span-2 flex gap-x-0.5 lg:col-span-1">
 									<Library class="mr-1 text-gray-700" size={24} />
 									<span class="entity-list-text-sm text-gray-500">{totalBooks} books</span>
 								</div>
 
-								<p class="text-gray-500">Total cover price: <span class="text-gray-700">{note.totalCoverPrice.toFixed(2)}</span></p>
-
-								<p class="text-gray-500">
-									Total discounted price: <span class="text-gray-700">{note.totalDiscountedPrice.toFixed(2)}</span>
+								<p class="order-2 col-span-2 text-gray-500 lg:order-3">
+									Total cover price: <span class="text-gray-700">{note.totalCoverPrice.toFixed(2)}</span>
 								</p>
 
-								<span class="badge badge-md {note.noteType === 'inbound' ? 'badge-green' : 'badge-red'}">
-									Committed: {generateUpdatedAtString(note.date, "time-only")}
-								</span>
+								<p class="order-3 col-span-2 lg:order-2">
+									<span class="badge badge-md {note.noteType === 'inbound' ? 'badge-green' : 'badge-red'}">
+										Committed: {generateUpdatedAtString(note.date, "time-only")}
+									</span>
+								</p>
+
+								<p class="order-4 col-span-2 text-gray-500">
+									Total discounted price: <span class="text-gray-700">{note.totalDiscountedPrice.toFixed(2)}</span>
+								</p>
 							</div>
 						</div>
 					</div>

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -144,7 +144,7 @@
 					{@const totalBooks = note.books}
 					{@const href = appPath("history/notes", note.id)}
 
-					<div class="group entity-list-row">
+					<div class="entity-list-row group">
 						<div class="flex flex-col gap-y-2">
 							<a {href} class="entity-list-text-lg text-gray-900 hover:underline focus:underline">{displayName}</a>
 

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -161,7 +161,7 @@
 								</p>
 
 								<span class="badge badge-md {note.noteType === 'inbound' ? 'badge-green' : 'badge-red'}">
-									Committed: {note.date}
+									Committed: {generateUpdatedAtString(note.date, "time-only")}
 								</span>
 							</div>
 						</div>

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -1772,7 +1772,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				isbn: "11111111",
 				quantity: 2,
 				warehouseId: warehouse1._id,
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				noteType: "inbound",
 				noteId: note1._id,
 				noteDisplayName: note1.displayName
@@ -1780,7 +1780,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			{
 				isbn: "22222222",
 				quantity: 2,
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				noteType: "inbound",
 				warehouseId: warehouse1._id,
 				noteId: note1._id,
@@ -1789,7 +1789,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			{
 				isbn: "11111111",
 				quantity: 2,
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				noteType: "inbound",
 				warehouseId: warehouse2._id,
 				noteId: note2._id,
@@ -1798,7 +1798,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			{
 				isbn: "22222222",
 				quantity: 2,
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				noteType: "inbound",
 				warehouseId: warehouse2._id,
 				noteId: note2._id,
@@ -1823,7 +1823,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				isbn: "11111111",
 				quantity: 1,
 				noteType: "outbound",
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				warehouseId: warehouse1._id,
 				noteId: note3._id,
 				noteDisplayName: note3.displayName
@@ -1832,7 +1832,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				isbn: "22222222",
 				quantity: 1,
 				noteType: "outbound",
-				date: slicedDate,
+				date: expect.stringContaining(slicedDate),
 				warehouseId: warehouse2._id,
 				noteId: note3._id,
 				noteDisplayName: note3.displayName

--- a/pkg/db/src/implementations/version-1.2/inventory-db.ts
+++ b/pkg/db/src/implementations/version-1.2/inventory-db.ts
@@ -126,10 +126,6 @@ class Database implements InventoryDatabaseInterface {
 		return newDbReplicator(this);
 	}
 
-	stock(): Observable<StockMap> {
-		return this.#stockStream;
-	}
-
 	getStock(): Promise<StockMap> {
 		return newStock(this).query();
 	}
@@ -241,7 +237,9 @@ class Database implements InventoryDatabaseInterface {
 		return {
 			warehouseMap: (ctx: debug.DebugCtx) => this.#warehouseMapStream.pipe(tap(debug.log(ctx, "db:warehouse_list:stream"))),
 			outNoteList: (ctx: debug.DebugCtx) => this.#outNoteListStream.pipe(tap(debug.log(ctx, "db:out_note_list:stream"))),
-			inNoteList: (ctx: debug.DebugCtx) => this.#inNoteListStream.pipe(tap(debug.log(ctx, "db:in_note_list:stream")))
+			inNoteList: (ctx: debug.DebugCtx) => this.#inNoteListStream.pipe(tap(debug.log(ctx, "db:in_note_list:stream"))),
+
+			stock: () => this.#stockStream
 		};
 	}
 }

--- a/pkg/db/src/implementations/version-1.2/note.ts
+++ b/pkg/db/src/implementations/version-1.2/note.ts
@@ -607,7 +607,7 @@ class Note implements NoteInterface {
 						)
 					),
 					this.#db.stream().warehouseMap(ctx),
-					this.#db.stock()
+					this.#db.stream().stock()
 				]).pipe(
 					tap(debug.log(ctx, "note:entries:stream:input")),
 					map(

--- a/pkg/db/src/implementations/version-1.2/note.ts
+++ b/pkg/db/src/implementations/version-1.2/note.ts
@@ -497,7 +497,7 @@ class Note implements NoteInterface {
 				}
 			}
 		}
-		const committedAt = new Date().toISOString().slice(0, 10);
+		const committedAt = new Date().toISOString();
 
 		return this.update(ctx, { committed: true, committedAt });
 	}

--- a/pkg/db/src/implementations/version-1.2/types.ts
+++ b/pkg/db/src/implementations/version-1.2/types.ts
@@ -33,7 +33,6 @@ export type WarehouseData = WD;
 export type WarehouseInterface = WI<NoteInterface>;
 export type InventoryDatabaseInterface = IDI<WarehouseInterface, NoteInterface> & {
 	view<R extends MapReduceRow, M extends CouchDocument = CouchDocument>(name: string): ViewInterface<R, M>;
-	stock: () => Observable<StockMap>;
 	getStock: () => Promise<StockMap>;
 	getWarehouseDataMap: () => Promise<WarehouseDataMap>;
 };

--- a/pkg/db/src/implementations/version-1.2/warehouse.ts
+++ b/pkg/db/src/implementations/version-1.2/warehouse.ts
@@ -70,10 +70,13 @@ class Warehouse implements WarehouseInterface {
 		);
 
 		const stockCache = new ReplaySubject<StockMap>(1);
-		this.#stock = this.#db.stock().pipe(
-			map((stock) => stock.warehouse(this._id)),
-			share({ connector: () => stockCache, resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
-		);
+		this.#stock = this.#db
+			.stream()
+			.stock()
+			.pipe(
+				map((stock) => stock.warehouse(this._id)),
+				share({ connector: () => stockCache, resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
+			);
 
 		// The first value from the stream will be either warehouse data, or an empty object (if the warehouse doesn't exist in the db).
 		// This is enough to signal that the warehouse intsance is initialised.

--- a/pkg/db/src/types/inventory.ts
+++ b/pkg/db/src/types/inventory.ts
@@ -2,7 +2,7 @@
 import type { Observable } from "rxjs";
 import PouchDB from "pouchdb";
 
-import { NoteState, VolumeStock, VolumeStockKind, debug } from "@librocco/shared";
+import { NoteState, StockMap, VolumeStock, VolumeStockKind, debug } from "@librocco/shared";
 
 import type { DatabaseInterface as BaseDatabaseInterface, BooksInterface, CouchDocument, PickPartial } from "./misc";
 
@@ -278,6 +278,8 @@ export interface DbStream {
 	warehouseMap: (ctx: debug.DebugCtx) => Observable<WarehouseDataMap>;
 	outNoteList: (ctx: debug.DebugCtx) => Observable<NavMap>;
 	inNoteList: (ctx: debug.DebugCtx) => Observable<InNoteMap>;
+
+	stock: () => Observable<StockMap>;
 }
 
 /**


### PR DESCRIPTION
I've crammed a lot in here (sorry):

- update the way the date is shown in history views: show only the time of day in date summary and past notes (by day)
- small fix: fall back to 0 for non existing book prices (to prevent NaN result)
- condense the data in daily summary and past notes to shrink the rows (and be able to display more rows)
- when searching for isbn in history view, navigate to isbn past transactions on enter press
- auto focus the search field on isbn past transactions view
- display book availability across warehouses in isbn past transactions view

Fixes #465 

Some bugs:
- in "by ISBN" history view: if we type in the same isbn (as the one currently opened), there's some weird behaviour, but this is an edge case, simple page reload will do the trick, I've spent too much time trying to fix that, while keeping the autofocus on page load and isbn switch