### PR TITLE
change the way the db is loaded in history pages - with respect to latest developments in 'getDB'

### DIFF
--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -14,7 +14,7 @@
 
 	import { appPath } from "$lib/paths";
 
-	const db = getDB();
+	const { db } = getDB();
 
 	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
 	const warehouseListStream = db

--- a/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouse]/[...params]/+page.svelte
@@ -95,7 +95,7 @@
 	};
 	// #endregion csv
 
-	const db = getDB();
+	const { db } = getDB();
 
 	const dailySummaryCtx = { name: "[DAILY_SUMMARY]", debug: false };
 	$: historyStores = createWarehouseHistoryStores(dailySummaryCtx, db, data.warehouseId, data.from.dateValue, data.to.dateValue, filter);


### PR DESCRIPTION
`getDB` now returns an object of shape `{ db, status }` (instead of mere db). The loading (`getDB` calls) were fixed in all existing pages - this PR fixes the same thing in pages added after the update (`history/warehouse/...`)