### PR TITLE
Fix/history isbn search fixes

### DIFF
--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -199,13 +199,14 @@ test("should delete the transaction from the note when when selected for deletio
 test("transaction should default to the only warehouse the given book is available in if there is only one", async ({ page }) => {
 	// Setup: Add the book to the warehouse (through an inbound note)
 	const dbHandle = await getDbHandle(page);
-	await dbHandle.evaluate(async (db) => {
-		db.warehouse("wh-1")
+	await dbHandle.evaluate((db) =>
+		db
+			.warehouse("wh-1")
 			.setName({}, "Warehouse 1")
 			.then((wh) => wh.note().create())
 			.then((n) => n.addVolumes({ isbn: "1234567890", quantity: 1 }))
-			.then((n) => n.commit({}));
-	});
+			.then((n) => n.commit({}))
+	);
 
 	const content = getDashboard(page).content();
 

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -76,7 +76,7 @@
 			{#each $entries as { isbn, title, authors, year, publisher }}
 				<li on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))} class="w-full cursor-pointer px-4 py-3">
 					<p class="mt-2 text-sm font-semibold leading-none text-gray-900">{isbn}</p>
-					<p class="text-xl font-medium">{title}</p>
+					<p class="text-xl font-medium">{title || "Unknown Title"}</p>
 					<p>{createMetaString({ authors, year, publisher })}</p>
 				</li>
 			{/each}

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -10,9 +10,10 @@
 	import { HistoryPage, PlaceholderBox } from "$lib/components";
 	import { getDB } from "$lib/db";
 
-	import { createFilteredEntriesStore } from "$lib/stores/proto/search";
+	import { createSearchStore } from "$lib/stores/proto/search";
 	import { createSearchDropdown } from "./[isbn]/actions";
 	import { goto } from "$app/navigation";
+	import { browser } from "$app/environment";
 
 	const db = getDB();
 
@@ -27,10 +28,11 @@
 	db?.books()
 		.streamSearchIndex()
 		.subscribe((ix) => (index = ix));
+	$: if (browser) window["_search_index"] = index;
 
-	$: bookSearch = createFilteredEntriesStore({ name: "[SEARCH]", debug: false }, db, index);
-	$: search = bookSearch.search;
-	$: entries = bookSearch.entries;
+	$: bookSearch = createSearchStore({ name: "[SEARCH]", debug: false }, index);
+	$: search = bookSearch.searchStore;
+	$: entries = bookSearch.searchResStore;
 
 	// Create search element actions (and state) and bind the state to the search state of the search store
 	const { input, dropdown, value, open } = createSearchDropdown({ onConfirmSelection: (isbn) => goto(appPath("history/isbn", isbn)) });

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -3,7 +3,7 @@
 
 	import { page } from "$app/stores";
 
-	import type { BookEntry, SearchIndex, VolumeStockClient } from "@librocco/db";
+	import type { BookEntry, SearchIndex } from "@librocco/db";
 	import { entityListView, testId } from "@librocco/shared";
 
 	import { appPath } from "$lib/paths";
@@ -12,7 +12,7 @@
 	import { getDB } from "$lib/db";
 
 	import { createBookHistoryStores } from "$lib/stores/inventory/history_entries";
-	import { createFilteredEntriesStore } from "$lib/stores/proto/search";
+	import { createSearchStore } from "$lib/stores/proto/search";
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
 	import { goto } from "$app/navigation";
@@ -41,9 +41,9 @@
 		.streamSearchIndex()
 		.subscribe((ix) => (index = ix));
 
-	$: bookSearch = createFilteredEntriesStore({ name: "[SEARCH]", debug: false }, db, index);
-	$: search = bookSearch.search;
-	$: entries = bookSearch.entries;
+	$: bookSearch = createSearchStore({ name: "[SEARCH]", debug: false }, index);
+	$: search = bookSearch.searchStore;
+	$: entries = bookSearch.searchResStore;
 
 	// Create search element actions (and state) and bind the state to the search state of the search store
 	const { input, dropdown, value, open } = createSearchDropdown({ onConfirmSelection: (isbn) => goto(appPath("history/isbn", isbn)) });

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -230,6 +230,10 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			expect(entries).toEqual([]);
 		});
 
+		// There is no book data for isbns we're about to add
+		let bookData = await db.books().get(["0123456789", "11111111"]);
+		expect(bookData).toEqual([undefined, undefined]);
+
 		// Adding volumes should add transactions to the note
 		await note.addVolumes(
 			{ isbn: "0123456789", quantity: 2, warehouseId: wh1._id },
@@ -268,6 +272,10 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				}
 			]);
 		});
+
+		// Adding volumes to the note should also create (empty: isbn-only) book data entries for added volumes
+		bookData = await db.books().get(["0123456789", "11111111"]);
+		await waitFor(() => expect(bookData).toEqual([{ isbn: "0123456789" }, { isbn: "11111111" }]));
 
 		// Adding volumes to the same ISBN/warheouseId pair should simply aggregate the quantities
 		await note.addVolumes(

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -275,6 +275,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 
 		// Adding volumes to the note should also create (empty: isbn-only) book data entries for added volumes
 		bookData = await db.books().get(["0123456789", "11111111"]);
+
 		await waitFor(() => expect(bookData).toEqual([{ isbn: "0123456789" }, { isbn: "11111111" }]));
 
 		// Adding volumes to the same ISBN/warheouseId pair should simply aggregate the quantities

--- a/pkg/shared/src/generators.ts
+++ b/pkg/shared/src/generators.ts
@@ -33,6 +33,24 @@ export function _group<T, K, V>(iterable: Iterable<T>, selector: (entry: T) => [
 	});
 }
 
+export function _unique<T extends Record<string, any>>(iterable: Iterable<T>, key: keyof T): Set<T>;
+export function _unique<T>(iterable: Iterable<T>, selector: (x: T) => any): Set<T>;
+export function _unique<T>(iterable: Iterable<T>): Set<T>;
+export function _unique<T>(...params: any[]): Set<T> {
+	if (params.length == 1) {
+		const [iter] = params as [Iterable<T>];
+		return new Set(iter);
+	}
+
+	if (typeof params[1] === "string") {
+		const [iter, selector] = params as [Iterable<Record<string, any>>, string];
+		return _unique(iter, (x) => x[selector]) as Set<T>;
+	}
+
+	const [iter, selector] = params as [Iterable<T>, (x: T) => any];
+	return _unique(iter, selector);
+}
+
 export function filter<T, S extends T>(iterable: Iterable<T>, predicate: (value: T) => value is S): ReusableGenerator<S>;
 export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): ReusableGenerator<T>;
 export function filter<T>(iterable: Iterable<T>, predicate: (value: T) => boolean): ReusableGenerator<T> {


### PR DESCRIPTION
Fixes #469 
Fixes #468 

In order to display existing isbns, even for entries for which there's no data, I've made it so that each time `note.addVolumes` is called, if there's no entry for a book, one will be created with empty data `{isbn: string}`.

I know @silviot is generally against automatically adding data, but this merely creates an entry (only the first time the isbn is encountered).