### PR TITLE
Enhance/fetch book data streaming results

### DIFF
--- a/apps/web-client/src/lib/stores/inventory/table_content.ts
+++ b/apps/web-client/src/lib/stores/inventory/table_content.ts
@@ -109,7 +109,8 @@ export const createDisplayEntriesStore: CreateDisplayEntriesStore = (
 const mergeBookData = (stock: Iterable<VolumeStockClient>) => (bookData: Iterable<BookEntry | undefined>) =>
 	wrapIter(stock)
 		.zip(bookData)
-		.map(([s, b = {} as BookEntry]) => ({ ...s, ...b }))
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		.map(([s, { updatedAt, ...b } = {} as BookEntry]) => ({ ...s, ...b }))
 		.array();
 
 const applyDiscount = <T extends Pick<VolumeStockClient<"book">, "warehouseDiscount"> & Pick<BookEntry, "price">>({

--- a/apps/web-client/src/lib/utils/misc.ts
+++ b/apps/web-client/src/lib/utils/misc.ts
@@ -1,6 +1,6 @@
 import { Observable, combineLatest, map } from "rxjs";
 
-import type { BookEntry, WarehouseDataMap } from "@librocco/db";
+import type { BookEntry, BookFetchResultEntry, WarehouseDataMap } from "@librocco/db";
 import { wrapIter, debug } from "@librocco/shared";
 
 import type { DailySummaryStore } from "$lib/types/inventory";
@@ -82,3 +82,19 @@ export const mapMergeBookWarehouseData =
 				};
 			})
 		);
+
+// #region book data fetching
+/**
+ * Merges book data for the same book retrieved from multiple sources
+ * @param sources
+ * @param kind "prefer_first" - values from the source that comes first in the array will be preferred and vice versa
+ * @returns
+ */
+export const mergeBookData = (sources: BookFetchResultEntry[], kind: "prefer_first" | "prefer_last" = "prefer_first") =>
+	!sources.some(Boolean)
+		? undefined
+		: kind === "prefer_first"
+		? sources.reduceRight((acc = {}, curr = {}) => ({ ...acc, ...curr }), {})
+		: sources.reduce((acc = {}, curr = {}) => ({ ...acc, ...curr }), {});
+
+// #endregion book data fetching

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -261,7 +261,7 @@
 
 			<div class="ml-auto flex items-center gap-x-2">
 				<button
-					class="button button-green xs:block hidden"
+					class="button button-green hidden xs:block"
 					use:melt={$dialogTrigger}
 					on:m-click={() => {
 						dialogContent = {
@@ -296,7 +296,7 @@
 								type: "commit"
 							};
 						}}
-						class="data-[highlighted]:bg-gray-100 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 xs:hidden"
 					>
 						<FileCheck class="text-gray-400" size={20} /><span class="text-gray-700">Commit</span>
 					</div>
@@ -304,7 +304,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrintReceipt}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -312,7 +312,7 @@
 						{...item}
 						use:item.action
 						on:m-click={autoPrintLabels.toggle}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 {$autoPrintLabels
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 {$autoPrintLabels
 							? '!bg-green-400'
 							: ''}"
 					>
@@ -322,7 +322,7 @@
 						{...item}
 						use:item.action
 						use:melt={$dialogTrigger}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 						on:m-click={() => {
 							dialogContent = {
 								onConfirm: handleDeleteSelf,

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -118,7 +118,7 @@
 		}
 
 		// If book data retrieved from 3rd party source - store it for future use
-		const [thirdPartyBookData] = await db.plugin("book-fetcher").fetchBookData([isbn]);
+		const [[thirdPartyBookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 		if (thirdPartyBookData) {
 			await db.books().upsert([thirdPartyBookData]);
 		}
@@ -481,9 +481,8 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
+							const [[bookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 
-							const [bookData] = result;
 							if (!bookData) {
 								return;
 							}

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -121,9 +121,8 @@
 		// If book data retrieved from 3rd party source - store it for future use
 		const thirdPartyBookData = await db
 			.plugin("book-fetcher")
-			.fetchBookData([isbn])
+			.fetchBookData(isbn)
 			.all()
-			.then((results) => results.map(([b]) => b))
 			.then((bookData) => mergeBookData(bookData));
 
 		if (thirdPartyBookData) {
@@ -253,7 +252,7 @@
 
 			<div class="ml-auto flex items-center gap-x-2">
 				<button
-					class="button button-green xs:block hidden"
+					class="button button-green hidden xs:block"
 					use:melt={$dialogTrigger}
 					on:m-click={() => {
 						dialogContent = {
@@ -288,7 +287,7 @@
 								type: "commit"
 							};
 						}}
-						class="data-[highlighted]:bg-gray-100 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 xs:hidden"
 					>
 						<FileCheck class="text-gray-400" size={20} /><span class="text-gray-700">Commit</span>
 					</div>
@@ -296,7 +295,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrintReceipt}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -304,7 +303,7 @@
 						{...item}
 						use:item.action
 						on:m-click={autoPrintLabels.toggle}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 {$autoPrintLabels
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 {$autoPrintLabels
 							? '!bg-green-400'
 							: ''}"
 					>
@@ -314,7 +313,7 @@
 						{...item}
 						use:item.action
 						use:melt={$dialogTrigger}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 						on:m-click={() => {
 							dialogContent = {
 								onConfirm: handleDeleteSelf,
@@ -488,9 +487,9 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const results = await db.plugin("book-fetcher").fetchBookData([isbn]).all();
+							const results = await db.plugin("book-fetcher").fetchBookData(isbn).all();
 							// Entries from (potentially) multiple sources for the same book (the only one requested in this case)
-							const bookData = mergeBookData(results.map(([b]) => b));
+							const bookData = mergeBookData(results);
 
 							// If there's no book was retrieved from any of the sources, exit early
 							if (!bookData) {

--- a/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
@@ -295,9 +295,8 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
+							const [[bookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 
-							const [bookData] = result;
 							if (!bookData) {
 								return;
 							}

--- a/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
@@ -298,9 +298,9 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const results = await db.plugin("book-fetcher").fetchBookData([isbn]).all();
+							const results = await db.plugin("book-fetcher").fetchBookData(isbn).all();
 							// Entries from (potentially) multiple sources for the same book (the only one requested in this case)
-							const bookData = mergeBookData(results.map(([b]) => b));
+							const bookData = mergeBookData(results);
 
 							// If there's no book was retrieved from any of the sources, exit early
 							if (!bookData) {

--- a/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import { fade, fly } from "svelte/transition";
 	import { writable } from "svelte/store";
+	import { download, generateCsv, mkConfig } from "export-to-csv";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { Search, FileEdit, X, Loader2 as Loader, Printer, MoreVertical } from "lucide-svelte";
 
 	import { debug, testId } from "@librocco/shared";
 	import type { BookEntry } from "@librocco/db";
+
+	import type { InventoryTableData } from "$lib/components/Tables/types";
 
 	import {
 		Page,
@@ -26,17 +29,17 @@
 	import type { PageData } from "./$types";
 
 	import { getDB } from "$lib/db";
+	import { printBookLabel } from "$lib/printer";
 
 	import { createWarehouseStores } from "$lib/stores/proto";
 
 	import { createIntersectionObserver, createTable } from "$lib/actions";
 
 	import { readableFromStream } from "$lib/utils/streams";
+	import { mergeBookData } from "$lib/utils/misc";
 
 	import { appPath } from "$lib/paths";
-	import { printBookLabel } from "$lib/printer";
-	import { download, generateCsv, mkConfig } from "export-to-csv";
-	import type { InventoryTableData } from "$lib/components/Tables/types";
+
 	export let data: PageData;
 
 	// Db will be undefined only on server side. If in browser,
@@ -295,8 +298,11 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const [[bookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
+							const results = await db.plugin("book-fetcher").fetchBookData([isbn]).all();
+							// Entries from (potentially) multiple sources for the same book (the only one requested in this case)
+							const bookData = mergeBookData(results.map(([b]) => b));
 
+							// If there's no book was retrieved from any of the sources, exit early
 							if (!bookData) {
 								return;
 							}

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -172,7 +172,7 @@
 		}
 
 		// If book data retrieved from 3rd party source - store it for future use
-		const [thirdPartyBookData] = await db.plugin("book-fetcher").fetchBookData([isbn]);
+		const [[thirdPartyBookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 		if (thirdPartyBookData) {
 			await db.books().upsert([thirdPartyBookData]);
 		}
@@ -642,9 +642,8 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
+							const [[bookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 
-							const [bookData] = result;
 							if (!bookData) {
 								return;
 							}

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -175,9 +175,8 @@
 		// If book data retrieved from 3rd party source - store it for future use
 		const thirdPartyBookData = await db
 			.plugin("book-fetcher")
-			.fetchBookData([isbn])
+			.fetchBookData(isbn)
 			.all()
-			.then((results) => results.map(([b]) => b))
 			.then((bookData) => mergeBookData(bookData));
 
 		if (thirdPartyBookData) {
@@ -383,7 +382,7 @@
 					</select>
 				</div>
 				<button
-					class="button button-green xs:block hidden"
+					class="button button-green hidden xs:block"
 					use:melt={$dialogTrigger}
 					on:m-click={() => {
 						dialogContent = {
@@ -418,7 +417,7 @@
 								type: "commit"
 							};
 						}}
-						class="data-[highlighted]:bg-gray-100 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 xs:hidden"
 					>
 						<FileCheck class="text-gray-400" size={20} /><span class="text-gray-700">Commit</span>
 					</div>
@@ -426,7 +425,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrintReceipt}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -434,7 +433,7 @@
 						{...item}
 						use:item.action
 						use:melt={$dialogTrigger}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 						on:m-click={() => {
 							dialogContent = {
 								onConfirm: handleDeleteSelf,
@@ -649,9 +648,9 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const results = await db.plugin("book-fetcher").fetchBookData([isbn]).all();
+							const results = await db.plugin("book-fetcher").fetchBookData(isbn).all();
 							// Entries from (potentially) multiple sources for the same book (the only one requested in this case)
-							const bookData = mergeBookData(results.map(([b]) => b));
+							const bookData = mergeBookData(results);
 
 							// If there's no book was retrieved from any of the sources, exit early
 							if (!bookData) {

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -390,7 +390,7 @@
 					</select>
 				</div>
 				<button
-					class="button button-green xs:block hidden"
+					class="button button-green hidden xs:block"
 					use:melt={$dialogTrigger}
 					on:m-click={() => {
 						dialogContent = {
@@ -425,7 +425,7 @@
 								type: "commit"
 							};
 						}}
-						class="data-[highlighted]:bg-gray-100 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100 xs:hidden"
 					>
 						<FileCheck class="text-gray-400" size={20} /><span class="text-gray-700">Commit</span>
 					</div>
@@ -433,7 +433,7 @@
 						{...item}
 						use:item.action
 						on:m-click={handlePrintReceipt}
-						class="data-[highlighted]:bg-gray-100 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-gray-100"
 					>
 						<Printer class="text-gray-400" size={20} /><span class="text-gray-700">Print</span>
 					</div>
@@ -441,7 +441,7 @@
 						{...item}
 						use:item.action
 						use:melt={$dialogTrigger}
-						class="data-[highlighted]:bg-red-500 flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
+						class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-red-500"
 						on:m-click={() => {
 							dialogContent = {
 								onConfirm: handleDeleteSelf,

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -258,9 +258,9 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const results = await db.plugin("book-fetcher").fetchBookData([isbn]).all();
+							const results = await db.plugin("book-fetcher").fetchBookData(isbn).all();
 							// Entries from (potentially) multiple sources for the same book (the only one requested in this case)
-							const bookData = mergeBookData(results.map(([b]) => b));
+							const bookData = mergeBookData(results);
 
 							// If there's no book was retrieved from any of the sources, exit early
 							if (!bookData) {

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -255,9 +255,8 @@
 						}}
 						onCancel={() => open.set(false)}
 						onFetch={async (isbn, form) => {
-							const result = await db.plugin("book-fetcher").fetchBookData([isbn]);
+							const [[bookData]] = await db.plugin("book-fetcher").fetchBookData([isbn]).promise();
 
-							const [bookData] = result;
 							if (!bookData) {
 								return;
 							}

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -231,10 +231,6 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 			expect(entries).toEqual([]);
 		});
 
-		// There is no book data for isbns we're about to add
-		let bookData = await db.books().get(["0123456789", "11111111"]);
-		expect(bookData).toEqual([undefined, undefined]);
-
 		// Adding volumes should add transactions to the note
 		await note.addVolumes(
 			{ isbn: "0123456789", quantity: 2, warehouseId: wh1._id },
@@ -275,11 +271,6 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 				}
 			]);
 		});
-
-		// Adding volumes to the note should also create (empty: isbn-only) book data entries for added volumes
-		bookData = await db.books().get(["0123456789", "11111111"]);
-
-		await waitFor(() => expect(bookData).toEqual([{ isbn: "0123456789" }, { isbn: "11111111" }]));
 
 		// Adding volumes to the same ISBN/warheouseId pair should simply aggregate the quantities
 		await note.addVolumes(

--- a/pkg/db/src/__tests__/inventory/main.test.ts
+++ b/pkg/db/src/__tests__/inventory/main.test.ts
@@ -13,6 +13,7 @@ import { NoWarehouseSelectedError, OutOfStockError, TransactionWarehouseMismatch
 
 import { createVersioningFunction } from "@/utils/misc";
 import { newTestDB } from "@/__testUtils__/db";
+import { fetchBookDataFromSingleSource } from "@/utils/plugins";
 
 import { fiftyEntries } from "./data";
 
@@ -2321,7 +2322,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		// The impl1 will return the 'isbn' and the 'title' (same as isbn)
 		const impl1 = {
 			__name: "impl-1",
-			fetchBookData: async (isbns: string[]) => isbns.map((isbn) => ({ isbn, title: isbn })),
+			fetchBookData: fetchBookDataFromSingleSource(async (isbns) => isbns.map((isbn) => ({ isbn, title: isbn }))),
 			isAvailableStream: new BehaviorSubject(false),
 			checkAvailability: async () => {}
 		};
@@ -2343,7 +2344,7 @@ describe.each(schema)("Inventory unit tests: $version", ({ version, getDB }) => 
 		// The impl2 will return only the price (static 20) - the results should be merged
 		const impl2 = {
 			__name: "impl-2",
-			fetchBookData: async (isbns: string[]) => isbns.map(() => ({ price: 20 })),
+			fetchBookData: fetchBookDataFromSingleSource(async (isbns) => isbns.map(() => ({ price: 20 }))),
 			isAvailableStream: new BehaviorSubject(false),
 			checkAvailability: async () => {}
 		};

--- a/pkg/db/src/implementations/version-1.2/note.ts
+++ b/pkg/db/src/implementations/version-1.2/note.ts
@@ -326,21 +326,6 @@ class Note implements NoteInterface {
 				this.entries.push({ ...existing, quantity: existing.quantity + update.quantity } as VolumeStock<"book">);
 			});
 
-			// Create book data entries for added books (if they don't exist)
-			// We're not awaiting this as it's not that relevant immediately
-			const isbns = (params as VolumeStock[]).filter(isBookRow).map(({ isbn }) => isbn);
-			this.#db
-				.books()
-				.get(isbns)
-				.then((results) => {
-					const bookDataToCreate = wrapIter(isbns)
-						.zip(results)
-						.filter(([, r]) => !r)
-						.map(([isbn]) => ({ isbn }))
-						.array();
-					return this.#db.books().upsert(bookDataToCreate);
-				});
-
 			return this.update({}, this);
 		}, this.#initialized);
 	}

--- a/pkg/db/src/index.ts
+++ b/pkg/db/src/index.ts
@@ -18,4 +18,6 @@ export * from "./enums";
 export * from "./types";
 export * from "./constants";
 export * from "./errors";
+
 export { isBookRow, isCustomItemRow } from "./utils/misc";
+export { fetchBookDataFromSingleSource } from "./utils/plugins";

--- a/pkg/db/src/types/index.ts
+++ b/pkg/db/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./inventory";
 export * from "./orders";
 
 export * from "./misc";
+export * from "./plugins";

--- a/pkg/db/src/types/misc.ts
+++ b/pkg/db/src/types/misc.ts
@@ -6,6 +6,8 @@ import { debug } from "@librocco/shared";
 
 import type { DocType } from "@/enums";
 
+import type { LibroccoPlugin, PluginInterfaceLookup } from "./plugins";
+
 // #region utils
 /**
  * Used to make one or more properties on the object optional.
@@ -163,28 +165,3 @@ export interface Replicator {
 	sync: (url: string | PouchDB.Database, options: PouchDB.Replication.ReplicateOptions) => PouchDB.Replication.Sync<{}>;
 }
 // #endregion replication
-
-// #region plugins
-export type LibroccoPlugin<T extends {}> = {
-	register: (instance: T) => LibroccoPlugin<T>;
-} & T;
-
-export type BookFetchResultEntry = Partial<BookEntry> | undefined;
-
-export interface BookFetchResult {
-	first(): Promise<BookFetchResultEntry[]>;
-	stream(): Observable<BookFetchResultEntry[]>;
-	all(): Promise<BookFetchResultEntry[][]>;
-}
-
-export interface BookFetcherPlugin {
-	// Name is used to differentiate between different implementations satisfying the same interface
-	__name: string;
-	fetchBookData(isbns: string[]): BookFetchResult;
-	isAvailableStream: Observable<boolean>;
-}
-
-export interface PluginInterfaceLookup {
-	"book-fetcher": BookFetcherPlugin;
-}
-// #endregion plugins

--- a/pkg/db/src/types/misc.ts
+++ b/pkg/db/src/types/misc.ts
@@ -172,9 +172,9 @@ export type LibroccoPlugin<T extends {}> = {
 export type BookFetchResultEntry = Partial<BookEntry> | undefined;
 
 export interface BookFetchResult {
+	first(): Promise<BookFetchResultEntry[]>;
 	stream(): Observable<BookFetchResultEntry[]>;
-	promise(): Promise<BookFetchResultEntry[][]>;
-	onResult(cb: (r: BookFetchResultEntry[]) => void): void;
+	all(): Promise<BookFetchResultEntry[][]>;
 }
 
 export interface BookFetcherPlugin {

--- a/pkg/db/src/types/misc.ts
+++ b/pkg/db/src/types/misc.ts
@@ -169,10 +169,18 @@ export type LibroccoPlugin<T extends {}> = {
 	register: (instance: T) => LibroccoPlugin<T>;
 } & T;
 
+export type BookFetchResultEntry = Partial<BookEntry> | undefined;
+
+export interface BookFetchResult {
+	stream(): Observable<BookFetchResultEntry[]>;
+	promise(): Promise<BookFetchResultEntry[][]>;
+	onResult(cb: (r: BookFetchResultEntry[]) => void): void;
+}
+
 export interface BookFetcherPlugin {
 	// Name is used to differentiate between different implementations satisfying the same interface
 	__name: string;
-	fetchBookData(isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]>;
+	fetchBookData(isbns: string[]): BookFetchResult;
 	isAvailableStream: Observable<boolean>;
 }
 

--- a/pkg/db/src/types/misc.ts
+++ b/pkg/db/src/types/misc.ts
@@ -68,6 +68,9 @@ export interface BookEntry {
 	editedBy?: string;
 	outOfPrint?: boolean;
 	category?: string;
+
+	/** Book data that has 'updatedAt' field set had already been filled with data */
+	updatedAt?: string;
 }
 
 /**

--- a/pkg/db/src/types/plugins.ts
+++ b/pkg/db/src/types/plugins.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import { Observable } from "rxjs";
+import { BookEntry } from "./misc";
+
+// #region plugins
+export type LibroccoPlugin<T extends {}> = {
+	register: (instance: T) => LibroccoPlugin<T>;
+} & T;
+
+export type BookFetchResultEntry = Partial<BookEntry> | undefined;
+
+export interface BookFetchResult {
+	first(): Promise<BookFetchResultEntry>;
+	stream(): Observable<BookFetchResultEntry>;
+	all(): Promise<BookFetchResultEntry[]>;
+}
+
+export interface BookFetcherPlugin {
+	// Name is used to differentiate between different implementations satisfying the same interface
+	__name: string;
+	fetchBookData(isbns: string): BookFetchResult;
+	isAvailableStream: Observable<boolean>;
+}
+
+export interface PluginInterfaceLookup {
+	"book-fetcher": BookFetcherPlugin;
+}
+// #endregion plugins

--- a/pkg/db/src/utils/plugins.ts
+++ b/pkg/db/src/utils/plugins.ts
@@ -1,0 +1,13 @@
+import { from } from "rxjs";
+
+import type { BookFetchResult, BookFetchResultEntry } from "@/types";
+
+export const fetchBookDataFromSingleSource =
+	(constructRequest: (isbns: string[]) => Promise<BookFetchResultEntry[]>) =>
+	(isbns: string[]): BookFetchResult => {
+		const request = constructRequest(isbns);
+		const promise = () => Promise.all([request]);
+		const stream = () => from(request);
+		const onResult = (cb: (r: BookFetchResultEntry[]) => void) => stream().subscribe(cb);
+		return { promise, stream, onResult };
+	};

--- a/pkg/db/src/utils/plugins.ts
+++ b/pkg/db/src/utils/plugins.ts
@@ -6,8 +6,8 @@ export const fetchBookDataFromSingleSource =
 	(constructRequest: (isbns: string[]) => Promise<BookFetchResultEntry[]>) =>
 	(isbns: string[]): BookFetchResult => {
 		const request = constructRequest(isbns);
-		const promise = () => Promise.all([request]);
+		const first = () => request;
 		const stream = () => from(request);
-		const onResult = (cb: (r: BookFetchResultEntry[]) => void) => stream().subscribe(cb);
-		return { promise, stream, onResult };
+		const all = () => Promise.all([request]);
+		return { first, stream, all };
 	};

--- a/pkg/db/src/utils/plugins.ts
+++ b/pkg/db/src/utils/plugins.ts
@@ -3,9 +3,9 @@ import { from } from "rxjs";
 import type { BookFetchResult, BookFetchResultEntry } from "@/types";
 
 export const fetchBookDataFromSingleSource =
-	(constructRequest: (isbns: string[]) => Promise<BookFetchResultEntry[]>) =>
-	(isbns: string[]): BookFetchResult => {
-		const request = constructRequest(isbns);
+	(constructRequest: (isbn: string) => Promise<BookFetchResultEntry>) =>
+	(isbn: string): BookFetchResult => {
+		const request = constructRequest(isbn);
 		const first = () => request;
 		const stream = () => from(request);
 		const all = () => Promise.all([request]);

--- a/plugins/book-data-extension/src/plugin/__tests__/book-fetcher.test.ts
+++ b/plugins/book-data-extension/src/plugin/__tests__/book-fetcher.test.ts
@@ -1,5 +1,5 @@
 import { filter, firstValueFrom } from "rxjs";
-import { test, describe, expect, vi } from "vitest";
+import { test, expect, vi } from "vitest";
 
 import { BookEntry, BookFetcherPlugin } from "@librocco/db";
 import { testUtils } from "@librocco/shared";
@@ -18,30 +18,11 @@ const withExtensionAvailable = async (plugin: BookFetcherPlugin) => {
 	return plugin;
 };
 
-describe("createBookDataExtensionPlugin", () => {
-	test("fetchBookData returns books when called with isbns", async () => {
-		vi.spyOn(comm, "ping").mockImplementation(() => Promise.resolve(true));
-		vi.spyOn(comm, "fetchBook").mockImplementation((isbn: string) => Promise.resolve({ title: `book-${isbn}` } as BookEntry));
+test("fetchBookData returns book when called with isbn", async () => {
+	vi.spyOn(comm, "ping").mockImplementation(() => Promise.resolve(true));
+	vi.spyOn(comm, "fetchBook").mockImplementation((isbn: string) => Promise.resolve({ title: `book-${isbn}` } as BookEntry));
 
-		const plugin = await withExtensionAvailable(createBookDataExtensionPlugin());
-		// The isbns are in a scattered lexicographical order to verify that the results will come in the same order as requested
-		const books = await plugin.fetchBookData(["3333", "1111", "2222"]);
+	const plugin = await withExtensionAvailable(createBookDataExtensionPlugin());
 
-		expect(books).toEqual([{ title: "book-3333" }, { title: "book-1111" }, { title: "book-2222" }]);
-	});
-
-	test("fetchBookData returns the same number of results even if book data for some isbns isn't found", async () => {
-		vi.spyOn(comm, "ping").mockImplementation(() => Promise.resolve(true));
-		vi.spyOn(comm, "fetchBook").mockImplementation((isbn: string) =>
-			isbn == "1111"
-				? // Make it so as if "1111" is not found
-				  Promise.resolve(undefined)
-				: Promise.resolve({ title: `book-${isbn}` } as BookEntry)
-		);
-
-		const plugin = await withExtensionAvailable(createBookDataExtensionPlugin());
-		const books = await plugin.fetchBookData(["3333", "1111", "2222"]);
-
-		expect(books).toEqual([{ title: "book-3333" }, undefined, { title: "book-2222" }]);
-	});
+	expect(await plugin.fetchBookData("3333").first()).toEqual({ title: "book-3333" });
 });

--- a/plugins/book-data-extension/src/plugin/index.ts
+++ b/plugins/book-data-extension/src/plugin/index.ts
@@ -9,7 +9,7 @@ export const createBookDataExtensionPlugin = (): BookFetcherPlugin => {
 	// Continuous availability stream
 	const isAvailableStream = createAvailabilityStream();
 
-	const fetchBookData = fetchBookDataFromSingleSource((isbns) => Promise.all(isbns.map((isbn) => fetchBook(isbn))));
+	const fetchBookData = fetchBookDataFromSingleSource((isbn) => fetchBook(isbn));
 
 	return { __name: "chrome-extension", fetchBookData, isAvailableStream };
 };

--- a/plugins/book-data-extension/src/plugin/index.ts
+++ b/plugins/book-data-extension/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable, concat, from, share } from "rxjs";
 
-import { BookFetcherPlugin, BookEntry } from "@librocco/db";
+import { BookFetcherPlugin, fetchBookDataFromSingleSource } from "@librocco/db";
 
 import { continuousListener } from "./listeners";
 import { fetchBook, ping } from "./comm";
@@ -9,9 +9,7 @@ export const createBookDataExtensionPlugin = (): BookFetcherPlugin => {
 	// Continuous availability stream
 	const isAvailableStream = createAvailabilityStream();
 
-	const fetchBookData = async (isbns: string[]): Promise<(BookEntry | undefined)[]> => {
-		return Promise.all(isbns.map((isbn) => fetchBook(isbn)));
-	};
+	const fetchBookData = fetchBookDataFromSingleSource((isbns) => Promise.all(isbns.map((isbn) => fetchBook(isbn))));
 
 	return { __name: "chrome-extension", fetchBookData, isAvailableStream };
 };

--- a/plugins/google-books-api/src/index.ts
+++ b/plugins/google-books-api/src/index.ts
@@ -15,9 +15,8 @@ export function createGoogleBooksApiPlugin(): BookFetcherPlugin {
 	// The plugin is always available (as long as there's internet connection)
 	const isAvailableStream = new BehaviorSubject(true);
 
-	const fetchBookData = fetchBookDataFromSingleSource((isbns) =>
-		Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))))
-	);
+	const fetchBookData = fetchBookDataFromSingleSource((isbn) => fetchBook(isbn).then(processResponse(isbn)));
+
 	return { __name: "google-books-api", fetchBookData, isAvailableStream };
 }
 

--- a/plugins/google-books-api/src/index.ts
+++ b/plugins/google-books-api/src/index.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject } from "rxjs";
 
-import { type BookFetcherPlugin, type BookEntry } from "@librocco/db";
+import { type BookFetcherPlugin, type BookEntry, fetchBookDataFromSingleSource } from "@librocco/db";
 
 const baseurl = "https://www.googleapis.com/books/v1/volumes";
 const reqFields = [
@@ -15,10 +15,9 @@ export function createGoogleBooksApiPlugin(): BookFetcherPlugin {
 	// The plugin is always available (as long as there's internet connection)
 	const isAvailableStream = new BehaviorSubject(true);
 
-	const fetchBookData = async (isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]> => {
-		return Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))));
-	};
-
+	const fetchBookData = fetchBookDataFromSingleSource((isbns) =>
+		Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))))
+	);
 	return { __name: "google-books-api", fetchBookData, isAvailableStream };
 }
 

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -12,9 +12,8 @@ export function createOpenLibraryApiPlugin(): BookFetcherPlugin {
 	// The plugin is always available (as long as there's internet connection)
 	const isAvailableStream = new BehaviorSubject(true);
 
-	const fetchBookData = fetchBookDataFromSingleSource((isbns) =>
-		Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))))
-	);
+	const fetchBookData = fetchBookDataFromSingleSource((isbn) => fetchBook(isbn).then(processResponse(isbn)));
+
 	return { __name: "open-library-api", fetchBookData, isAvailableStream };
 }
 

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -30,7 +30,6 @@ type OLBooksRes = {
 
 async function fetchBook(isbn: string): Promise<OLBookEntry> {
 	const url = new URL(baseurl);
-	console.log({ url });
 
 	url.searchParams.append("q", isbn);
 	url.searchParams.append("limit", "1");

--- a/plugins/open-library-api/src/index.ts
+++ b/plugins/open-library-api/src/index.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject } from "rxjs";
 
-import { type BookFetcherPlugin, type BookEntry } from "@librocco/db";
+import { type BookFetcherPlugin, type BookEntry, fetchBookDataFromSingleSource } from "@librocco/db";
 
 const baseurl = "https://openlibrary.org/search.json";
 // publisher is an array
@@ -12,15 +12,13 @@ export function createOpenLibraryApiPlugin(): BookFetcherPlugin {
 	// The plugin is always available (as long as there's internet connection)
 	const isAvailableStream = new BehaviorSubject(true);
 
-	const fetchBookData = async (isbns: string[]): Promise<(Partial<BookEntry> | undefined)[]> => {
-		return Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse)));
-	};
-
+	const fetchBookData = fetchBookDataFromSingleSource((isbns) =>
+		Promise.all(isbns.map((isbn) => fetchBook(isbn).then(processResponse(isbn))))
+	);
 	return { __name: "open-library-api", fetchBookData, isAvailableStream };
 }
 
 type OLBookEntry = {
-	isbn: string;
 	title?: string;
 	author_name?: string[];
 	publisher?: string[];
@@ -42,25 +40,27 @@ async function fetchBook(isbn: string): Promise<OLBookEntry> {
 	const { docs = [] } = await fetch(url).then((r) => r.json() as OLBooksRes);
 	const [olBookData] = docs;
 
-	return { ...olBookData, isbn };
+	return olBookData;
 }
 
-function processResponse(olBook: OLBookEntry | undefined): Partial<BookEntry> | undefined {
-	if (!olBook) {
-		return undefined;
-	}
+function processResponse(isbn: string) {
+	return (olBook: OLBookEntry | undefined): Partial<BookEntry> | undefined => {
+		if (!olBook) {
+			return undefined;
+		}
 
-	const res: Partial<BookEntry> = { isbn: olBook.isbn };
+		const res: Partial<BookEntry> = {};
 
-	const { title, author_name: _authors, publisher, publish_date } = olBook;
-	const authors = _authors?.join(", ");
-	const publishers = publisher?.join(", "); // join or first element?
-	const year = publish_date?.[0] || "";
+		const { title, author_name: _authors, publisher, publish_date } = olBook;
+		const authors = _authors?.join(", ");
+		const publishers = publisher?.join(", "); // join or first element?
+		const year = publish_date?.[0] || "";
 
-	if (title) res.title = title;
-	if (authors) res.authors = authors;
-	if (publishers) res.publisher = publishers;
-	if (year) res.year = year;
+		if (title) res.title = title;
+		if (authors) res.authors = authors;
+		if (publishers) res.publisher = publishers;
+		if (year) res.year = year;
 
-	return res;
+		return { ...res, isbn };
+	};
 }


### PR DESCRIPTION
Continues from #491 
Contains fixes from #492 #493 but in a more sane manner

The `fetchBookData` now:
- accepts a single isbn
- returns:
  - first() - the value from first source to resolve resolved - TODO: have this be the first non `undefined` value (or `undefined` if none found)
  - stream() - streams the values as they're resolved
  - all() - awaits requests to all sources and resolves with an array of values (preserving the order of results = order of plugins)
- the `note.addVolumes` no longer touches the `db.books().upsert`
- the UI is in charge of updating the book data (in each note view)
- if the book data doesn't exist isbn-only entry is added
- if the book data exists, but doesn't have `updatedAt` field - initiates the fetch attempt
- if the book data has `updatedAt` - no automatic fetching takes place
- `updatedAt` is assigned/updated on each `db.books().upsert()` **only if the entry has at least one other field than isbn**