### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflow.templates/cache.lib.yml
+++ b/.github/workflow.templates/cache.lib.yml
@@ -2,10 +2,10 @@
 name: Cache node modules
 uses: actions/cache@v4
 with:
-    path: |
-        ~/.rush
-        ~/.pnpm-store
-        common/temp
-        **/node_modules
-    key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+  path: |
+    ~/.rush
+    ~/.pnpm-store
+    common/temp
+    ./common/temp/node_modules/
+  key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
 #@ end

--- a/.github/workflow.templates/ci-debug.yml
+++ b/.github/workflow.templates/ci-debug.yml
@@ -27,7 +27,7 @@ jobs:
         run: cd apps/web-client && rushx build:prod
       - name: Setup upterm (debug) session
         uses: lhotari/action-upterm@v1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ci-debug-artifacts

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -34,7 +34,7 @@ jobs:
         run: cd apps/web-client && rushx build:e2e
       - name: Run Playwright tests
         run: cd apps/e2e && rushx test:ci
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-test-results

--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -34,7 +34,7 @@ jobs:
         run: cd apps/web-client && rushx build:e2e
       - name: Run Playwright tests
         run: cd apps/e2e && rushx test:ci
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-test-results

--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -19,8 +19,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages

--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -31,7 +31,7 @@ jobs:
       run: cd apps/web-client && rushx build:prod
     - name: Setup upterm (debug) session
       uses: lhotari/action-upterm@v1
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ci-debug-artifacts

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -24,8 +24,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -61,8 +61,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -91,8 +91,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -116,8 +116,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -153,8 +153,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -185,8 +185,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -212,8 +212,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages
@@ -237,8 +237,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -128,7 +128,7 @@ jobs:
       run: cd apps/web-client && rushx build:e2e
     - name: Run Playwright tests
       run: cd apps/e2e && rushx test:ci
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-test-results

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -50,7 +50,7 @@ jobs:
       run: cd apps/web-client && rushx build:e2e
     - name: Run Playwright tests
       run: cd apps/e2e && rushx test:ci
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-test-results

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -38,8 +38,8 @@ jobs:
           ~/.rush
           ~/.pnpm-store
           common/temp
-          **/node_modules
-        key: ${{ runner.os }}-modules-node16-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node16-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Add local rush scripts to PATH
       run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
     - name: Install packages


### PR DESCRIPTION
This PR fixes these two problems:

* cache warnings:
    I believe [the errors visible in all CI runs](https://github.com/librocco/librocco/actions/runs/11341112596) are caused by the directories we pass to `actions/cache`: since most of these paths will have a symlink (rush maintains only one "real" `node_modules` directory and symlinks to it from the other ones) in them.
* upload artifacts warning:
  > The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "playwright-test-results".
  > Please update your workflow to use v4 of the artifact actions.