### PR TITLE
exclude empty '_rev' for new documents when upserting book data

### DIFF
--- a/pkg/db/src/implementations/version-1.2/books.ts
+++ b/pkg/db/src/implementations/version-1.2/books.ts
@@ -50,7 +50,7 @@ class Books implements BooksInterface {
 		const updates = wrapIter(docsToUpsert)
 			.map((doc) => ({ _id: `books/${doc.isbn}`, ...doc }))
 			.zip(docs)
-			.map(([update, existing = { _rev: "" }]) => ({ ...existing, ...update }));
+			.map(([update, existing = {}]) => ({ ...existing, ...update }));
 
 		await this.#db._pouch.bulkDocs([...updates]);
 	}


### PR DESCRIPTION
Fixes #440 
The stupidest thing: PouchDB accepts `_rev:""` for when no rev number exists. CouchDB, however, doesn't. We've been using `_rev: ""` for `books.upsert` entries that don't yet exist. Removing that fixed the issue with staging/production DB.