### PR TITLE
Only create url connectivity store if url is provided

### DIFF
--- a/apps/web-client/src/lib/stores/index.ts
+++ b/apps/web-client/src/lib/stores/index.ts
@@ -11,9 +11,10 @@ import { browser } from "$app/environment";
 
 const createDBConnectivityStream = () => {
 	const shareSuject = new BehaviorSubject(true);
+	const url = get(settingsStore).couchUrl;
 
-	return browser
-		? from(checkUrlConnection(get(settingsStore).couchUrl)).pipe(
+	return browser && url
+		? from(checkUrlConnection(url)).pipe(
 				map((response: Response) => response.ok),
 				catchError(() => of(false)),
 				share({ connector: () => shareSuject, resetOnComplete: false, resetOnError: false, resetOnRefCountZero: false })


### PR DESCRIPTION
Tiny fix for fetching undefined when using local pouchdb.