### PR TITLE
warehouse history + csv

### DIFF
--- a/apps/web-client/src/lib/components/CalendarPicker.svelte
+++ b/apps/web-client/src/lib/components/CalendarPicker.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { getLocalTimeZone, now, type DateValue } from "@internationalized/date";
+	import { createDatePicker, melt } from "@melt-ui/svelte";
+	import { Calendar, ChevronLeft, ChevronRight } from "lucide-svelte";
+	import { fade } from "svelte/transition";
+
+	export let defaultValue: DateValue = now(getLocalTimeZone());
+	export let onValueChange: (args: { curr: DateValue; next: DateValue }) => DateValue = ({ next }) => next;
+	let checkIsDateDisabled: (date: DateValue) => boolean = () => false;
+	export { checkIsDateDisabled as isDateDisabled };
+
+	const {
+		elements: { calendar, cell, content, field, grid, heading, nextButton, prevButton, segment, trigger },
+		states: { months, headingValue, weekdays, segmentContentsObj, open },
+		helpers: { isDateDisabled, isDateUnavailable }
+		// create a ZonedDateTime object with the current date and time
+	} = createDatePicker({
+		// 'date' param should always be defined as the route doesn't render without the date param
+		defaultValue,
+		isDateDisabled: checkIsDateDisabled,
+		onValueChange,
+		preventDeselect: true
+	});
+
+	// segments
+	$: day = $segmentContentsObj.day;
+	$: month = $segmentContentsObj.month;
+	$: year = $segmentContentsObj.year;
+	$: hour = $segmentContentsObj.hour;
+	$: minute = $segmentContentsObj.minute;
+	$: dayPeriod = $segmentContentsObj.dayPeriod;
+</script>
+
+<div>
+	<div
+		class="mt-1.5 flex w-full min-w-[200px] items-center gap-x-1 rounded-lg border border-gray-400 bg-gray-50 p-1.5 px-4 text-gray-600"
+		use:melt={$field}
+	>
+		<p class="flex items-center gap-x-0.5">
+			<span use:melt={$segment("day")}>{day}</span>
+			<span>/</span>
+			<span use:melt={$segment("month")}>{month}</span>
+			<span>/</span>
+			<span use:melt={$segment("year")}>{year},</span>
+		</p>
+
+		<p class="flex items-center">
+			<span use:melt={$segment("hour")}>{hour}</span>
+			<span>:</span>
+			<span use:melt={$segment("minute")}>{minute}</span>
+			<span class="ml-1 block" use:melt={$segment("dayPeriod")}>{dayPeriod}</span>
+		</p>
+
+		<button class="rounded-md p-1 text-gray-600 transition-all" use:melt={$trigger}>
+			<Calendar size={20} />
+		</button>
+	</div>
+</div>
+{#if $open}
+	<div class="z-10 min-w-[320px] rounded-lg bg-white shadow-sm" transition:fade={{ duration: 100 }} use:melt={$content}>
+		<div class="w-full rounded-lg bg-white p-3 text-gray-600 shadow-sm" use:melt={$calendar}>
+			<header class="flex items-center justify-between pb-2">
+				<button class="rounded-lg p-1 transition-all" use:melt={$prevButton}>
+					<ChevronLeft size={24} />
+				</button>
+				<div class="flex items-center gap-6" use:melt={$heading}>
+					{$headingValue}
+				</div>
+				<button class="rounded-lg p-1 transition-all" use:melt={$nextButton}>
+					<ChevronRight size={24} />
+				</button>
+			</header>
+			<div>
+				{#each $months as month}
+					<table class="w-full" use:melt={$grid}>
+						<thead aria-hidden="true">
+							<tr>
+								{#each $weekdays as day}
+									<th class="text-sm font-semibold">
+										<div class="flex h-6 w-6 items-center justify-center p-4">
+											{day}
+										</div>
+									</th>
+								{/each}
+							</tr>
+						</thead>
+						<tbody>
+							{#each month.weeks as weekDates}
+								<tr>
+									{#each weekDates as date}
+										<td role="gridcell" aria-disabled={$isDateDisabled(date) || $isDateUnavailable(date)}>
+											<div use:melt={$cell(date, month.value)}>
+												{date.day}
+											</div>
+										</td>
+									{/each}
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	[data-melt-calendar-prevbutton][data-disabled] {
+		@apply pointer-events-none rounded-lg p-1 opacity-40;
+	}
+
+	[data-melt-calendar-nextbutton][data-disabled] {
+		@apply pointer-events-none rounded-lg p-1 opacity-40;
+	}
+
+	[data-melt-calendar-heading] {
+		@apply font-semibold;
+	}
+
+	[data-melt-calendar-grid] {
+		@apply w-full;
+	}
+
+	[data-melt-calendar-cell] {
+		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg  p-4;
+	}
+
+	[data-melt-calendar-cell][data-disabled] {
+		@apply pointer-events-none opacity-40;
+	}
+	[data-melt-calendar-cell][data-unavailable] {
+		@apply pointer-events-none text-red-400 line-through;
+	}
+
+	[data-melt-calendar-cell][data-selected] {
+		@apply bg-teal-400 text-base;
+	}
+
+	[data-melt-calendar-cell][data-outside-visible-months] {
+		@apply pointer-events-none cursor-default opacity-40;
+	}
+
+	[data-melt-calendar-cell][data-outside-month] {
+		@apply pointer-events-none cursor-default opacity-0;
+	}
+</style>

--- a/apps/web-client/src/lib/components/CalendarPicker.svelte
+++ b/apps/web-client/src/lib/components/CalendarPicker.svelte
@@ -33,7 +33,7 @@
 
 <div>
 	<div
-		class="mt-1.5 flex w-full min-w-[200px] items-center gap-x-1 rounded-lg border border-gray-400 bg-gray-50 p-1.5 px-4 text-gray-600"
+		class="mt-1.5 flex min-w-[200px] items-center gap-x-1 rounded-lg border border-gray-400 bg-gray-50 p-1.5 px-4 text-gray-600"
 		use:melt={$field}
 	>
 		<p class="flex items-center gap-x-0.5">

--- a/apps/web-client/src/lib/components/HistoryPage.svelte
+++ b/apps/web-client/src/lib/components/HistoryPage.svelte
@@ -28,13 +28,20 @@
 			label: "Notes by date",
 			href: appPath("history/notes", $page.params?.date || ""), // Keep the date when switching from one dated tab to another
 			linkto: historyView("history/notes")
+		},
+		{
+			icon: Book,
+			label: "by Warehouse",
+			href: appPath("history/warehouse"), // Keep the date when switching from one dated tab to another
+			linkto: historyView("history/warehouse")
 		}
 	];
 
 	export let view: HistoryView;
+	export let loaded = true;
 </script>
 
-<Page {view} loaded={true}>
+<Page {view} {loaded}>
 	<svelte:fragment slot="topbar" let:iconProps let:inputProps>
 		{#if $$slots.topbar}
 			<slot name="topbar" {iconProps} {inputProps} />

--- a/apps/web-client/src/lib/paths.ts
+++ b/apps/web-client/src/lib/paths.ts
@@ -11,7 +11,8 @@ const PATHS = {
 	settings: `${basepath}/settings/`,
 	"history/date": `${basepath}/history/date/`,
 	"history/isbn": `${basepath}/history/isbn/`,
-	"history/notes": `${basepath}/history/notes/`
+	"history/notes": `${basepath}/history/notes/`,
+	"history/warehouse": `${basepath}/history/warehouse/`
 };
 
 /**

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -19,36 +19,29 @@
 
 	import { appPath } from "$lib/paths";
 	import { generateUpdatedAtString } from "$lib/utils/time";
+	import CalendarPicker from "$lib/components/CalendarPicker.svelte";
 
 	export let data: PageData;
 
+	// #region date picker
 	const isEqualDateValue = (a?: DateValue, b?: DateValue): boolean => {
 		if (!a || !b) return false;
 		return a.toString().slice(0, 10) === b.toString().slice(0, 10);
 	};
-
-	const {
-		elements: { calendar, cell, content, field, grid, heading, nextButton, prevButton, segment, trigger },
-		states: { months, headingValue, weekdays, segmentContents, open },
-		helpers: { isDateDisabled, isDateUnavailable }
-		// create a ZonedDateTime object with the current date and time
-	} = createDatePicker({
-		// 'date' param should always be defined as the route doesn't render without the date param
-		defaultValue: data.dateValue,
-		isDateDisabled: (date) => {
-			return date > now(getLocalTimeZone());
-		},
-		onValueChange: ({ next }) => {
-			// Redirect only in browser, if data value is different then the one in route param
-			if (browser && !isEqualDateValue(data.dateValue, next)) {
-				// The replaceState part allows us to have the date as part of the route (for sharing/reaload),
-				// whilst keeping the date changes a single history entry (allowing for quick 'back' navigation)
-				goto(appPath("history/date", next.toString().slice(0, 10)), { replaceState: true });
-			}
-			return next;
-		},
-		preventDeselect: true
-	});
+	const defaultDateValue = data.dateValue;
+	const onDateValueChange = ({ next }) => {
+		// Redirect only in browser, if data value is different then the one in route param
+		if (browser && !isEqualDateValue(data.dateValue, next)) {
+			// The replaceState part allows us to have the date as part of the route (for sharing/reaload),
+			// whilst keeping the date changes a single history entry (allowing for quick 'back' navigation)
+			goto(appPath("history/date", next.toString().slice(0, 10)), { replaceState: true });
+		}
+		return next;
+	};
+	const isDateDisabled = (date: DateValue) => {
+		return date > now(getLocalTimeZone());
+	};
+	// #endregion date picker
 
 	const db = getDB();
 
@@ -61,72 +54,9 @@
 		<div class="flex w-full justify-between">
 			<h1 class="text-2xl font-bold leading-7 text-gray-900">History</h1>
 
-			<section class="flex w-full flex-col items-center gap-3">
-				<div>
-					<div
-						class="mt-1.5 flex w-full min-w-[200px] items-center rounded-lg border border-gray-400 bg-gray-50 p-1.5 text-gray-600"
-						use:melt={$field}
-					>
-						{#each $segmentContents as seg}
-							<div class="px-0.5" use:melt={$segment(seg.part)}>
-								{seg.value}
-							</div>
-						{/each}
-						<div class="ml-4 flex w-full items-center justify-end">
-							<button class="rounded-md p-1 text-gray-600 transition-all" use:melt={$trigger}>
-								<Calendar size={20} />
-							</button>
-						</div>
-					</div>
-				</div>
-				{#if $open}
-					<div class="z-10 min-w-[320px] rounded-lg bg-white shadow-sm" transition:fade={{ duration: 100 }} use:melt={$content}>
-						<div class="w-full rounded-lg bg-white p-3 text-gray-600 shadow-sm" use:melt={$calendar}>
-							<header class="flex items-center justify-between pb-2">
-								<button class="rounded-lg p-1 transition-all" use:melt={$prevButton}>
-									<ChevronLeft size={24} />
-								</button>
-								<div class="flex items-center gap-6" use:melt={$heading}>
-									{$headingValue}
-								</div>
-								<button class="rounded-lg p-1 transition-all" use:melt={$nextButton}>
-									<ChevronRight size={24} />
-								</button>
-							</header>
-							<div>
-								{#each $months as month}
-									<table class="w-full" use:melt={$grid}>
-										<thead aria-hidden="true">
-											<tr>
-												{#each $weekdays as day}
-													<th class="text-sm font-semibold">
-														<div class="flex h-6 w-6 items-center justify-center p-4">
-															{day}
-														</div>
-													</th>
-												{/each}
-											</tr>
-										</thead>
-										<tbody>
-											{#each month.weeks as weekDates}
-												<tr>
-													{#each weekDates as date}
-														<td role="gridcell" aria-disabled={$isDateDisabled(date) || $isDateUnavailable(date)}>
-															<div use:melt={$cell(date, month.value)}>
-																{date.day}
-															</div>
-														</td>
-													{/each}
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								{/each}
-							</div>
-						</div>
-					</div>
-				{/if}
-			</section>
+			<div class="flex w-full flex-col items-center gap-3">
+				<CalendarPicker onValueChange={onDateValueChange} defaultValue={defaultDateValue} {isDateDisabled} />
+			</div>
 		</div>
 	</svelte:fragment>
 
@@ -228,44 +158,3 @@
 		<!-- End entity list contaier -->
 	</svelte:fragment>
 </HistoryPage>
-
-<style lang="postcss">
-	[data-melt-calendar-prevbutton][data-disabled] {
-		@apply pointer-events-none rounded-lg p-1 opacity-40;
-	}
-
-	[data-melt-calendar-nextbutton][data-disabled] {
-		@apply pointer-events-none rounded-lg p-1 opacity-40;
-	}
-
-	[data-melt-calendar-heading] {
-		@apply font-semibold;
-	}
-
-	[data-melt-calendar-grid] {
-		@apply w-full;
-	}
-
-	[data-melt-calendar-cell] {
-		@apply flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-lg  p-4;
-	}
-
-	[data-melt-calendar-cell][data-disabled] {
-		@apply pointer-events-none opacity-40;
-	}
-	[data-melt-calendar-cell][data-unavailable] {
-		@apply pointer-events-none text-red-400 line-through;
-	}
-
-	[data-melt-calendar-cell][data-selected] {
-		@apply bg-teal-400 text-base;
-	}
-
-	[data-melt-calendar-cell][data-outside-visible-months] {
-		@apply pointer-events-none cursor-default opacity-40;
-	}
-
-	[data-melt-calendar-cell][data-outside-month] {
-		@apply pointer-events-none cursor-default opacity-0;
-	}
-</style>

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
-	import { fade } from "svelte/transition";
-
-	import { melt, createDatePicker } from "@melt-ui/svelte";
-	import { Library, Calendar, ChevronRight, ChevronLeft } from "lucide-svelte";
-	import { now, getLocalTimeZone, fromDate, type DateValue } from "@internationalized/date";
+	import { Library } from "lucide-svelte";
+	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
 
 	import { entityListView, testId } from "@librocco/shared";
 
@@ -17,6 +14,7 @@
 	import { createPastNotesStore } from "$lib/stores/inventory/history_entries";
 	import { browser } from "$app/environment";
 	import { generateUpdatedAtString } from "$lib/utils/time";
+	import CalendarPicker from "$lib/components/CalendarPicker.svelte";
 
 	export let data: PageData;
 
@@ -25,28 +23,21 @@
 		return a.toString().slice(0, 10) === b.toString().slice(0, 10);
 	};
 
-	const {
-		elements: { calendar, cell, content, field, grid, heading, nextButton, prevButton, segment, trigger },
-		states: { months, headingValue, weekdays, segmentContents, open, value },
-		helpers: { isDateDisabled, isDateUnavailable }
-		// create a ZonedDateTime object with the current date and time
-	} = createDatePicker({
-		// 'date' param should always be defined as the route doesn't render without the date param
-		defaultValue: data.dateValue,
-		isDateDisabled: (date) => {
-			return date > now(getLocalTimeZone());
-		},
-		onValueChange: ({ next }) => {
-			// Redirect only in browser, if data value is different then the one in route param
-			if (browser && !isEqualDateValue(data.dateValue, next)) {
-				// The replaceState part allows us to have the date as part of the route (for sharing/reaload),
-				// whilst keeping the date changes a single history entry (allowing for quick 'back' navigation)
-				goto(appPath("history/notes", next.toString().slice(0, 10)), { replaceState: true });
-			}
-			return next;
-		},
-		preventDeselect: true
-	});
+	// #region date picker
+	const defaultDateValue = data.dateValue;
+	const onDateValueChange = ({ next }) => {
+		// Redirect only in browser, if data value is different then the one in route param
+		if (browser && !isEqualDateValue(data.dateValue, next)) {
+			// The replaceState part allows us to have the date as part of the route (for sharing/reaload),
+			// whilst keeping the date changes a single history entry (allowing for quick 'back' navigation)
+			goto(appPath("history/notes", next.toString().slice(0, 10)), { replaceState: true });
+		}
+		return next;
+	};
+	const isDateDisabled = (date: DateValue) => {
+		return date > now(getLocalTimeZone());
+	};
+	// #endregion date picker
 
 	const db = getDB();
 
@@ -59,72 +50,9 @@
 		<div class="flex w-full justify-between">
 			<h1 class="text-2xl font-bold leading-7 text-gray-900">History</h1>
 
-			<section class="flex w-full flex-col items-center gap-3">
-				<div>
-					<div
-						class="mt-1.5 flex w-full min-w-[200px] items-center rounded-lg border border-gray-400 bg-gray-50 p-1.5 text-gray-600"
-						use:melt={$field}
-					>
-						{#each $segmentContents as seg}
-							<div class="px-0.5" use:melt={$segment(seg.part)}>
-								{seg.value}
-							</div>
-						{/each}
-						<div class="ml-4 flex w-full items-center justify-end">
-							<button class="rounded-md p-1 text-gray-600 transition-all" use:melt={$trigger}>
-								<Calendar size={20} />
-							</button>
-						</div>
-					</div>
-				</div>
-				{#if $open}
-					<div class="z-10 min-w-[320px] rounded-lg bg-white shadow-sm" transition:fade={{ duration: 100 }} use:melt={$content}>
-						<div class="w-full rounded-lg bg-white p-3 text-gray-600 shadow-sm" use:melt={$calendar}>
-							<header class="flex items-center justify-between pb-2">
-								<button class="rounded-lg p-1 transition-all" use:melt={$prevButton}>
-									<ChevronLeft size={24} />
-								</button>
-								<div class="flex items-center gap-6" use:melt={$heading}>
-									{$headingValue}
-								</div>
-								<button class="rounded-lg p-1 transition-all" use:melt={$nextButton}>
-									<ChevronRight size={24} />
-								</button>
-							</header>
-							<div>
-								{#each $months as month}
-									<table class="w-full" use:melt={$grid}>
-										<thead aria-hidden="true">
-											<tr>
-												{#each $weekdays as day}
-													<th class="text-sm font-semibold">
-														<div class="flex h-6 w-6 items-center justify-center p-4">
-															{day}
-														</div>
-													</th>
-												{/each}
-											</tr>
-										</thead>
-										<tbody>
-											{#each month.weeks as weekDates}
-												<tr>
-													{#each weekDates as date}
-														<td role="gridcell" aria-disabled={$isDateDisabled(date) || $isDateUnavailable(date)}>
-															<div use:melt={$cell(date, month.value)}>
-																{date.day}
-															</div>
-														</td>
-													{/each}
-												</tr>
-											{/each}
-										</tbody>
-									</table>
-								{/each}
-							</div>
-						</div>
-					</div>
-				{/if}
-			</section>
+			<div class="flex w-full flex-col items-center gap-3">
+				<CalendarPicker onValueChange={onDateValueChange} defaultValue={defaultDateValue} {isDateDisabled} />
+			</div>
 		</div>
 	</svelte:fragment>
 

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+
+	import { firstValueFrom, map } from "rxjs";
+	import { Loader2 as Loader, Library, Percent } from "lucide-svelte";
+
+	import { entityListView, filter, testId } from "@librocco/shared";
+
+	import HistoryPage from "$lib/components/HistoryPage.svelte";
+
+	import { getDB } from "$lib/db";
+
+	import { readableFromStream } from "$lib/utils/streams";
+
+	import { appPath } from "$lib/paths";
+
+	const db = getDB();
+
+	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
+	const warehouseListStream = db
+		?.stream()
+		.warehouseMap(warehouseListCtx)
+		/** @TODO we could probably wrap the Map to be ArrayLike (by having 'm.length' = 'm.size') */
+		.pipe(map((m) => [...filter(m, ([warehouseId]) => !warehouseId.includes("0-all"))]));
+	const warehouseList = readableFromStream(warehouseListCtx, warehouseListStream, []);
+
+	let initialised = false;
+	onMount(() => {
+		firstValueFrom(warehouseListStream).then((wls) => {
+			console.log("warehouseListStream", wls);
+			initialised = true;
+		});
+	});
+</script>
+
+<HistoryPage view="history/warehouse" loaded={initialised}>
+	<svelte:fragment slot="main">
+		{#if !initialised}
+			<div class="center-absolute">
+				<Loader strokeWidth={0.6} class="animate-[spin_0.5s_linear_infinite] text-teal-500 duration-300" size={70} />
+			</div>
+		{:else}
+			<!-- Start entity list contaier -->
+
+			<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
+			<ul class={testId("entity-list-container")} data-view={entityListView("warehouse-list")} data-loaded={true}>
+				<!-- Start entity list -->
+				{#each $warehouseList as [warehouseId, warehouse]}
+					{@const displayName = warehouse.displayName || warehouseId}
+					{@const totalBooks = warehouse.totalBooks}
+					{@const href = appPath("history/warehouse", warehouseId.split("/").pop())}
+					{@const warehouseDiscount = warehouse.discountPercentage}
+
+					<div class="group entity-list-row">
+						<div class="flex flex-col gap-y-2 self-start">
+							<a {href} class="entity-list-text-lg text-gray-900 hover:underline focus:underline">{displayName}</a>
+
+							<div class="flex flex-col gap-2 sm:flex-row">
+								<div class="flex w-32 items-center gap-x-1">
+									<Library class="text-gray-700" size={20} />
+									<span class="entity-list-text-sm text-gray-500">{totalBooks} books</span>
+								</div>
+
+								{#if warehouseDiscount}
+									<div class="flex items-center gap-x-1">
+										<div class="border border-gray-700 p-[1px]">
+											<Percent class="text-gray-700" size={14} />
+										</div>
+										<span class="entity-list-text-sm text-gray-500">{warehouseDiscount}% discount</span>
+									</div>
+								{/if}
+							</div>
+						</div>
+					</div>
+				{/each}
+				<!-- End entity list -->
+			</ul>
+			<!-- End entity list contaier -->
+		{/if}
+	</svelte:fragment>
+</HistoryPage>

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/+layout.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/+layout.ts
@@ -1,0 +1,30 @@
+import { fromDate, getLocalTimeZone } from "@internationalized/date";
+import { redirect } from "@sveltejs/kit";
+
+import type { LayoutLoad } from "./$types";
+
+import { appPath } from "$lib/paths";
+
+export const load: LayoutLoad = async ({ params }) => {
+	const warehouseId = params.warehouse;
+
+	const dateRange = params.params.split("/").filter(Boolean); // Remove the empty "" as the last segment of a path with trailing a slash
+
+	// Validate dates - if not valid, redirect to default
+	if (dateRange?.length !== 2 || !dateRange?.every((date) => /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(date))) {
+		const today = new Date().toISOString().slice(0, 10);
+		throw redirect(307, appPath("history/warehouse", warehouseId, today, today));
+	}
+
+	const [_from, _to] = dateRange;
+	const from = {
+		date: _from,
+		dateValue: fromDate(new Date(_from), getLocalTimeZone())
+	};
+	const to = {
+		date: _to,
+		dateValue: fromDate(new Date(_to), getLocalTimeZone())
+	};
+
+	return { warehouseId, to, from };
+};

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
@@ -105,31 +105,37 @@
 
 <HistoryPage view="history/date">
 	<svelte:fragment slot="heading">
-		<div class="flex w-full justify-between">
-			<h1 class="whitespace-nowrap text-2xl font-bold leading-7 text-gray-900">{$displayName || ""} history</h1>
+		<div class="flex w-full flex-wrap justify-between gap-y-4 xl:flex-nowrap">
+			<h1 class="order-1 whitespace-nowrap text-2xl font-bold leading-7 text-gray-900">{$displayName || ""} history</h1>
 
-			<div class="flex w-full items-center justify-center gap-3">
+			<button on:click={handleExportCsv} class="button button-green order-2 whitespace-nowrap xl:order-3">Export CSV</button>
+
+			<div class="order-3 w-full items-center gap-3 md:flex xl:order-2 xl:justify-center">
 				<p>From:</p>
-				<CalendarPicker onValueChange={onDateValueChange("from")} defaultValue={data.from.dateValue} {isDateDisabled} />
+				<div class="mb-4 inline-block md:mb-0">
+					<CalendarPicker onValueChange={onDateValueChange("from")} defaultValue={data.from.dateValue} {isDateDisabled} />
+				</div>
 				<p>To:</p>
-				<CalendarPicker onValueChange={onDateValueChange("to")} defaultValue={data.to.dateValue} {isDateDisabled} />
+				<div class="mb-4 inline-block md:mb-0">
+					<CalendarPicker onValueChange={onDateValueChange("to")} defaultValue={data.to.dateValue} {isDateDisabled} />
+				</div>
 
-				Filter:
-				<div class="flex items-center divide-x divide-gray-300 overflow-hidden rounded-md border">
-					{#each options as { label, value }}
-						{@const active = value === filter}
-						<button
-							on:click={selectFilter(value)}
-							class="{active ? 'button-green' : 'button-white'} whitespace-nowrap border-none px-3 py-1"
-							class:selected={filter === value}
-						>
-							{label}
-						</button>
-					{/each}
+				<p>Filter:</p>
+				<div class="inline-block">
+					<div class="mt-1 flex items-center divide-x divide-gray-300 overflow-hidden rounded-md border">
+						{#each options as { label, value }}
+							{@const active = value === filter}
+							<button
+								on:click={selectFilter(value)}
+								class="{active ? 'button-green' : 'button-white'} whitespace-nowrap border-none px-3 py-1"
+								class:selected={filter === value}
+							>
+								{label}
+							</button>
+						{/each}
+					</div>
 				</div>
 			</div>
-
-			<button on:click={handleExportCsv} class="button button-green whitespace-nowrap">Export CSV</button>
 		</div>
 	</svelte:fragment>
 
@@ -152,35 +158,37 @@
 				</div>
 				<ul class="grid w-full grid-cols-12 divide-y">
 					{#each $transactions as txn}
-						{@const isbn = txn.isbn}
-						{@const quantity = txn.quantity}
-						{@const noteId = txn.noteId}
-						{@const noteName = txn.noteDisplayName}
-						{@const noteType = txn.noteType}
-						{@const committedAt = txn.date}
+						<li class="entity-list-row col-span-12 grid grid-cols-12 items-center gap-4 whitespace-nowrap text-gray-800">
+							<p class="col-span-12 overflow-hidden font-semibold lg:col-span-2 lg:font-normal">
+								{generateUpdatedAtString(txn.date)}
+							</p>
 
-						<li class="col-span-12 grid grid-cols-12">
-							<div class="entity-list-row col-span-8 grid grid-cols-8 items-center text-gray-800">
-								<p class="col-span-2">
-									{generateUpdatedAtString(committedAt)}
-								</p>
+							<div class="col-span-8 grid items-center gap-x-4 md:grid-cols-1 lg:col-span-7 lg:grid-cols-7 xl:col-span-8 xl:grid-cols-8">
+								<p class="col-span-2 overflow-hidden">{txn.isbn}</p>
 
-								<p class="col-span-2">{isbn}</p>
+								<p class="col-span-3 overflow-hidden">{txn.title || "Unkonwn Title"}</p>
 
-								<a href={appPath("history/notes", noteId)} class="col-span-4 flex items-center">
-									<div class="{noteType === 'outbound' ? 'badge-red' : 'badge-green'} mx-4 flex items-center rounded-sm px-3">
-										{#if noteType === "inbound"}
-											<p><ArrowLeft size={16} /></p>
-											<p>{quantity}</p>
-										{:else}
-											<p>{quantity}</p>
-											<p><ArrowRight size={16} /></p>
-										{/if}
-									</div>
-
-									<p>{noteName}</p>
-								</a>
+								<p class="col-span-2 overflow-hidden xl:col-span-3">{txn.authors || ""}</p>
 							</div>
+
+							<a
+								href={appPath("history/notes", txn.noteId)}
+								class="col-span-4 flex items-center overflow-hidden lg:col-span-3 xl:col-span-2"
+							>
+								{#if txn.noteType === "inbound"}
+									<div class="badge-green mx-4 flex items-center rounded-sm px-3">
+										<p><ArrowLeft size={16} /></p>
+										<p>{txn.quantity}</p>
+									</div>
+								{:else}
+									<div class="badge-red mx-4 flex items-center rounded-sm px-3">
+										<p>{txn.quantity}</p>
+										<p><ArrowRight size={16} /></p>
+									</div>
+								{/if}
+
+								<p>{txn.noteDisplayName}</p>
+							</a>
 						</li>
 					{/each}
 				</ul>

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import { ArrowLeft, ArrowRight, FileCheck } from "lucide-svelte";
+	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
+
+	import { entityListView, testId } from "@librocco/shared";
+
+	import { goto } from "$app/navigation";
+	import { browser } from "$app/environment";
+
+	import type { PageData } from "./$types";
+
+	import { HistoryPage, PlaceholderBox } from "$lib/components";
+
+	import { createWarehouseHistoryStores } from "$lib/stores/inventory/history_entries";
+
+	import { getDB } from "$lib/db";
+
+	import { appPath } from "$lib/paths";
+	import { generateUpdatedAtString } from "$lib/utils/time";
+	import CalendarPicker from "$lib/components/CalendarPicker.svelte";
+	import { download, generateCsv, mkConfig } from "export-to-csv";
+	import type { DisplayRow } from "$lib/types/inventory";
+
+	export let data: PageData;
+
+	// #region date picker
+	const isEqualDateValue = (a?: DateValue, b?: DateValue): boolean => {
+		if (!a || !b) return false;
+		return a.toString().slice(0, 10) === b.toString().slice(0, 10);
+	};
+
+	const onDateValueChange =
+		(which: "to" | "from") =>
+		({ next }) => {
+			// Redirect only in browser, if data value is different then the one in route param
+			if (browser && !isEqualDateValue(data[which].dateValue, next)) {
+				const path =
+					which === "from"
+						? appPath("history/warehouse", data.warehouseId, next.toString().slice(0, 10), data.to.date)
+						: appPath("history/warehouse", data.warehouseId, data.from.date, next.toString().slice(0, 10));
+				// The replaceState part allows us to have the date as part of the route (for sharing/reaload),
+				// whilst keeping the date changes a single history entry (allowing for quick 'back' navigation)
+				goto(path);
+			}
+			return next;
+		};
+
+	const isDateDisabled = (date: DateValue) => {
+		return date > now(getLocalTimeZone());
+	};
+	// #endregion date picker
+
+	// #region dropdown
+	let filter = "";
+	const options = [
+		{
+			label: "All",
+			value: ""
+		},
+		{
+			label: "Inbound",
+			value: "inbound"
+		},
+		{
+			label: "Outbound",
+			value: "outbound"
+		}
+	];
+	const selectFilter = (value: string) => () => (filter = value);
+	// #endregion dropdown
+
+	// #region csv
+	type CsvEntries = Omit<DisplayRow<"book">, "warehouseId" | "availableWarehouses">;
+	const handleExportCsv = () => {
+		const csvConfig = mkConfig({
+			columnHeaders: [
+				{ displayLabel: "Quantity", key: "quantity" },
+				{ displayLabel: "ISBN", key: "isbn" },
+				{ displayLabel: "Title", key: "title" },
+				{ displayLabel: "Publisher", key: "publisher" },
+				{ displayLabel: "Authors", key: "authors" },
+				{ displayLabel: "Year", key: "year" },
+				{ displayLabel: "Price", key: "price" },
+				{ displayLabel: "Category", key: "category" },
+				{ displayLabel: "Edited by", key: "edited_by" },
+				{ displayLabel: "Out of print", key: "out_of_print" }
+			],
+			filename: `${$displayName.replace(" ", "-")}-${Date.now()}`
+		});
+
+		const gen = generateCsv(csvConfig)<CsvEntries>(
+			$transactions.map((txn) => ({ ...txn, quantity: txn.noteType === "outbound" ? -txn.quantity : txn.quantity }))
+		);
+		download(csvConfig)(gen);
+	};
+	// #endregion csv
+
+	const db = getDB();
+
+	const dailySummaryCtx = { name: "[DAILY_SUMMARY]", debug: false };
+	$: historyStores = createWarehouseHistoryStores(dailySummaryCtx, db, data.warehouseId, data.from.dateValue, data.to.dateValue, filter);
+	$: transactions = historyStores.transactions;
+	$: displayName = historyStores.displayName;
+</script>
+
+<HistoryPage view="history/date">
+	<svelte:fragment slot="heading">
+		<div class="flex w-full justify-between">
+			<h1 class="whitespace-nowrap text-2xl font-bold leading-7 text-gray-900">{$displayName || ""} history</h1>
+
+			<div class="flex w-full items-center justify-center gap-3">
+				<p>From:</p>
+				<CalendarPicker onValueChange={onDateValueChange("from")} defaultValue={data.from.dateValue} {isDateDisabled} />
+				<p>To:</p>
+				<CalendarPicker onValueChange={onDateValueChange("to")} defaultValue={data.to.dateValue} {isDateDisabled} />
+
+				Filter:
+				<div class="flex items-center divide-x divide-gray-300 overflow-hidden rounded-md border">
+					{#each options as { label, value }}
+						{@const active = value === filter}
+						<button
+							on:click={selectFilter(value)}
+							class="{active ? 'button-green' : 'button-white'} whitespace-nowrap border-none px-3 py-1"
+							class:selected={filter === value}
+						>
+							{label}
+						</button>
+					{/each}
+				</div>
+			</div>
+
+			<button on:click={handleExportCsv} class="button button-green whitespace-nowrap">Export CSV</button>
+		</div>
+	</svelte:fragment>
+
+	<svelte:fragment slot="main">
+		<!-- Start entity list contaier -->
+
+		<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
+		<div class={testId("entity-list-container")} data-view={entityListView("outbound-list")} data-loaded={true}>
+			{#if !$transactions?.length}
+				<!-- Start entity list placeholder -->
+				<PlaceholderBox
+					title="No transactions found"
+					description="There seems to be no record for transactions of the given isbn volumes going in or out"
+					class="center-absolute"
+				/>
+				<!-- End entity list placeholder -->
+			{:else}
+				<div class="sticky top-0">
+					<h2 class="border-b border-gray-300 bg-white px-4 py-4 pt-8 text-xl font-semibold">Transactions</h2>
+				</div>
+				<ul class="grid w-full grid-cols-12 divide-y">
+					{#each $transactions as txn}
+						{@const isbn = txn.isbn}
+						{@const quantity = txn.quantity}
+						{@const noteId = txn.noteId}
+						{@const noteName = txn.noteDisplayName}
+						{@const noteType = txn.noteType}
+						{@const committedAt = txn.date}
+
+						<li class="col-span-12 grid grid-cols-12">
+							<div class="entity-list-row col-span-8 grid grid-cols-8 items-center text-gray-800">
+								<p class="col-span-2">
+									{generateUpdatedAtString(committedAt)}
+								</p>
+
+								<p class="col-span-2">{isbn}</p>
+
+								<a href={appPath("history/notes", noteId)} class="col-span-4 flex items-center">
+									<div class="{noteType === 'outbound' ? 'badge-red' : 'badge-green'} mx-4 flex items-center rounded-sm px-3">
+										{#if noteType === "inbound"}
+											<p><ArrowLeft size={16} /></p>
+											<p>{quantity}</p>
+										{:else}
+											<p>{quantity}</p>
+											<p><ArrowRight size={16} /></p>
+										{/if}
+									</div>
+
+									<p>{noteName}</p>
+								</a>
+							</div>
+						</li>
+					{/each}
+				</ul>
+				<!-- End entity list -->
+			{/if}
+		</div>
+		<!-- End entity list contaier -->
+	</svelte:fragment>
+</HistoryPage>

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = async ({ parent }) => {
+	return await parent();
+};

--- a/pkg/shared/src/testing.ts
+++ b/pkg/shared/src/testing.ts
@@ -13,11 +13,12 @@ export type WebClientView =
 	| "history/date"
 	| "history/isbn"
 	| "history/notes"
+	| "history/warehouse"
 	| "debug";
 /** Union of names for all views containing entity lists (warehouses / notes) */
 export type EntityListView = "warehouse-list" | "inbound-list" | "outbound-list";
 /** Union of names for all views regarding history (summaries, past notes/transactions) */
-export type HistoryView = "history/date" | "history/isbn" | "history/notes";
+export type HistoryView = "history/date" | "history/isbn" | "history/notes" | "history/warehouse";
 
 /** A typesafe identity function (preventing typos) used to assign the value for the [data-view] property to the page container element */
 export const view = (name: WebClientView) => name;


### PR DESCRIPTION
Fixes #464 

Still requires some touch-ups, but if you navigate to /history/["by Warehouse"] (using the UI), you can select a warehouse, select the from and to dates and see the report. You can also toggle between all/inbound/outbound views (for filtering of in/out transctions). On "Export CSV" button click, the currently selected filtered view will be exported as CSV (all/inbound/outbound) - where inbound transactions will have a positive quantity and outbound negative quantity.

TODO: rethink query params (currently we're a bit restricted with warehouse id - can't be a full doc path) -> **potentially in the next unit of work**