### PR TITLE
book fetcher plugin controller:

### DIFF
--- a/pkg/db/src/implementations/version-1.2/book-fetcher-plugin.ts
+++ b/pkg/db/src/implementations/version-1.2/book-fetcher-plugin.ts
@@ -1,0 +1,65 @@
+import { BehaviorSubject, Observable, combineLatest, map, switchMap } from "rxjs";
+
+import { wrapIter } from "@librocco/shared";
+
+import { BookEntry, BookFetcherPlugin, LibroccoPlugin } from "@/types";
+
+export class BookFetcherPluginController implements LibroccoPlugin<BookFetcherPlugin> {
+	#lookup = new Map<string, BookFetcherPlugin>();
+	#availabilityStreams = new BehaviorSubject([] as Observable<boolean>[]);
+
+	__name = "root";
+
+	isAvailableStream = this.#availabilityStreams.pipe(
+		// If at least one of the registered implementations is available, the plugin is considered available
+		switchMap((streams) => combineLatest(streams).pipe(map(($streams) => $streams.some((s) => s))))
+	);
+
+	constructor() {
+		this.#lookup.set("fallback", bookFetcherFallback);
+		// Register is written as a property and not a method because the plugins interface
+		// checks for register using 'Object.hasOwn' and method doesn't get picked up
+		//
+		// This is necessary in order for the 'register' method to be preserved on the plugin and not overridden
+		// by the plugins interface's default method
+		this.register = this.register.bind(this);
+	}
+
+	register = (plugin: BookFetcherPlugin) => {
+		// Add the plugin to the lookup
+		// If the plugin is a different instance of the same implementation, it won't be added
+		// (same implementation is registered only once)
+		this.#lookup.set(plugin.__name, plugin);
+
+		// Reflect any potential updates to in the availability streams.
+		//
+		// If no plugin was added - no novel implementation was registered, this is an identity operation
+		const availabilityStreams = wrapIter(this.#lookup.values())
+			.map(({ isAvailableStream }) => isAvailableStream)
+			.array();
+		this.#availabilityStreams.next(availabilityStreams);
+
+		return this;
+	};
+
+	async fetchBookData(isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]> {
+		const results = await Promise.all(wrapIter(this.#lookup.entries()).map(([, plugin]) => plugin.fetchBookData(isbns)));
+		const init = Array<Partial<BookEntry> | undefined>(isbns.length).fill(undefined);
+		return results.reduce(mergeResults, init);
+	}
+}
+
+type FetchBookDataRes = Awaited<ReturnType<BookFetcherPlugin["fetchBookData"]>>;
+
+const mergeResults = (prev: FetchBookDataRes, curr: FetchBookDataRes) =>
+	wrapIter(prev)
+		.zip(curr)
+		.map(([_acc, _curr]) => (!_curr ? _acc : { ..._acc, ..._curr }))
+		.array();
+
+const bookFetcherFallback = {
+	__name: "fallback",
+	// The 'fetchBookData' is expected to return the same number of results as the number of isbns requested
+	fetchBookData: async (isbns: string[]) => Array(isbns.length).fill(undefined),
+	isAvailableStream: new BehaviorSubject(false)
+};

--- a/pkg/db/src/implementations/version-1.2/plugins.ts
+++ b/pkg/db/src/implementations/version-1.2/plugins.ts
@@ -1,5 +1,6 @@
 import { LibroccoPlugin, PluginInterfaceLookup } from "@/types";
-import { BehaviorSubject } from "rxjs";
+
+import { BookFetcherPluginController } from "./book-fetcher-plugin";
 
 export interface PluginsInterface {
 	get<T extends keyof PluginInterfaceLookup>(pluginName: T): LibroccoPlugin<PluginInterfaceLookup[T]>;
@@ -10,32 +11,30 @@ class Plugins implements PluginsInterface {
 
 	constructor() {
 		this.#lookup = {
-			"book-fetcher": bookFetcherFallback
+			// We're using a book fetcher plugin controller to manage the book fetcher plugins
+			// the book fetcher plugin controller has its own 'register' method, meaning: all book fetcher
+			// plugin implementations will be registered internally and "book-fetcher" (in this lookup) will
+			// always be the plugin controller (it won't get overwritten by new registrations)
+			"book-fetcher": new BookFetcherPluginController()
 		};
 	}
 
-	private set<T extends keyof PluginInterfaceLookup>(pluginName: T): (plugin: PluginInterfaceLookup[T]) => void {
-		return (plugin: PluginInterfaceLookup[T]) => {
-			this.#lookup[pluginName] = plugin;
-		};
+	private set<T extends keyof PluginInterfaceLookup>(pluginName: T, plugin: PluginInterfaceLookup[T]): void {
+		this.#lookup[pluginName] = plugin;
 	}
 
 	get<T extends keyof PluginInterfaceLookup>(pluginName: T): LibroccoPlugin<PluginInterfaceLookup[T]> {
 		const plugin = this.#lookup[pluginName];
 		const register = (plugin: PluginInterfaceLookup[T]) => {
-			this.set(pluginName)(plugin);
-			return Object.assign(plugin, { register });
+			this.set(pluginName, plugin);
+
+			// If the instance has a its own register method, we're using that one, otherwise we're assigning a default register - acitve instance will be overwitten
+			return Object.hasOwn(plugin, "register") ? (plugin as LibroccoPlugin<PluginInterfaceLookup[T]>) : Object.assign(plugin, { register });
 		};
-		return Object.assign(plugin, { register });
+
+		// If the instance has a its own register method, we're using that one, otherwise we're assigning a default register - acitve instance will be overwitten
+		return Object.hasOwn(plugin, "register") ? (plugin as LibroccoPlugin<PluginInterfaceLookup[T]>) : Object.assign(plugin, { register });
 	}
 }
-
-// #region fallbacks
-const bookFetcherFallback = {
-	// The 'fetchBookData' is expected to return the same number of results as the number of isbns requested
-	fetchBookData: async (isbns: string[]) => Array(isbns.length).fill(undefined),
-	isAvailableStream: new BehaviorSubject(false)
-};
-// #endregion fallbacks
 
 export const newPluginsInterface = () => new Plugins();

--- a/pkg/db/src/types/misc.ts
+++ b/pkg/db/src/types/misc.ts
@@ -170,6 +170,8 @@ export type LibroccoPlugin<T extends {}> = {
 } & T;
 
 export interface BookFetcherPlugin {
+	// Name is used to differentiate between different implementations satisfying the same interface
+	__name: string;
 	fetchBookData(isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]>;
 	isAvailableStream: Observable<boolean>;
 }

--- a/plugins/book-data-extension/src/plugin/index.ts
+++ b/plugins/book-data-extension/src/plugin/index.ts
@@ -13,7 +13,7 @@ export const createBookDataExtensionPlugin = (): BookFetcherPlugin => {
 		return Promise.all(isbns.map((isbn) => fetchBook(isbn)));
 	};
 
-	return { fetchBookData, isAvailableStream };
+	return { __name: "chrome-extension", fetchBookData, isAvailableStream };
 };
 
 const createAvailabilityStream = () => {

--- a/plugins/google-books-api/src/index.ts
+++ b/plugins/google-books-api/src/index.ts
@@ -19,7 +19,7 @@ export function createGoogleBooksApiPlugin(): BookFetcherPlugin {
 		return Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))));
 	};
 
-	return { fetchBookData, isAvailableStream };
+	return { __name: "google-books-api", fetchBookData, isAvailableStream };
 }
 
 type GBookEntry = {

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -16,7 +16,7 @@ export function createOpenLibraryApiPlugin(): BookFetcherPlugin {
 		return Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse)));
 	};
 
-	return { fetchBookData, isAvailableStream };
+	return { __name: "open-library-api", fetchBookData, isAvailableStream };
 }
 
 type OLBookEntry = {


### PR DESCRIPTION
* add a root book fetcher plugin as a controller and register all instances against it
* when fetching book data the controller will perform fetch on all registeres instances and merge the results
* when checking for availability (isAvailableStream) - the plugin controller will emit `true` if at least one instance is available

Fixes #477 
