### PR TITLE
Fix/invalid couchdb

### DIFF
--- a/apps/web-client/src/lib/components/FormControls/Input.svelte
+++ b/apps/web-client/src/lib/components/FormControls/Input.svelte
@@ -6,6 +6,7 @@
 		name: string;
 		label?: string;
 		helpText?: string;
+		errorText?: string;
 		inputRef?: HTMLInputElement | null;
 		inputAction?: Action<HTMLElement, any> | (() => void);
 	}
@@ -20,6 +21,7 @@
 	export let type = "text";
 	export let label = "";
 	export let helpText = "";
+	export let errorText = "";
 	export let required = false;
 	export let inputRef = null;
 	export let inputAction: Action<HTMLElement, any> = () => {};
@@ -52,13 +54,18 @@
 	];
 
 	const helpTextColour = "text-oyster-500 font-regular";
+	const errorTextColour = "text-red-500 font-regular";
 	const containerBorderWidth = "outline-1";
 	const containerBorderColour = "outline-oyster-300";
+	const errorBorderColour = "outline-red-500";
 
 	const labelClasses = labelBaseClasses.join(" ");
 	const inputClasses = inputBaseClasses.join(" ");
 	const helpTextClasses = helpTextBaseClasses.concat(helpTextColour).join(" ");
-	const containerClasses = containerBaseClasses.concat(containerBorderColour, containerBorderWidth).join(" ");
+	const errorTextClasses = helpTextBaseClasses.concat(errorTextColour).join(" ");
+	const containerClasses = containerBaseClasses
+		.concat(`${errorText ? errorBorderColour : containerBorderColour}`, containerBorderWidth)
+		.join(" ");
 
 	// Props passed to the built in input element or (optional) input slot
 	$: inputProps = {
@@ -100,7 +107,9 @@
 			</div>
 		{/if}
 	</div>
-	{#if helpText}
+	{#if errorText}
+		<p class={errorTextClasses}>{errorText}</p>
+	{:else if helpText}
 		<p class={helpTextClasses}>{helpText}</p>
 	{/if}
 </div>

--- a/apps/web-client/src/lib/db/index.ts
+++ b/apps/web-client/src/lib/db/index.ts
@@ -51,7 +51,7 @@ export const createDB = async (url?: string): Promise<{ db: InventoryDatabaseInt
 
 			if (!response.ok) {
 				status = false;
-				reason = `Failed to connect to provided URL: ${response.status} ${response.statusText}`;
+				reason = `Failed to connect using provided username and password.`;
 			} else {
 				status = true;
 				connectionUrl = url;

--- a/apps/web-client/src/lib/forms/SettingsForm.svelte
+++ b/apps/web-client/src/lib/forms/SettingsForm.svelte
@@ -12,13 +12,17 @@
 
 	import { Input } from "$lib/components";
 	import { settingsSchema } from "$lib/forms/schemas";
+	import { getDB } from "$lib/db";
 
 	export let form: SuperValidated<typeof settingsSchema>;
 	export let options: SettingsFormOptions;
 
+
 	const _form = superForm(form, options);
 
 	const { form: formStore, enhance, tainted } = _form;
+
+	const {reason} = getDB()
 
 	$: hasChanges = $tainted && !compare($formStore, form.data);
 </script>
@@ -33,6 +37,7 @@
 					label="Remote CouchDB URL"
 					helpText="Couch DB Url's should be formatted https://user:password@host:post/db_name. 
 						When no url is provided, the app will use local browser storage to persist data."
+					errorText={reason}
 					bind:value={$formStore.couchUrl}
 				/>
 			</div>

--- a/apps/web-client/src/lib/forms/SettingsForm.svelte
+++ b/apps/web-client/src/lib/forms/SettingsForm.svelte
@@ -17,12 +17,11 @@
 	export let form: SuperValidated<typeof settingsSchema>;
 	export let options: SettingsFormOptions;
 
-
 	const _form = superForm(form, options);
 
 	const { form: formStore, enhance, tainted } = _form;
 
-	const {reason} = getDB()
+	const { reason } = getDB();
 
 	$: hasChanges = $tainted && !compare($formStore, form.data);
 </script>

--- a/apps/web-client/src/routes/+error.svelte
+++ b/apps/web-client/src/routes/+error.svelte
@@ -1,0 +1,14 @@
+<script>
+	import Page from "$lib/components/Page.svelte";
+</script>
+
+<Page view="error" loaded={true}>
+	<svelte:fragment slot="topbar">
+		<div class="w-full p-5">
+			<h1 class="text-2xl font-bold text-gray-800">Something crashed!</h1>
+		</div>
+	</svelte:fragment>
+	<svelte:fragment slot="heading">
+		<h2 class="mb-6 text-gray-500">Try checking your internet connection if you're using an online database.</h2>
+	</svelte:fragment>
+</Page>

--- a/pkg/shared/src/testing.ts
+++ b/pkg/shared/src/testing.ts
@@ -13,7 +13,8 @@ export type WebClientView =
 	| "history/date"
 	| "history/isbn"
 	| "history/notes"
-	| "debug";
+	| "debug"
+	| "error";
 /** Union of names for all views containing entity lists (warehouses / notes) */
 export type EntityListView = "warehouse-list" | "inbound-list" | "outbound-list";
 /** Union of names for all views regarding history (summaries, past notes/transactions) */

--- a/pkg/shared/src/testing.ts
+++ b/pkg/shared/src/testing.ts
@@ -14,7 +14,7 @@ export type WebClientView =
 	| "history/isbn"
 	| "history/notes"
 	| "debug"
-	| "error";
+	| "error"
 	| "history/warehouse"
 	| "debug";
 /** Union of names for all views containing entity lists (warehouses / notes) */


### PR DESCRIPTION
#456 Enhancements

- Use an error boundary: 
    - the +error.svelte page catches all error thrown inside routes, so it doesn't catch errors thrown inside layout.ts or errors thrown inside the handle hook
    - it's displayed when app goes offline while a couchdb url is provided
- Display reason when user is redirected:
    - username and password are invalid
    - url format is invalid