### PR TITLE
update: sort note transactions newest added/aggregated - first

### DIFF
--- a/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
@@ -107,8 +107,8 @@ test("should aggregate the quantity for the same isbn", async ({ page }) => {
 	// Check that both books are in the entries table
 	// (by not using 'strict: true', we're asserting only by values we care about)
 	await entries.assertRows([
-		{ isbn: "1234567890", quantity: 1 },
-		{ isbn: "1234567891", quantity: 1 }
+		{ isbn: "1234567891", quantity: 1 },
+		{ isbn: "1234567890", quantity: 1 }
 	]);
 
 	// Add another transaction for "1234567890"
@@ -156,12 +156,12 @@ test("should allow for changing of transaction quantity using the quantity field
 	await scanField.add("1234567891");
 
 	await entries.assertRows([
-		{ isbn: "1234567890", quantity: 3 },
-		{ isbn: "1234567891", quantity: 1 }
+		{ isbn: "1234567891", quantity: 1 },
+		{ isbn: "1234567890", quantity: 3 }
 	]);
 });
 
-test("should sort transactions by isbn", async ({ page }) => {
+test("should sort in reverse order to being added/aggregated", async ({ page }) => {
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("inbound-note");
 
@@ -173,7 +173,11 @@ test("should sort transactions by isbn", async ({ page }) => {
 	await entries.assertRows([{ isbn: "1234567890" }, { isbn: "1234567891" }]);
 
 	await scanField.add("1234567892");
-	await entries.assertRows([{ isbn: "1234567890" }, { isbn: "1234567891" }, { isbn: "1234567892" }]);
+	await entries.assertRows([{ isbn: "1234567892" }, { isbn: "1234567890" }, { isbn: "1234567891" }]);
+
+	// Aggregating should push the aggregated txn up
+	await scanField.add("1234567891");
+	await entries.assertRows([{ isbn: "1234567891" }, { isbn: "1234567892" }, { isbn: "1234567890" }]);
 });
 
 test("should delete the transaction from the note on delete button click", async ({ page }) => {
@@ -189,13 +193,13 @@ test("should delete the transaction from the note on delete button click", async
 	const entries = getDashboard(page).content().table("inbound-note");
 
 	// Wait for all the entries to be displayed before selection/deletion (to reduce flakiness)
-	await entries.assertRows([{ isbn: "1234567890" }, { isbn: "1234567891" }, { isbn: "1234567892" }]);
+	await entries.assertRows([{ isbn: "1234567892" }, { isbn: "1234567891" }, { isbn: "1234567890" }]);
 
 	// Delete the second transaction
 	await entries.row(1).delete();
 
 	// Check that the second transaction was deleted
-	await entries.assertRows([{ isbn: "1234567890" }, { isbn: "1234567892" }]);
+	await entries.assertRows([{ isbn: "1234567892" }, { isbn: "1234567890" }]);
 });
 
 // TODO: Should not allow committing of an empty note ??

--- a/apps/e2e/integration/scan_flow.spec.ts
+++ b/apps/e2e/integration/scan_flow.spec.ts
@@ -42,7 +42,7 @@ test("should allow for continous scanning by auto focusing the scan field after 
 	await page.keyboard.press("Enter");
 
 	await content.table("outbound-note").assertRows([
-		{ isbn: "1234567890", quantity: 1 },
-		{ isbn: "1234567891", quantity: 1 }
+		{ isbn: "1234567891", quantity: 1 },
+		{ isbn: "1234567890", quantity: 1 }
 	]);
 });

--- a/apps/web-client/src/lib/stores/inventory/__tests__/table_content.test.ts
+++ b/apps/web-client/src/lib/stores/inventory/__tests__/table_content.test.ts
@@ -92,8 +92,8 @@ describe("tableContentStore", () => {
 			expect(displayEntries).toEqual([
 				{
 					__kind: "book",
-					...book1,
-					quantity: 12,
+					isbn: book3.isbn,
+					quantity: 5,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -112,8 +112,8 @@ describe("tableContentStore", () => {
 				// Book data for book3 is not available in the db - only the transaction data is shown
 				{
 					__kind: "book",
-					isbn: book3.isbn,
-					quantity: 5,
+					...book1,
+					quantity: 12,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -128,8 +128,8 @@ describe("tableContentStore", () => {
 			expect(displayEntries).toEqual([
 				{
 					__kind: "book",
-					...book1,
-					quantity: 12,
+					...book3,
+					quantity: 5,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -147,8 +147,8 @@ describe("tableContentStore", () => {
 				// Full book3 data should be displayed
 				{
 					__kind: "book",
-					...book3,
-					quantity: 5,
+					...book1,
+					quantity: 12,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -164,9 +164,8 @@ describe("tableContentStore", () => {
 			expect(displayEntries).toEqual([
 				{
 					__kind: "book",
-					...book1,
-					title: "The Age of Wonder (updated)",
-					quantity: 12,
+					...book3,
+					quantity: 5,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -183,8 +182,9 @@ describe("tableContentStore", () => {
 				},
 				{
 					__kind: "book",
-					...book3,
-					quantity: 5,
+					...book1,
+					title: "The Age of Wonder (updated)",
+					quantity: 12,
 					warehouseId: `v1/jazz`,
 					warehouseName: "not-found",
 					availableWarehouses: new Map(),
@@ -241,19 +241,19 @@ describe("tableContentStore", () => {
 			expect(displayEntries).toEqual([
 				{
 					__kind: "book",
-					...book1,
-					quantity: 12,
-					warehouseId: `v1/wh-1`,
-					warehouseName: "Warehouse 1",
+					...book2,
+					quantity: 10,
+					warehouseId: `v1/wh-2`,
+					warehouseName: "Warehouse 2",
 					availableWarehouses: new Map(),
 					warehouseDiscount: 0
 				},
 				{
 					__kind: "book",
-					...book2,
-					quantity: 10,
-					warehouseId: `v1/wh-2`,
-					warehouseName: "Warehouse 2",
+					...book1,
+					quantity: 12,
+					warehouseId: `v1/wh-1`,
+					warehouseName: "Warehouse 1",
 					availableWarehouses: new Map(),
 					warehouseDiscount: 0
 				}
@@ -264,17 +264,6 @@ describe("tableContentStore", () => {
 		await wh1.setDiscount({}, 10);
 		await waitFor(() =>
 			expect(displayEntries).toEqual([
-				// The price of book1 should be discounted (as wh-1 has a discount of 10%)
-				{
-					__kind: "book",
-					...book1,
-					quantity: 12,
-					warehouseId: `v1/wh-1`,
-					warehouseName: "Warehouse 1",
-					price: 54,
-					availableWarehouses: new Map(),
-					warehouseDiscount: 10
-				},
 				// Warehouse 2 doesn't have a discount applied to it
 				{
 					__kind: "book",
@@ -285,15 +274,8 @@ describe("tableContentStore", () => {
 					price: 12,
 					availableWarehouses: new Map(),
 					warehouseDiscount: 0
-				}
-			])
-		);
-
-		// Set the warehouse discount for the second warehouse
-		await wh2.setDiscount({}, 20);
-		await waitFor(() =>
-			expect(displayEntries).toEqual([
-				// Applied discount: 10%
+				},
+				// The price of book1 should be discounted (as wh-1 has a discount of 10%)
 				{
 					__kind: "book",
 					...book1,
@@ -303,7 +285,14 @@ describe("tableContentStore", () => {
 					price: 54,
 					availableWarehouses: new Map(),
 					warehouseDiscount: 10
-				},
+				}
+			])
+		);
+
+		// Set the warehouse discount for the second warehouse
+		await wh2.setDiscount({}, 20);
+		await waitFor(() =>
+			expect(displayEntries).toEqual([
 				// Applied discount: 20%
 				{
 					__kind: "book",
@@ -314,6 +303,17 @@ describe("tableContentStore", () => {
 					price: 9.6,
 					availableWarehouses: new Map(),
 					warehouseDiscount: 20
+				},
+				// Applied discount: 10%
+				{
+					__kind: "book",
+					...book1,
+					quantity: 12,
+					warehouseId: `v1/wh-1`,
+					warehouseName: "Warehouse 1",
+					price: 54,
+					availableWarehouses: new Map(),
+					warehouseDiscount: 10
 				}
 			])
 		);

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -14,7 +14,7 @@
 
 	import { appPath } from "$lib/paths";
 
-	const db = getDB();
+	const { db } = getDB();
 
 	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
 	const warehouseListStream = db

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
@@ -95,7 +95,7 @@
 	};
 	// #endregion csv
 
-	const db = getDB();
+	const { db } = getDB();
 
 	const dailySummaryCtx = { name: "[DAILY_SUMMARY]", debug: false };
 	$: historyStores = createWarehouseHistoryStores(dailySummaryCtx, db, data.warehouseId, data.from.dateValue, data.to.dateValue, filter);

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -241,17 +241,10 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			{ isbn: "11111111", quantity: 4, warehouseId: wh1._id },
 			{ isbn: "11111111", quantity: 3 }
 		);
+
+		// Transactions are ordered in a reverse order of being added/aggregated
 		await waitFor(() => {
 			expect(entries).toEqual([
-				{
-					__kind: "book",
-					isbn: "0123456789",
-					quantity: 2,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
 				{
 					__kind: "book",
 					isbn: "11111111",
@@ -265,6 +258,15 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					__kind: "book",
 					isbn: "11111111",
 					quantity: 4,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
+				},
+				{
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 2,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
@@ -289,19 +291,19 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			expect(entries).toEqual([
 				{
 					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
+					isbn: "11111111",
+					quantity: 10,
+					warehouseId: "",
+					warehouseName: "not-found",
 					availableWarehouses,
 					warehouseDiscount: 0
 				},
 				{
 					__kind: "book",
-					isbn: "11111111",
-					quantity: 10,
-					warehouseId: "",
-					warehouseName: "not-found",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
 				},
@@ -321,6 +323,16 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await note.addVolumes({ __kind: "custom", title: "Custom Item", price: 10 });
 		await waitFor(() => {
 			expect(entries).toEqual([
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item", price: 10 },
+				{
+					__kind: "book",
+					isbn: "11111111",
+					quantity: 10,
+					warehouseId: "",
+					warehouseName: "not-found",
+					availableWarehouses,
+					warehouseDiscount: 0
+				},
 				{
 					__kind: "book",
 					isbn: "0123456789",
@@ -333,22 +345,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				{
 					__kind: "book",
 					isbn: "11111111",
-					quantity: 10,
-					warehouseId: "",
-					warehouseName: "not-found",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
-				{
-					__kind: "book",
-					isbn: "11111111",
 					quantity: 4,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
-				{ id: expect.any(String), __kind: "custom", title: "Custom Item", price: 10 }
+				}
 			]);
 		});
 
@@ -361,6 +363,17 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await note.addVolumes({ __kind: "custom", title: "Custom Item 2", price: 20 });
 		await waitFor(() => {
 			expect(entries).toEqual([
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item", price: 10 },
+				{
+					__kind: "book",
+					isbn: "11111111",
+					quantity: 10,
+					warehouseId: "",
+					warehouseName: "not-found",
+					availableWarehouses,
+					warehouseDiscount: 0
+				},
 				{
 					__kind: "book",
 					isbn: "0123456789",
@@ -373,24 +386,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				{
 					__kind: "book",
 					isbn: "11111111",
-					quantity: 10,
-					warehouseId: "",
-					warehouseName: "not-found",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
-				{
-					__kind: "book",
-					isbn: "11111111",
 					quantity: 4,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
-				// Custom items should be sorted in order of addition (timestamped)
-				{ id: customItemId, __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: expect.any(String), __kind: "custom", title: "Custom Item 2", price: 20 }
+				}
 			]);
 		});
 		const newCustomItemId = await note
@@ -406,6 +407,18 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await note.addVolumes({ __kind: "custom", id: undefined, title: "Custom Item 3", price: 20 });
 		await waitFor(() => {
 			expect(entries).toEqual([
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item 3", price: 20 },
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: expect.any(String), __kind: "custom", title: "Custom Item", price: 10 },
+				{
+					__kind: "book",
+					isbn: "11111111",
+					quantity: 10,
+					warehouseId: "",
+					warehouseName: "not-found",
+					availableWarehouses,
+					warehouseDiscount: 0
+				},
 				{
 					__kind: "book",
 					isbn: "0123456789",
@@ -418,25 +431,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				{
 					__kind: "book",
 					isbn: "11111111",
-					quantity: 10,
-					warehouseId: "",
-					warehouseName: "not-found",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
-				{
-					__kind: "book",
-					isbn: "11111111",
 					quantity: 4,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
-				// Custom items should be sorted in order of addition (timestamped)
-				{ id: customItemId, __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: expect.any(String), __kind: "custom", title: "Custom Item 2", price: 20 },
-				{ id: expect.any(String), __kind: "custom", title: "Custom Item 3", price: 20 }
+				}
 			]);
 		});
 	});
@@ -471,10 +471,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		// Initial stream should be empty
 		await waitFor(() => {
 			expect(entries).toEqual([
+				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
 				{
 					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
+					isbn: "11111111",
+					quantity: 4,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
@@ -491,15 +493,13 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				},
 				{
 					__kind: "book",
-					isbn: "11111111",
-					quantity: 4,
+					isbn: "0123456789",
+					quantity: 5,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
-				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 }
+				}
 			]);
 		});
 
@@ -512,10 +512,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 
 		await waitFor(() => {
 			expect(entries).toEqual([
+				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
 				{
 					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
+					isbn: "11111111",
+					quantity: 8,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
@@ -532,31 +534,22 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				},
 				{
 					__kind: "book",
-					isbn: "11111111",
-					quantity: 8,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
-				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 }
-			]);
-		});
-
-		// Update transaction should be able to update warehouseId for a transaction
-		await note.updateTransaction({}, { isbn: "11111111" }, { isbn: "11111111", quantity: 10, warehouseId: "wh3" });
-		await waitFor(() => {
-			expect(entries).toEqual([
-				{
-					__kind: "book",
 					isbn: "0123456789",
 					quantity: 5,
 					warehouseId: versionId(wh1._id),
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
+				}
+			]);
+		});
+
+		// Update transaction should be able to update warehouseId for a transaction (warehouseId falls back to "" if not specified otherwise)
+		await note.updateTransaction({}, { isbn: "11111111" }, { isbn: "11111111", quantity: 10, warehouseId: "wh3" });
+		await waitFor(() => {
+			expect(entries).toEqual([
+				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
 				{
 					__kind: "book",
 					isbn: "11111111",
@@ -575,8 +568,15 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					availableWarehouses,
 					warehouseDiscount: 0
 				},
-				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 }
+				{
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
+				}
 			]);
 		});
 
@@ -588,15 +588,8 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		);
 		await waitFor(() => {
 			expect(entries).toEqual([
-				{
-					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
+				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
 				{
 					__kind: "book",
 					isbn: "11111111",
@@ -606,8 +599,15 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					availableWarehouses,
 					warehouseDiscount: 0
 				},
-				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 }
+				{
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
+				}
 			]);
 		});
 
@@ -619,15 +619,8 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		);
 		await waitFor(() =>
 			expect(entries).toEqual([
-				{
-					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
+				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
 				{
 					__kind: "book",
 					isbn: "11111111",
@@ -637,8 +630,15 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					availableWarehouses,
 					warehouseDiscount: 0
 				},
-				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 10 },
-				{ id: "custom-item-2", __kind: "custom", title: "Custom Item 2", price: 20 }
+				{
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
+				}
 			])
 		);
 
@@ -648,15 +648,8 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 
 		await waitFor(() => {
 			expect(entries).toEqual([
-				{
-					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
-				},
+				{ id: "custom-item-2", __kind: "custom", title: "Updated 2nd item", price: 25 },
+				{ id: "custom-item-1", __kind: "custom", title: "Custom Item", price: 15 },
 				{
 					__kind: "book",
 					isbn: "11111111",
@@ -667,16 +660,13 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					warehouseDiscount: 0
 				},
 				{
-					__kind: "custom",
-					id: "custom-item-1",
-					title: "Custom Item",
-					price: 15
-				},
-				{
-					__kind: "custom",
-					id: "custom-item-2",
-					title: "Updated 2nd item",
-					price: 25
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
 				}
 			]);
 		});
@@ -711,13 +701,16 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await waitFor(() => {
 			expect(entries).toEqual([
 				{
-					__kind: "book",
-					isbn: "0123456789",
-					quantity: 5,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
+					__kind: "custom",
+					id: "custom-item-2",
+					title: "Updated 2nd item",
+					price: 25
+				},
+				{
+					__kind: "custom",
+					id: "custom-item-1",
+					title: "Custom Item",
+					price: 15
 				},
 				{
 					__kind: "book",
@@ -729,16 +722,13 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					warehouseDiscount: 0
 				},
 				{
-					__kind: "custom",
-					id: "custom-item-1",
-					title: "Custom Item",
-					price: 15
-				},
-				{
-					__kind: "custom",
-					id: "custom-item-2",
-					title: "Updated 2nd item",
-					price: 25
+					__kind: "book",
+					isbn: "0123456789",
+					quantity: 5,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
 				}
 			]);
 		});
@@ -748,13 +738,10 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await waitFor(() => {
 			expect(entries).toEqual([
 				{
-					__kind: "book",
-					isbn: "11111111",
-					quantity: 18,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
+					__kind: "custom",
+					id: "custom-item-2",
+					title: "Updated 2nd item",
+					price: 25
 				},
 				{
 					__kind: "custom",
@@ -763,10 +750,13 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					price: 15
 				},
 				{
-					__kind: "custom",
-					id: "custom-item-2",
-					title: "Updated 2nd item",
-					price: 25
+					__kind: "book",
+					isbn: "11111111",
+					quantity: 18,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
 				}
 			]);
 		});
@@ -776,13 +766,10 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await waitFor(() => {
 			expect(entries).toEqual([
 				{
-					__kind: "book",
-					isbn: "11111111",
-					quantity: 18,
-					warehouseId: versionId(wh1._id),
-					warehouseName: "Warehouse 1",
-					availableWarehouses,
-					warehouseDiscount: 0
+					__kind: "custom",
+					id: "custom-item-2",
+					title: "Updated 2nd item",
+					price: 25
 				},
 				{
 					__kind: "custom",
@@ -791,10 +778,13 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					price: 15
 				},
 				{
-					__kind: "custom",
-					id: "custom-item-2",
-					title: "Updated 2nd item",
-					price: 25
+					__kind: "book",
+					isbn: "11111111",
+					quantity: 18,
+					warehouseId: versionId(wh1._id),
+					warehouseName: "Warehouse 1",
+					availableWarehouses,
+					warehouseDiscount: 0
 				}
 			]);
 		});
@@ -804,6 +794,12 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await waitFor(() => {
 			expect(entries).toEqual([
 				{
+					__kind: "custom",
+					id: "custom-item-1",
+					title: "Custom Item",
+					price: 15
+				},
+				{
 					__kind: "book",
 					isbn: "11111111",
 					quantity: 18,
@@ -811,12 +807,6 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 					warehouseName: "Warehouse 1",
 					availableWarehouses,
 					warehouseDiscount: 0
-				},
-				{
-					__kind: "custom",
-					id: "custom-item-1",
-					title: "Custom Item",
-					price: 15
 				}
 			]);
 		});
@@ -890,13 +880,17 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await note.addVolumes(...fiftyEntries.slice(0, 20));
 		await waitFor(() => {
 			expect(entries.rows).toEqual(
-				fiftyEntries.slice(0, 20).map((e) => ({
-					__kind: "book",
-					...e,
-					warehouseId: versionId("test-warehouse"),
-					warehouseName: "New Warehouse",
-					warehouseDiscount: 0
-				}))
+				fiftyEntries
+					.slice(0, 20)
+					.map((e) => ({
+						__kind: "book",
+						...e,
+						warehouseId: versionId("test-warehouse"),
+						warehouseName: "New Warehouse",
+						warehouseDiscount: 0
+					}))
+					// Reversed as transactions are stored in a reverse order with respect to being added/aggregated
+					.reverse()
 			);
 			expect(entries.total).toEqual(20);
 		});
@@ -907,14 +901,17 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await note.updateTransaction({}, matchTxn, updateTxn);
 		await waitFor(() =>
 			expect(entries.rows).toEqual([
-				...fiftyEntries.slice(0, 19).map((e) => ({
-					...e,
-					__kind: "book",
-					warehouseId: versionId("test-warehouse"),
-					warehouseName: "New Warehouse",
-					warehouseDiscount: 0
-				})),
-				{ ...updateTxn, __kind: "book", warehouseName: "New Warehouse", warehouseDiscount: 0 }
+				{ ...updateTxn, __kind: "book", warehouseName: "New Warehouse", warehouseDiscount: 0 },
+				...fiftyEntries
+					.slice(0, 19)
+					.map((e) => ({
+						...e,
+						__kind: "book",
+						warehouseId: versionId("test-warehouse"),
+						warehouseName: "New Warehouse",
+						warehouseDiscount: 0
+					}))
+					.reverse()
 			])
 		);
 
@@ -922,14 +919,17 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		await db.warehouse("test-warehouse").setDiscount({}, 10);
 		await waitFor(() =>
 			expect(entries.rows).toEqual([
-				...fiftyEntries.slice(0, 19).map((e) => ({
-					...e,
-					__kind: "book",
-					warehouseId: versionId("test-warehouse"),
-					warehouseName: "New Warehouse",
-					warehouseDiscount: 10
-				})),
-				{ ...updateTxn, __kind: "book", warehouseName: "New Warehouse", warehouseDiscount: 10 }
+				{ ...updateTxn, __kind: "book", warehouseName: "New Warehouse", warehouseDiscount: 10 },
+				...fiftyEntries
+					.slice(0, 19)
+					.map((e) => ({
+						...e,
+						__kind: "book",
+						warehouseId: versionId("test-warehouse"),
+						warehouseName: "New Warehouse",
+						warehouseDiscount: 10
+					}))
+					.reverse()
 			])
 		);
 
@@ -2157,9 +2157,9 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		// Can't commit the note as it contains out-of-stock transactions
 		await expect(note.commit({})).rejects.toThrow(
 			new OutOfStockError([
-				{ isbn: "11111111", warehouseId: versionId("warehouse-2"), warehouseName: "Warehouse 2", quantity: 1, available: 0 },
 				{ isbn: "22222222", warehouseId: versionId("warehouse-1"), warehouseName: "Warehouse 1", quantity: 2, available: 0 },
-				{ isbn: "22222222", warehouseId: versionId("warehouse-2"), warehouseName: "Warehouse 2", quantity: 3, available: 2 }
+				{ isbn: "22222222", warehouseId: versionId("warehouse-2"), warehouseName: "Warehouse 2", quantity: 3, available: 2 },
+				{ isbn: "11111111", warehouseId: versionId("warehouse-2"), warehouseName: "Warehouse 2", quantity: 1, available: 0 }
 			])
 		);
 

--- a/pkg/db/src/implementations/version-1.2/note.ts
+++ b/pkg/db/src/implementations/version-1.2/note.ts
@@ -17,7 +17,7 @@ import {
 import { NoteInterface, WarehouseInterface, NoteData, InventoryDatabaseInterface } from "./types";
 
 import { versionId } from "./utils";
-import { isBookRow, isCustomItemRow, isEmpty, isVersioned, runAfterCondition, sortBooks, uniqueTimestamp } from "@/utils/misc";
+import { isBookRow, isCustomItemRow, isEmpty, isVersioned, runAfterCondition, uniqueTimestamp } from "@/utils/misc";
 import { newDocumentStream } from "@/utils/pouchdb";
 import {
 	EmptyNoteError,
@@ -305,7 +305,7 @@ class Note implements NoteInterface {
 
 				if (!update.isbn) throw new EmptyTransactionError();
 
-				const warehouseId = update.warehouseId
+				update.warehouseId = update.warehouseId
 					? versionId(update.warehouseId)
 					: this.noteType === "inbound"
 					? this.#w._id
@@ -313,18 +313,17 @@ class Note implements NoteInterface {
 
 				const matchIndex = this.entries
 					.filter(isBookRow)
-					.findIndex((entry) => entry.isbn === update.isbn && entry.warehouseId === warehouseId);
+					.findIndex((entry) => entry.isbn === update.isbn && entry.warehouseId === update.warehouseId);
 
+				// If transaction doesn't already exist, create a new one
 				if (matchIndex === -1) {
-					this.entries.push({ isbn: update.isbn, warehouseId, quantity: update.quantity });
+					this.entries.push(update as VolumeStock<"book">);
 					return;
 				}
 
-				this.entries[matchIndex] = {
-					isbn: update.isbn,
-					warehouseId,
-					quantity: (this.entries[matchIndex] as VolumeStock<"book">).quantity + update.quantity
-				};
+				// If transaction already exists, aggregate the quantity, but push it to the top of the list (we're displaying the list in reverse)
+				const [existing] = this.entries.splice(matchIndex, 1) as VolumeStock<"book">[];
+				this.entries.push({ ...existing, quantity: existing.quantity + update.quantity } as VolumeStock<"book">);
 			});
 
 			// Create book data entries for added books (if they don't exist)
@@ -357,12 +356,12 @@ class Note implements NoteInterface {
 
 			if (ix === -1) {
 				debug.log(ctx, "update_transaction:custom_item:no_item_found")({});
-				return this.update(ctx, {}); // Noop update
+				return Promise.resolve(this);
 			}
 
 			debug.log(ctx, "update_transaction:custom_item:found_item")({ ix, item: this.entries[ix] });
 			this.entries[ix] = { ...(this.entries[ix] as VolumeStock<"custom">), ...update };
-			return this.update(ctx, { entries: this.entries.sort(sortBooks) });
+			return this.update(ctx, this);
 		}
 
 		// Update book transaction row
@@ -383,36 +382,37 @@ class Note implements NoteInterface {
 
 		debug.log(ctx, "update_transaction:book_row:data")({ matchTr, updateTr });
 
-		// Remove the matched transaction from the list of entries (this is the transaction we're updating to a new one)
-		const entries = this.entries.filter((e) => isCustomItemRow(e) || !(e.isbn === matchTr.isbn && e.warehouseId === matchTr.warehouseId));
+		// Find the transaction we're updating
+		const matchIx = this.entries.findIndex((e) => isBookRow(e) && e.isbn === matchTr.isbn && e.warehouseId === matchTr.warehouseId);
 
-		// If both existing entries and entries without the match transaction are the same:
-		// the match transaction wasn't found, exit early
-		if (entries.length === this.entries.length) {
+		if (matchIx === -1) {
+			// No transaction to update: exit early
 			debug.log(ctx, "update_transaction:book_row:no_item_found")({});
 			return this.update(ctx, {}); // Noop update
 		}
 
-		// Check if there already is a transaction with the same 'isbn' and 'warehouseId' as the updated transaction.
-		// If so, we're merging the two, if not we're simply adding a new transaction to the list.
-		const existingTxnIx = entries.findIndex((e) => isBookRow(e) && e.isbn === updateTr.isbn && e.warehouseId === updateTr.warehouseId);
+		// Check if there already exists a transation with same isbn/warehouse as the one we're updating to (in which case we're merely aggregating)
+		//
+		// Start by excluding the transaction from entries - this prevents faulty behaviour when only updating quantity
+		const otherEntries = [...this.entries];
+		otherEntries.splice(matchIx, 1);
 
-		if (existingTxnIx == -1) {
-			debug.log(ctx, "update_transaction:book_row:unique_txn")({});
-			entries.push(updateTr);
-		} else {
-			const old = entries[existingTxnIx];
-			const aggregated = {
-				...old,
-				quantity: (entries[existingTxnIx] as VolumeStock<"book">).quantity + updateTr.quantity
-			} as VolumeStock<"book">;
-			debug.log(ctx, "update_transaction:book_row:txn_exists:aggregating")({ old, aggregated });
+		const updateMatchIx = otherEntries.findIndex((e) => isBookRow(e) && e.isbn === updateTr.isbn && e.warehouseId === updateTr.warehouseId);
 
-			entries[existingTxnIx] = aggregated;
+		// There already exists a transaction with same isbn/warehouse id - aggregate the quantity
+		//
+		// Use the 'otherEntries' as the old transaction no longer exists as such - it's getting merged with another txn
+		if (updateMatchIx !== -1) {
+			(otherEntries[updateMatchIx] as VolumeStock<"book">).quantity += updateTr.quantity;
+			return this.update(ctx, { entries: otherEntries });
 		}
 
-		// Post an update, the local entries will be updated by the update function.
-		return this.update(ctx, { entries: entries.sort(sortBooks) });
+		// There's no transaction with same isbn/warehouse id - merely update the existing txn
+		//
+		// Notice we're using the existing entries - this preserves the order
+		this.entries[matchIx] = updateTr;
+
+		return this.update(ctx, this);
 	}
 
 	removeTransactions(...transactions: Array<VolumeStock<"custom">["id"] | Omit<VolumeStock<"book">, "quantity">>): Promise<NoteInterface> {
@@ -615,7 +615,7 @@ class Note implements NoteInterface {
 					this.#stream.pipe(
 						map(
 							({ entries = [] }): TableData => ({
-								rows: entries.map((e) => (isCustomItemRow(e) ? e : { ...e, warehouseName: "" })).sort(sortBooks),
+								rows: entries.map((e) => (isCustomItemRow(e) ? e : { ...e, warehouseName: "" })).reverse(),
 								total: entries.length
 							})
 						)


### PR DESCRIPTION
* update 'note.addVolumes' to perform desired behaviour:
	* don't sort entries on streams, get requests, etc. (keep original sorting)
	* don't push custom items to the end of the list - same rules apply (newest - first)
	* don't change ordering when updating a transaction ('note.updateTransaction')
	* when aggregating quantities (by scanning more of the same book), push the transaction to the top
* update tests

Fixes #480 

@silviot please verify that this is the desired functionality - `note.updateTransaction` will not push the note to the top of the list - I consider that awkward behaviour - changing a combobox value moving the row from underneath you
 
_(note.addVolumes was updated as specified)_