### PR TITLE
Feature/open library

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -36,6 +36,7 @@
 		"@histoire/plugin-svelte": "~0.17.0",
 		"@librocco/book-data-extension": "workspace:*",
 		"@librocco/google-books-api-plugin": "workspace:*",
+		"@librocco/open-library-api-plugin": "workspace:*",
 		"@librocco/shared": "workspace:*",
 		"@melt-ui/pp": "~0.1.4",
 		"@melt-ui/svelte": "~0.65.1",

--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -30,8 +30,8 @@ export const load: LayoutLoad = async ({ url }) => {
 		const { db, status } = await createDB(remoteUrl);
 
 		if (status) {
-			db.plugin("book-fetcher").register(createGoogleBooksApiPlugin());
 			db.plugin("book-fetcher").register(createOpenLibraryApiPlugin());
+			db.plugin("book-fetcher").register(createGoogleBooksApiPlugin());
 		}
 
 		return {

--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -9,6 +9,7 @@ import type { LayoutLoad } from "./$types";
 import { get } from "svelte/store";
 import { settingsStore } from "$lib/stores";
 import { createGoogleBooksApiPlugin } from "@librocco/google-books-api-plugin";
+import { createOpenLibraryApiPlugin } from "@librocco/open-library-api-plugin";
 
 // Paths which are valid (shouldn't return 404, but don't have any content and should get redirected to the default route "/inventory/stock/all")
 const redirectPaths = ["", "/"].map((path) => `${base}${path}`);
@@ -30,6 +31,7 @@ export const load: LayoutLoad = async ({ url }) => {
 
 		if (status) {
 			db.plugin("book-fetcher").register(createGoogleBooksApiPlugin());
+			db.plugin("book-fetcher").register(createOpenLibraryApiPlugin());
 		}
 
 		return {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@librocco/google-books-api-plugin':
         specifier: workspace:*
         version: link:../../plugins/google-books-api
+      '@librocco/open-library-api-plugin':
+        specifier: workspace:*
+        version: link:../../plugins/open-library-api
       '@librocco/shared':
         specifier: workspace:*
         version: link:../../pkg/shared
@@ -485,6 +488,36 @@ importers:
         version: 0.21.1(jsdom@21.1.2)
 
   ../../plugins/google-books-api:
+    devDependencies:
+      '@librocco/db':
+        specifier: workspace:*
+        version: link:../../pkg/db
+      '@typescript-eslint/eslint-plugin':
+        specifier: ~5.27.0
+        version: 5.27.1(@typescript-eslint/parser@5.27.1)(eslint@8.16.0)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ~5.27.0
+        version: 5.27.1(eslint@8.16.0)(typescript@4.9.5)
+      eslint:
+        specifier: ~8.16.0
+        version: 8.16.0
+      eslint-config-prettier:
+        specifier: ^8.3.0
+        version: 8.10.0(eslint@8.16.0)
+      prettier:
+        specifier: ~2.7.1
+        version: 2.7.1
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+      typescript:
+        specifier: ^4.8.4
+        version: 4.9.5
+      vite:
+        specifier: ~4.0.0
+        version: 4.0.5(@types/node@16.18.68)
+
+  ../../plugins/open-library-api:
     devDependencies:
       '@librocco/db':
         specifier: workspace:*

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "585a5b03cfe8883c5bcbff934c94715c47455faf",
+  "pnpmShrinkwrapHash": "bb054e1c5317a10e28258980f6a43ef433c7c4f0",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/plugins/google-books-api/src/index.ts
+++ b/plugins/google-books-api/src/index.ts
@@ -18,6 +18,7 @@ export function createGoogleBooksApiPlugin(): BookFetcherPlugin {
 
 type GBookEntry = {
 	volumeInfo: {
+		isbn: string;
 		title?: string;
 		authors?: string[];
 		publisher?: string;
@@ -38,6 +39,7 @@ async function fetchBook(isbn: string): Promise<GBookEntry | undefined> {
 
 	const { items = [] } = await fetch(url).then((r) => r.json() as GBooksRes);
 	const [gBookData] = items;
+	gBookData.volumeInfo = { ...gBookData.volumeInfo, isbn };
 
 	return gBookData;
 }
@@ -49,7 +51,7 @@ function processResponse(gBook: GBookEntry | undefined): Partial<BookEntry> | un
 
 	const res: Partial<BookEntry> = {};
 
-	const { title, authors: _authors, publisher, publishedDate } = gBook.volumeInfo;
+	const { title, authors: _authors, publisher, publishedDate, isbn } = gBook.volumeInfo;
 	const authors = _authors?.join(", ");
 	const year = publishedDate?.slice(0, 4);
 
@@ -57,6 +59,7 @@ function processResponse(gBook: GBookEntry | undefined): Partial<BookEntry> | un
 	if (authors) res.authors = authors;
 	if (publisher) res.publisher = publisher;
 	if (year) res.year = year;
+	res.isbn = isbn;
 
 	return res;
 }

--- a/plugins/open-library-api/.eslintignore
+++ b/plugins/open-library-api/.eslintignore
@@ -1,0 +1,19 @@
+.DS_Store
+node_modules
+/build
+/dist
+/.svelte-kit
+/package
+.env
+.env.*
+!.env.example
+
+# Ignore files for PNPM, NPM and YARN
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# Skip linting config files as that produces more headache than benefit
+vite.config.js
+vitest.config.ts
+svelte.config.js

--- a/plugins/open-library-api/.eslintrc.cjs
+++ b/plugins/open-library-api/.eslintrc.cjs
@@ -1,0 +1,17 @@
+const path = require("path");
+
+const { useTSConfig } = require("../../pkg/scaffold/.eslint.utils.js");
+const scaffoldConfig = require("../../pkg/scaffold/.eslintrc.cjs");
+
+const tsPaths = [path.join(__dirname, "./tsconfig.json")];
+
+module.exports = useTSConfig(
+	{
+		...scaffoldConfig,
+		env: {
+			...scaffoldConfig.env,
+			browser: true
+		}
+	},
+	tsPaths
+);

--- a/plugins/open-library-api/.npmrc
+++ b/plugins/open-library-api/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/plugins/open-library-api/.prettierignore
+++ b/plugins/open-library-api/.prettierignore
@@ -1,0 +1,20 @@
+.DS_Store
+node_modules
+.env
+.env.*
+!.env.example
+
+# Ignore files for PNPM, NPM and YARN
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# Ignore meta folders
+/.svelte-kit
+/.rush
+/.vscode
+
+# Bundles and built packages
+/build
+/dist
+/package

--- a/plugins/open-library-api/.prettierrc.cjs
+++ b/plugins/open-library-api/.prettierrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require("../../pkg/scaffold/.prettierrc.cjs");

--- a/plugins/open-library-api/package.json
+++ b/plugins/open-library-api/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@librocco/open-library-api-plugin",
+	"version": "0.0.1",
+	"main": "./dist/plugin/index.js",
+	"exports": {
+		".": {
+			"import": {
+				"default": "./dist/index.es.js",
+				"types": "./dist/index.d.ts"
+			},
+			"require": {
+				"default": "./dist/index.js",
+				"types": "./dist/index.d.ts"
+			}
+		}
+	},
+	"scripts": {
+		"build": "vite build && tsc --project tsconfig.build.json",
+		"typecheck": "tsc --noEmit",
+		"lint": "prettier --check --plugin-search-dir=. . && eslint .",
+		"lint:strict": "prettier --check --plugin-search-dir=. . && eslint . --max-warnings=0",
+		"test": "vitest",
+		"test:ci": "vitest",
+		"format": "prettier --write --plugin-search-dir=. ."
+	},
+	"devDependencies": {
+		"@librocco/db": "workspace:*",
+		"@typescript-eslint/eslint-plugin": "~5.27.0",
+		"@typescript-eslint/parser": "~5.27.0",
+		"eslint": "~8.16.0",
+		"eslint-config-prettier": "^8.3.0",
+		"rxjs": "^7.8.1",
+		"prettier": "~2.7.1",
+		"typescript": "^4.8.4",
+		"vite": "~4.0.0"
+	},
+	"peerDependencies": {
+		"@librocco/db": "workspace:*"
+	},
+	"type": "module"
+}

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -1,0 +1,70 @@
+import { BehaviorSubject } from "rxjs";
+
+import { type BookFetcherPlugin, type BookEntry } from "@librocco/db";
+
+const baseurl = "https://openlibrary.org/search.json";
+// publisher is an array
+// author is an array
+// publish date is an array
+const reqFields = ["title", "author_name", "publisher", "publish_date"].join(",");
+
+export function createOpenLibraryApiPlugin(): BookFetcherPlugin {
+	// The plugin is always available (as long as there's internet connection)
+	const isAvailableStream = new BehaviorSubject(true);
+
+	const fetchBookData = async (isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]> => {
+		return Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse)));
+	};
+
+	return { fetchBookData, isAvailableStream };
+}
+
+type OLBookEntry = {
+	docs: {
+		title?: string;
+		author_name?: string[];
+		publisher?: string[];
+		publish_date?: string[];
+	}[];
+};
+
+type OLBooksRes = {
+	items?: OLBookEntry[];
+};
+
+
+async function fetchBook(isbn: string): Promise<OLBookEntry> {
+
+	const url = new URL(baseurl);
+	console.log({ url })
+
+	url.searchParams.append("q", isbn);
+	url.searchParams.append("limit", "1");
+	url.searchParams.append("fields", reqFields);
+
+	const { items = [] } = await fetch(url).then((r) => r.json() as OLBooksRes);
+	const [olBookData] = items;
+
+	return olBookData;
+}
+
+
+function processResponse(olBook: OLBookEntry | undefined): Partial<BookEntry> | undefined {
+	if (!olBook) {
+		return undefined;
+	}
+
+	const res: Partial<BookEntry> = {};
+
+	const { title, author_name: _authors, publisher, publish_date } = olBook.docs[0];
+	const authors = _authors?.join(", ");
+	const publishers = publisher?.join(", "); // join or first element?
+	const year = publish_date?.[0] || ""; // 
+
+	if (title) res.title = title;
+	if (authors) res.authors = authors;
+	if (publishers) res.publisher = publishers;
+	if (year) res.year = year;
+
+	return res;
+}

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -20,46 +20,42 @@ export function createOpenLibraryApiPlugin(): BookFetcherPlugin {
 }
 
 type OLBookEntry = {
-	docs: {
-		title?: string;
-		author_name?: string[];
-		publisher?: string[];
-		publish_date?: string[];
-	}[];
+	isbn: string;
+	title?: string;
+	author_name?: string[];
+	publisher?: string[];
+	publish_date?: string[];
 };
 
 type OLBooksRes = {
-	items?: OLBookEntry[];
+	docs?: OLBookEntry[];
 };
 
-
 async function fetchBook(isbn: string): Promise<OLBookEntry> {
-
 	const url = new URL(baseurl);
-	console.log({ url })
+	console.log({ url });
 
 	url.searchParams.append("q", isbn);
 	url.searchParams.append("limit", "1");
 	url.searchParams.append("fields", reqFields);
 
-	const { items = [] } = await fetch(url).then((r) => r.json() as OLBooksRes);
-	const [olBookData] = items;
+	const { docs = [] } = await fetch(url).then((r) => r.json() as OLBooksRes);
+	const [olBookData] = docs;
 
-	return olBookData;
+	return { ...olBookData, isbn };
 }
-
 
 function processResponse(olBook: OLBookEntry | undefined): Partial<BookEntry> | undefined {
 	if (!olBook) {
 		return undefined;
 	}
 
-	const res: Partial<BookEntry> = {};
+	const res: Partial<BookEntry> = { isbn: olBook.isbn };
 
-	const { title, author_name: _authors, publisher, publish_date } = olBook.docs[0];
+	const { title, author_name: _authors, publisher, publish_date } = olBook;
 	const authors = _authors?.join(", ");
 	const publishers = publisher?.join(", "); // join or first element?
-	const year = publish_date?.[0] || ""; // 
+	const year = publish_date?.[0] || "";
 
 	if (title) res.title = title;
 	if (authors) res.authors = authors;

--- a/plugins/open-library-api/tsconfig.build.json
+++ b/plugins/open-library-api/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"sourceMap": true,
+		"removeComments": false,
+		"declaration": true,
+		"declarationDir": "dist",
+		"emitDeclarationOnly": true
+	}
+}

--- a/plugins/open-library-api/tsconfig.json
+++ b/plugins/open-library-api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../pkg/scaffold/tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"baseUrl": ".",
+		"lib": ["ESNext", "DOM"],
+		"esModuleInterop": true
+	},
+	"exclude": ["node_modules"],
+	"include": ["src"]
+}

--- a/plugins/open-library-api/vite.config.js
+++ b/plugins/open-library-api/vite.config.js
@@ -1,0 +1,23 @@
+import path from "path";
+
+/** @type {import('vite').UserConfig} */
+const config = {
+	build: {
+		sourcemap: true,
+		lib: {
+			name: "@librocco/db",
+			entry: path.join(__dirname, "src", "index.ts"),
+			fileName: (fmt) => (fmt === "es" ? "index.es.js" : "index.js"),
+			formats: ["es", "cjs"]
+		},
+		rollupOptions: {
+			external: ["@librocco/db"],
+			output: {
+				exports: "named"
+			}
+		},
+		outDir: "dist"
+	}
+};
+
+export default config;

--- a/rush.json
+++ b/rush.json
@@ -409,6 +409,10 @@
 		{
 			"packageName": "@librocco/google-books-api-plugin",
 			"projectFolder": "plugins/google-books-api"
+		},
+		{
+			"packageName": "@librocco/open-library-api-plugin",
+			"projectFolder": "plugins/open-library-api"
 		}
 	]
 }


### PR DESCRIPTION
Partly fixes #477 

The openLibrary plugin could now be used, however, only one plugin could be registered at a time. So, if the google books plugin is registered after, it would overwrite the openLibrary one. Currently, the google books one takes precedence. 

I started on creating a controller that fetches book data from multiple sources, merges the results, and returns the combined data, however, I couldn't catch enough time to wrap it up.