### PR TITLE
google books data fetcher: when fetching data, get cetegory as well

### DIFF
--- a/plugins/google-books-api/src/index.ts
+++ b/plugins/google-books-api/src/index.ts
@@ -3,7 +3,13 @@ import { BehaviorSubject } from "rxjs";
 import { type BookFetcherPlugin, type BookEntry } from "@librocco/db";
 
 const baseurl = "https://www.googleapis.com/books/v1/volumes";
-const reqFields = ["volumeInfo/title", "volumeInfo/authors", "volumeInfo/publisher", "volumeInfo/publishedDate"].join(",");
+const reqFields = [
+	"volumeInfo/title",
+	"volumeInfo/authors",
+	"volumeInfo/publisher",
+	"volumeInfo/publishedDate",
+	"volumeInfo/categories"
+].join(",");
 
 export function createGoogleBooksApiPlugin(): BookFetcherPlugin {
 	// The plugin is always available (as long as there's internet connection)
@@ -22,6 +28,7 @@ type GBookEntry = {
 		authors?: string[];
 		publisher?: string;
 		publishedDate?: string;
+		categories?: string[];
 	};
 };
 
@@ -49,7 +56,8 @@ function processResponse(gBook: GBookEntry | undefined): Partial<BookEntry> | un
 
 	const res: Partial<BookEntry> = {};
 
-	const { title, authors: _authors, publisher, publishedDate } = gBook.volumeInfo;
+	// TODO: We're picking the first category, whereas google books can return multiple categories, find a way to handle this
+	const { title, authors: _authors, publisher, publishedDate, categories: [category] = [] } = gBook.volumeInfo;
 	const authors = _authors?.join(", ");
 	const year = publishedDate?.slice(0, 4);
 
@@ -57,6 +65,7 @@ function processResponse(gBook: GBookEntry | undefined): Partial<BookEntry> | un
 	if (authors) res.authors = authors;
 	if (publisher) res.publisher = publisher;
 	if (year) res.year = year;
+	if (category) res.category = category;
 
 	return res;
 }


### PR DESCRIPTION
Fixes #467 
When fetching book data using google books api, also fetches categories. 
**However:**
- our data structure allows for only one category - for initial implementation we're just taking the first category from the response, it might be good to replace `category` with `categories`
- I would challenge the correctness of the response as Google Books classifies "The Prince" by Machiavelli as "Fiction", for instance