### PR TITLE
create a server/client safe `goto` wrapping Svelte's `goto`:

### DIFF
--- a/apps/web-client/.eslintrc.cjs
+++ b/apps/web-client/.eslintrc.cjs
@@ -8,7 +8,22 @@ const tsPaths = [path.join(__dirname, "./tsconfig.json")];
 module.exports = useTSConfig(
 	{
 		...scaffoldConfig,
-		ignorePatterns: [...scaffoldConfig.ignorePatterns, "playwright.config.ts"]
+		ignorePatterns: [...scaffoldConfig.ignorePatterns, "playwright.config.ts"],
+		rules: {
+			...scaffoldConfig.rules,
+			"no-restricted-imports": [
+				"error",
+				{
+					paths: [
+						{
+							name: "$app/navigation",
+							importNames: ["goto"],
+							message: "Please use `goto` from `$lib/utils/navigation` instead."
+						}
+					]
+				}
+			]
+		}
 	},
 	tsPaths
 );

--- a/apps/web-client/src/lib/components/HistoryPage.svelte
+++ b/apps/web-client/src/lib/components/HistoryPage.svelte
@@ -3,7 +3,7 @@
 
 	import { historyView, type HistoryView } from "@librocco/shared";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { page } from "$app/stores";
 
 	import Page from "$lib/components/Page.svelte";

--- a/apps/web-client/src/lib/components/InventoryManagementPage.svelte
+++ b/apps/web-client/src/lib/components/InventoryManagementPage.svelte
@@ -5,7 +5,7 @@
 	import { entityListView } from "@librocco/shared";
 
 	import { page } from "$app/stores";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { ExtensionAvailabilityToast, Page } from "$lib/components";
 

--- a/apps/web-client/src/lib/components/Page.svelte
+++ b/apps/web-client/src/lib/components/Page.svelte
@@ -6,7 +6,7 @@
 	import { testId, type WebClientView } from "@librocco/shared";
 
 	import { page } from "$app/stores";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { TooltipWrapper } from "$lib/components";
 

--- a/apps/web-client/src/lib/utils/navigation.ts
+++ b/apps/web-client/src/lib/utils/navigation.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line no-restricted-imports
+import { goto as svelteGoto } from "$app/navigation";
+import { browser } from "$app/environment";
+
+/**
+ * A client/server safe `goto` it aims to replace svelte's `goto` (banned on the server) by calling the
+ * original `goto` only in browser environemnt, noop otherwise
+ */
+export const goto = (...params: Parameters<typeof svelteGoto>) => browser && svelteGoto(...params);

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
 	import { pwaInfo } from "virtual:pwa-info";
 
 	import type { LayoutData } from "./$types";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { appPath } from "$lib/paths";
 
 	export let data: LayoutData & { status: boolean };

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -6,7 +6,7 @@
 
 	import { entityListView, testId } from "@librocco/shared";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { browser } from "$app/environment";
 
 	import type { PageData } from "./$types";

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -12,7 +12,7 @@
 
 	import { createSearchStore } from "$lib/stores/proto/search";
 	import { createSearchDropdown } from "./[isbn]/actions";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { browser } from "$app/environment";
 
 	const { db } = getDB();

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -15,7 +15,7 @@
 	import { createSearchStore } from "$lib/stores/proto/search";
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { createSearchDropdown } from "./actions";
 
 	const { db } = getDB();

--- a/apps/web-client/src/routes/history/notes/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[...id]/+page.svelte
@@ -14,7 +14,7 @@
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { appPath } from "$lib/paths";
 
 	export let data: PageData;

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -4,7 +4,7 @@
 
 	import { entityListView, testId } from "@librocco/shared";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import type { PageData } from "./$types";
 

--- a/apps/web-client/src/routes/history/warehouse/[...warehouseId]/[from]/[to]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[...warehouseId]/[from]/[to]/+page.svelte
@@ -4,7 +4,7 @@
 
 	import { entityListView, testId } from "@librocco/shared";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { browser } from "$app/environment";
 
 	import type { PageData } from "./$types";

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -12,7 +12,7 @@
 	import { PlaceholderBox, Dialog } from "$lib/components";
 
 	import { getDB } from "$lib/db";
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { type DialogContent, dialogTitle, dialogDescription } from "$lib/dialogs";
 

--- a/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[...id]/+page.svelte
@@ -5,7 +5,7 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { Printer, QrCode, Trash2, FileEdit, MoreVertical, X, Loader2 as Loader, FileCheck } from "lucide-svelte";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { NoteState, testId } from "@librocco/shared";
 	import type { BookEntry } from "@librocco/db";

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -9,7 +9,7 @@
 	import { entityListView, filter, testId } from "@librocco/shared";
 	import { NEW_WAREHOUSE } from "@librocco/db";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import InventoryManagementPage from "$lib/components/InventoryManagementPage.svelte";
 	import { DropdownWrapper, PlaceholderBox } from "$lib/components";

--- a/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[...id]/+page.svelte
@@ -24,7 +24,7 @@
 	import { BookForm, bookSchema, type BookFormOptions } from "$lib/forms";
 	import { createExtensionAvailabilityStore, settingsStore } from "$lib/stores";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import type { PageData } from "./$types";
 

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -6,7 +6,7 @@
 	import { Plus, Search, Trash, Loader2 as Loader, Library } from "lucide-svelte";
 	import { firstValueFrom, map } from "rxjs";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { entityListView, testId } from "@librocco/shared";
 

--- a/apps/web-client/src/routes/outbound/[...id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[...id]/+page.svelte
@@ -6,7 +6,7 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { Printer, QrCode, Trash2, FileEdit, MoreVertical, X, Loader2 as Loader, FileCheck } from "lucide-svelte";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { NoteState, testId, wrapIter, type VolumeStock } from "@librocco/shared";
 
@@ -63,7 +63,7 @@
 	// it will be defined immediately, but `db.init` is ran asynchronously.
 	// We don't care about 'db.init' here (for nav stream), hence the non-reactive 'const' declaration.
 	const { db } = getDB();
-	// if(!status) goto(appPath("settings"))
+	// if (!status) goto(appPath("settings"));
 
 	const warehouseListCtx = { name: "[WAREHOUSE_LIST]", debug: false };
 	const warehouseListStream = db

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Search } from "lucide-svelte";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { SettingsForm } from "$lib/forms";
 	import { Page, ExtensionAvailabilityToast } from "$lib/components";

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -12,7 +12,7 @@
 	import { getDB } from "$lib/db";
 	import { printBookLabel } from "$lib/printer";
 
-	import { goto } from "$app/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { ExtensionAvailabilityToast, PopoverWrapper, StockTable, StockBookRow, TooltipWrapper } from "$lib/components";
 	import { BookForm, bookSchema, type BookFormOptions } from "$lib/forms";


### PR DESCRIPTION
* create safe `goto` in `$lib/utils/navigation`
* add a eslint rule to ban `goto` from `$app/navigation`
* replace all existing usage with preferred one