### PR TITLE
First supplier order API

### DIFF
--- a/apps/web-client/src/lib/db/orders/__tests__/lib.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/lib.ts
@@ -1,0 +1,25 @@
+import { getDB, initializeDB, getChanges, applyChanges, getSiteId, getPeerDBVersion } from "../db";
+import { type DB } from "../types";
+
+export const getRandomDb = async (): Promise<DB> => {
+	// Each test run will use a different db
+	// birthday paradox chance of collision for 1k runs is 0.5%)
+	const randomTestRunId = Math.floor(Math.random() * 100000000);
+	const db = await getDB("testdb" + randomTestRunId);
+	await initializeDB(db);
+	return db;
+};
+
+export const getRandomDbs = async (): Promise<DB[]> => {
+	const randomTestRunId = Math.floor(Math.random() * 100000000);
+	const db1 = await getDB("testdb1" + randomTestRunId);
+	const db2 = await getDB("testdb2" + randomTestRunId);
+	await initializeDB(db1);
+	await initializeDB(db2);
+	return [db1, db2];
+};
+
+export const syncDBs = async (source: DB, destination: DB) => {
+	const sourceDBVersion = await getPeerDBVersion(source, await getSiteId(destination));
+	await applyChanges(destination, await getChanges(source, sourceDBVersion));
+};

--- a/apps/web-client/src/lib/db/orders/__tests__/lib.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/lib.ts
@@ -1,5 +1,8 @@
 import { getDB, initializeDB, getChanges, applyChanges, getSiteId, getPeerDBVersion } from "../db";
+import { upsertCustomer, addBooksToCustomer } from "../customers";
+import { upsertBook } from "../books";
 import { type DB } from "../types";
+import { upsertSupplier, associatePublisher } from "../suppliers";
 
 export const getRandomDb = async (): Promise<DB> => {
 	// Each test run will use a different db
@@ -22,4 +25,45 @@ export const getRandomDbs = async (): Promise<DB[]> => {
 export const syncDBs = async (source: DB, destination: DB) => {
 	const sourceDBVersion = await getPeerDBVersion(source, await getSiteId(destination));
 	await applyChanges(destination, await getChanges(source, sourceDBVersion));
+};
+
+export const createCustomerOrders = async (db: DB) => {
+	// Add three books
+	await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics", price: 7 });
+	await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry", price: 13 });
+	await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit", price: 5 });
+
+	// There is an old order that has been completely fullfilled
+	await upsertCustomer(db, { fullname: "An older order", id: 100 });
+	const sql =
+		"INSERT INTO customer_order_lines (customer_id, isbn, quantity, created, placed, received, collected) VALUES (?, ?, ?, ?, ?, ?, ?);";
+	const params = [
+		100,
+		"1",
+		"1",
+		new Date("2024-10-20").getTime(),
+		new Date("2024-10-21").getTime(),
+		new Date("2024-10-22").getTime(),
+		new Date("2024-10-23").getTime()
+	];
+	await db.exec(sql, params);
+
+	// Two customers order some books
+	await upsertCustomer(db, { fullname: "John Doe", id: 1 });
+	addBooksToCustomer(db, 1, [
+		{ isbn: "1", quantity: 1 },
+		{ isbn: "2", quantity: 1 },
+		{ isbn: "3", quantity: 1 }
+	]);
+
+	await upsertCustomer(db, { fullname: "Jane Doe", id: 2 });
+	addBooksToCustomer(db, 2, [{ isbn: "3", quantity: 1 }]);
+
+	// We have two different suppliers
+	await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
+	await upsertSupplier(db, { id: 2, name: "Phantasy Books LTD" });
+	// Publishers are associated with suppliers
+	await associatePublisher(db, 1, "MathsAndPhysicsPub");
+	await associatePublisher(db, 1, "ChemPub");
+	await associatePublisher(db, 2, "PhantasyPub");
 };

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach } from "vitest";
 
 import { type DB } from "../types";
 
-import { getDB, initializeDB, getChanges, applyChanges, getSiteId, getPeerDBVersion } from "../db";
+import { getDB, initializeDB } from "../db";
 
 import { getAllCustomers, upsertCustomer, getCustomerBooks, addBooksToCustomer, removeBooksFromCustomer } from "../customers";
+import { getRandomDb, getRandomDbs, syncDBs } from "./lib";
 import type { Customer } from "../customers";
 
 describe("Db creation tests", () => {
@@ -12,22 +13,14 @@ describe("Db creation tests", () => {
 		const randomTestRunId = Math.floor(Math.random() * 100000000);
 		const db = await getDB("init-db-test" + randomTestRunId);
 		await expect(getAllCustomers(db)).rejects.toThrow();
-		initializeDB(db);
+		await initializeDB(db);
 		expect((await getAllCustomers(db)).length).toBe(0);
 	});
 });
 
 describe("Customer order tests", () => {
 	let db: DB;
-	// Each test run will use a different db
-	// birthday paradox chance of collision for 1k runs is 0.5%)
-	let randomTestRunId: number;
-
-	beforeEach(async () => {
-		randomTestRunId = Math.floor(Math.random() * 100000000);
-		db = await getDB("testdb" + randomTestRunId);
-		await initializeDB(db);
-	});
+	beforeEach(async () => (db = await getRandomDb()));
 
 	it("can create and update a customer", async () => {
 		await expect(upsertCustomer(db, { fullname: "John Doe" })).rejects.toThrow("Customer must have an id");
@@ -97,17 +90,7 @@ describe("Customer order tests", () => {
 
 describe("Customer order tests", () => {
 	let db1: DB, db2: DB;
-	// Each test run will use a different db
-	// birthday paradox chance of collision for 1k runs is 0.5%)
-	let randomTestRunId: number;
-
-	beforeEach(async () => {
-		randomTestRunId = Math.floor(Math.random() * 100000000);
-		db1 = await getDB("testdb1" + randomTestRunId);
-		db2 = await getDB("testdb2" + randomTestRunId);
-		await initializeDB(db1);
-		await initializeDB(db2);
-	});
+	beforeEach(async () => ([db1, db2] = await getRandomDbs()));
 	it("Should sync customer creation", async () => {
 		// We create one customer in db1 and a different one in db2
 		let db1Customers: Customer[], db2Customers: Customer[];
@@ -134,8 +117,3 @@ describe("Customer order tests", () => {
 		expect(db1Customers).toEqual([{ fullname: "Jane Doe", id: 1, email: "jane@example.com", deposit: 13.2 }]);
 	});
 });
-
-const syncDBs = async (source: DB, destination: DB) => {
-	const sourceDBVersion = await getPeerDBVersion(source, await getSiteId(destination));
-	await applyChanges(destination, await getChanges(source, sourceDBVersion));
-};

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -56,7 +56,7 @@ describe("Customer order tests", () => {
 		const startTime = Date.now();
 		for (let i = 0; i < howMany; i++) {
 			await db.tx(async (db) => {
-				await addBooksToCustomer(db, 1, [
+				await addBooksToCustomer(db as DB, 1, [
 					{ isbn: "9780000000000", quantity: 1 },
 					{ isbn: "9780000000001", quantity: 3 },
 					{ isbn: "9780000000002", quantity: 1 },

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -6,7 +6,7 @@ import { getDB, initializeDB } from "../db";
 
 import { getAllCustomers, upsertCustomer, getCustomerBooks, addBooksToCustomer, removeBooksFromCustomer } from "../customers";
 import { getRandomDb, getRandomDbs, syncDBs } from "./lib";
-import type { Customer } from "../customers";
+import type { Customer } from "../types";
 
 describe("Db creation tests", () => {
 	it("should allow initializing a database", async () => {

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -41,7 +41,7 @@ describe("Customer order tests", () => {
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
 		let books = await getCustomerBooks(db, 1);
 		expect(books.length).toBe(0);
-		addBooksToCustomer(db, 1, [
+		await addBooksToCustomer(db, 1, [
 			{ isbn: "9780000000000", quantity: 1 },
 			{ isbn: "9780000000000", quantity: 1 }
 		]);
@@ -50,33 +50,35 @@ describe("Customer order tests", () => {
 		expect(books[0].id).toBeTypeOf("number");
 	});
 
-	it("can add ten books to a customer 100 times and not take more than 100ms", async () => {
+	it("can add ten books to a customer 10 times and not take more than 250ms", async () => {
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
-		const howMany = 100;
+		const howMany = 10;
 		const startTime = Date.now();
 		for (let i = 0; i < howMany; i++) {
-			addBooksToCustomer(db, 1, [
-				{ isbn: "9780000000000", quantity: 1 },
-				{ isbn: "9780000000001", quantity: 3 },
-				{ isbn: "9780000000002", quantity: 1 },
-				{ isbn: "9780000000003", quantity: 3 },
-				{ isbn: "9780000000004", quantity: 1 },
-				{ isbn: "9780000000005", quantity: 2 },
-				{ isbn: "9780000000006", quantity: 1 },
-				{ isbn: "9780000000007", quantity: 1 },
-				{ isbn: "9780000000008", quantity: 2 },
-				{ isbn: "9780000000009", quantity: 1 }
-			]);
+			await db.tx(async (db) => {
+				await addBooksToCustomer(db, 1, [
+					{ isbn: "9780000000000", quantity: 1 },
+					{ isbn: "9780000000001", quantity: 3 },
+					{ isbn: "9780000000002", quantity: 1 },
+					{ isbn: "9780000000003", quantity: 3 },
+					{ isbn: "9780000000004", quantity: 1 },
+					{ isbn: "9780000000005", quantity: 2 },
+					{ isbn: "9780000000006", quantity: 1 },
+					{ isbn: "9780000000007", quantity: 1 },
+					{ isbn: "9780000000008", quantity: 2 },
+					{ isbn: "9780000000009", quantity: 1 }
+				]);
+			});
 		}
 		const duration = Date.now() - startTime;
 		const books = await getCustomerBooks(db, 1);
 		expect(books.length).toBe(10 * howMany);
-		expect(duration).toBeLessThanOrEqual(100);
+		expect(duration).toBeLessThanOrEqual(250);
 	});
 
 	it("can remove books from a customer order", async () => {
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
-		addBooksToCustomer(db, 1, [
+		await addBooksToCustomer(db, 1, [
 			{ isbn: "9780000000000", quantity: 1 },
 			{ isbn: "9780000000000", quantity: 1 }
 		]);

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -51,7 +51,7 @@ describe("Customer order tests", () => {
 		expect(books[0].created).toBeInstanceOf(Date);
 	});
 
-	it("can add ten books to a customer 10 times and not take more than 300ms", async () => {
+	it("can add ten books to a customer 10 times and not take more than 400ms", async () => {
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
 		const howMany = 10;
 		const startTime = Date.now();
@@ -74,7 +74,7 @@ describe("Customer order tests", () => {
 		const duration = Date.now() - startTime;
 		const books = await getCustomerBooks(db, 1);
 		expect(books.length).toBe(10 * howMany);
-		expect(duration).toBeLessThanOrEqual(300);
+		expect(duration).toBeLessThanOrEqual(400);
 	});
 
 	it("can remove books from a customer order", async () => {

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -116,14 +116,14 @@ describe("Customer order tests", () => {
 		[db1Customers, db2Customers] = await Promise.all([getAllCustomers(db1), getAllCustomers(db2)]);
 		expect(db1Customers.length).toBe(1);
 		expect(db2Customers.length).toBe(1);
-		syncDBs(db1, db2);
+		await syncDBs(db1, db2);
 		expect((await getAllCustomers(db2)).length).toBe(2);
-		syncDBs(db2, db1);
+		await syncDBs(db2, db1);
 		expect((await getAllCustomers(db1)).length).toBe(2);
 		[db1Customers, db2Customers] = await Promise.all([getAllCustomers(db1), getAllCustomers(db2)]);
 		expect(db1Customers).toEqual(db2Customers);
 	});
-	it.only("Should keep both updates done at the same time on different dbs", async () => {
+	it("Should keep both updates done at the same time on different dbs", async () => {
 		// We create one customer in db1 and a different one in db2
 		await upsertCustomer(db1, { fullname: "John Doe", id: 1, email: "john@example.com", deposit: 13.2 });
 		await syncDBs(db1, db2);

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -48,9 +48,10 @@ describe("Customer order tests", () => {
 		books = await getCustomerBooks(db, 1);
 		expect(books.length).toBe(2);
 		expect(books[0].id).toBeTypeOf("number");
+		expect(books[0].created).toBeInstanceOf(Date);
 	});
 
-	it("can add ten books to a customer 10 times and not take more than 250ms", async () => {
+	it("can add ten books to a customer 10 times and not take more than 300ms", async () => {
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
 		const howMany = 10;
 		const startTime = Date.now();
@@ -73,7 +74,7 @@ describe("Customer order tests", () => {
 		const duration = Date.now() - startTime;
 		const books = await getCustomerBooks(db, 1);
 		expect(books.length).toBe(10 * howMany);
-		expect(duration).toBeLessThanOrEqual(250);
+		expect(duration).toBeLessThanOrEqual(300);
 	});
 
 	it("can remove books from a customer order", async () => {

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -4,7 +4,13 @@ import { type DB } from "../types";
 
 import { getRandomDb } from "./lib";
 
-import { upsertSupplier, associatePublisher, getPossibleSupplerOrderLines, getPossibleSupplerOrderInfos } from "../suppliers";
+import {
+	upsertSupplier,
+	associatePublisher,
+	getPossibleSupplerOrderLines,
+	getPossibleSupplerOrderInfos,
+	createSupplierOrder
+} from "../suppliers";
 import { upsertCustomer, addBooksToCustomer } from "../customers";
 import { upsertBook } from "../books";
 
@@ -52,7 +58,7 @@ describe("Suppliers order creation", () => {
 		await associatePublisher(db, 2, "PhantasyPub");
 	});
 
-	it("creates a supplier order from a client order", async () => {
+	it("sees possible supplier orders from client orders", async () => {
 		expect(await getPossibleSupplerOrderLines(db)).toStrictEqual([
 			{ supplier_id: 1, isbn: "1", quantity: 1 },
 			{ supplier_id: 1, isbn: "2", quantity: 1 },
@@ -70,5 +76,12 @@ describe("Suppliers order creation", () => {
 			{ supplier_id: 2, isbn: "2", quantity: 1 }, // This is now from supplier 2
 			{ supplier_id: 2, isbn: "3", quantity: 2 }
 		]);
+	});
+	it.only("creates two new supplier orders", async () => {
+		const possibleOrderLines = await getPossibleSupplerOrderLines(db);
+		const newOrders = await createSupplierOrder(db, possibleOrderLines);
+		expect(newOrders.length).toStrictEqual(2);
+		const newPossibleOrderLines = await getPossibleSupplerOrderLines(db);
+		expect(newPossibleOrderLines.length).toStrictEqual(0);
 	});
 });

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -5,7 +5,6 @@ import { type DB } from "../types";
 import { getRandomDb, createCustomerOrders } from "./lib";
 
 import { associatePublisher, getPossibleSupplerOrderLines, getPossibleSupplerOrderInfos, createSupplierOrder } from "../suppliers";
-import { getCustomerBooks } from "../customers";
 
 describe("Suppliers order creation", () => {
 	let db: DB;

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -2,60 +2,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 
 import { type DB } from "../types";
 
-import { getRandomDb } from "./lib";
+import { getRandomDb, createCustomerOrders } from "./lib";
 
-import {
-	upsertSupplier,
-	associatePublisher,
-	getPossibleSupplerOrderLines,
-	getPossibleSupplerOrderInfos,
-	createSupplierOrder
-} from "../suppliers";
-import { upsertCustomer, addBooksToCustomer, getCustomerBooks } from "../customers";
-import { upsertBook } from "../books";
+import { associatePublisher, getPossibleSupplerOrderLines, getPossibleSupplerOrderInfos, createSupplierOrder } from "../suppliers";
+import { getCustomerBooks } from "../customers";
 
 describe("Suppliers order creation", () => {
 	let db: DB;
 	beforeEach(async () => {
 		db = await getRandomDb();
-		// Add three books
-		await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics", price: 7 });
-		await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry", price: 13 });
-		await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit", price: 5 });
-
-		// There is an old order that has been completely fullfilled
-		await upsertCustomer(db, { fullname: "An older order", id: 100 });
-		const sql =
-			"INSERT INTO customer_order_lines (customer_id, isbn, quantity, created, placed, received, collected) VALUES (?, ?, ?, ?, ?, ?, ?);";
-		const params = [
-			100,
-			"1",
-			"1",
-			new Date("2024-10-20").getTime(),
-			new Date("2024-10-21").getTime(),
-			new Date("2024-10-22").getTime(),
-			new Date("2024-10-23").getTime()
-		];
-		await db.exec(sql, params);
-
-		// Two customers order some books
-		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
-		addBooksToCustomer(db, 1, [
-			{ isbn: "1", quantity: 1 },
-			{ isbn: "2", quantity: 1 },
-			{ isbn: "3", quantity: 1 }
-		]);
-
-		await upsertCustomer(db, { fullname: "Jane Doe", id: 2 });
-		addBooksToCustomer(db, 2, [{ isbn: "3", quantity: 1 }]);
-
-		// We have two different suppliers
-		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
-		await upsertSupplier(db, { id: 2, name: "Phantasy Books LTD" });
-		// Publishers are associated with suppliers
-		await associatePublisher(db, 1, "MathsAndPhysicsPub");
-		await associatePublisher(db, 1, "ChemPub");
-		await associatePublisher(db, 2, "PhantasyPub");
+		await createCustomerOrders(db);
 	});
 
 	it("sees possible supplier orders from client orders", async () => {
@@ -83,7 +39,5 @@ describe("Suppliers order creation", () => {
 		expect(newOrders.length).toStrictEqual(2);
 		const newPossibleOrderLines = await getPossibleSupplerOrderLines(db);
 		expect(newPossibleOrderLines.length).toStrictEqual(0);
-		const customer1Books = await getCustomerBooks(db, 1);
-		console.log(customer1Books);
 	});
 });

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -11,7 +11,7 @@ import {
 	getPossibleSupplerOrderInfos,
 	createSupplierOrder
 } from "../suppliers";
-import { upsertCustomer, addBooksToCustomer } from "../customers";
+import { upsertCustomer, addBooksToCustomer, getCustomerBooks } from "../customers";
 import { upsertBook } from "../books";
 
 describe("Suppliers order creation", () => {
@@ -83,5 +83,7 @@ describe("Suppliers order creation", () => {
 		expect(newOrders.length).toStrictEqual(2);
 		const newPossibleOrderLines = await getPossibleSupplerOrderLines(db);
 		expect(newPossibleOrderLines.length).toStrictEqual(0);
+		const customer1Books = await getCustomerBooks(db, 1);
+		console.log(customer1Books);
 	});
 });

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { type DB } from "../types";
+
+import { getRandomDb } from "./lib";
+
+import { upsertSupplier, associatePublisher, getPossibleSupplerOrders } from "../suppliers";
+import { upsertCustomer, addBooksToCustomer } from "../customers";
+import { upsertBook } from "../books";
+
+describe("Suppliers order creation", () => {
+	let db: DB;
+	beforeEach(async () => {
+		db = await getRandomDb();
+		// Add three books
+		await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics" });
+		await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry" });
+		await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit" });
+
+		// Two customers order some books
+		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
+		addBooksToCustomer(db, 1, [
+			{ isbn: "1", quantity: 1 },
+			{ isbn: "2", quantity: 1 },
+			{ isbn: "3", quantity: 1 }
+		]);
+
+		await upsertCustomer(db, { fullname: "Jane Doe", id: 2 });
+		addBooksToCustomer(db, 2, [{ isbn: "3", quantity: 1 }]);
+
+		// We have two different suppliers
+		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
+		await upsertSupplier(db, { id: 2, name: "Phantasy Books LTD" });
+		// Publishers are associated with suppliers
+		await associatePublisher(db, 1, "MathsAndPhysicsPub");
+		await associatePublisher(db, 1, "ChemPub");
+		await associatePublisher(db, 2, "PhantasyPub");
+	});
+
+	it("creates a supplier order from a client order", async () => {
+		expect(await getPossibleSupplerOrders(db)).toStrictEqual([
+			{ supplier_id: 1, isbn: "1", quantity: 1 },
+			{ supplier_id: 1, isbn: "2", quantity: 1 },
+			{ supplier_id: 2, isbn: "3", quantity: 2 }
+		]);
+		// If we change the supplier for ChemPub to Phantasy Books LTD
+		// the supplier order will reflect that
+		await associatePublisher(db, 2, "ChemPub");
+		expect(await getPossibleSupplerOrders(db)).toStrictEqual([
+			{ supplier_id: 1, isbn: "1", quantity: 1 },
+			{ supplier_id: 2, isbn: "2", quantity: 1 }, // This is now from supplier 2
+			{ supplier_id: 2, isbn: "3", quantity: 2 }
+		]);
+	});
+});

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -17,6 +17,21 @@ describe("Suppliers order creation", () => {
 		await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry", price: 13 });
 		await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit", price: 5 });
 
+		// There is an old order that has been completely fullfilled
+		await upsertCustomer(db, { fullname: "An older order", id: 100 });
+		const sql =
+			"INSERT INTO customer_order_lines (customer_id, isbn, quantity, created, placed, received, collected) VALUES (?, ?, ?, ?, ?, ?, ?);";
+		const params = [
+			100,
+			"1",
+			"1",
+			new Date("2024-10-20").getTime(),
+			new Date("2024-10-21").getTime(),
+			new Date("2024-10-22").getTime(),
+			new Date("2024-10-23").getTime()
+		];
+		await db.exec(sql, params);
+
 		// Two customers order some books
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
 		addBooksToCustomer(db, 1, [

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -4,7 +4,7 @@ import { type DB } from "../types";
 
 import { getRandomDb } from "./lib";
 
-import { upsertSupplier, associatePublisher, getPossibleSupplerOrders } from "../suppliers";
+import { upsertSupplier, associatePublisher, getPossibleSupplerOrderLines, getPossibleSupplerOrderInfos } from "../suppliers";
 import { upsertCustomer, addBooksToCustomer } from "../customers";
 import { upsertBook } from "../books";
 
@@ -13,9 +13,9 @@ describe("Suppliers order creation", () => {
 	beforeEach(async () => {
 		db = await getRandomDb();
 		// Add three books
-		await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics" });
-		await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry" });
-		await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit" });
+		await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics", price: 7 });
+		await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry", price: 13 });
+		await upsertBook(db, { isbn: "3", publisher: "PhantasyPub", title: "The Hobbit", price: 5 });
 
 		// Two customers order some books
 		await upsertCustomer(db, { fullname: "John Doe", id: 1 });
@@ -38,15 +38,19 @@ describe("Suppliers order creation", () => {
 	});
 
 	it("creates a supplier order from a client order", async () => {
-		expect(await getPossibleSupplerOrders(db)).toStrictEqual([
+		expect(await getPossibleSupplerOrderLines(db)).toStrictEqual([
 			{ supplier_id: 1, isbn: "1", quantity: 1 },
 			{ supplier_id: 1, isbn: "2", quantity: 1 },
 			{ supplier_id: 2, isbn: "3", quantity: 2 }
 		]);
+		expect(await getPossibleSupplerOrderInfos(db)).toStrictEqual([
+			{ supplier_name: "Science Books LTD", supplier_id: 1, total_book_number: 2, total_book_price: 20 },
+			{ supplier_name: "Phantasy Books LTD", supplier_id: 2, total_book_number: 2, total_book_price: 10 }
+		]);
 		// If we change the supplier for ChemPub to Phantasy Books LTD
 		// the supplier order will reflect that
 		await associatePublisher(db, 2, "ChemPub");
-		expect(await getPossibleSupplerOrders(db)).toStrictEqual([
+		expect(await getPossibleSupplerOrderLines(db)).toStrictEqual([
 			{ supplier_id: 1, isbn: "1", quantity: 1 },
 			{ supplier_id: 2, isbn: "2", quantity: 1 }, // This is now from supplier 2
 			{ supplier_id: 2, isbn: "3", quantity: 2 }

--- a/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
@@ -2,21 +2,13 @@ import { describe, it, expect, beforeEach } from "vitest";
 
 import { type DB } from "../types";
 
-import { getDB, initializeDB } from "../db";
+import { getRandomDb } from "./lib";
 
 import { getAllSuppliers, upsertSupplier, getPublishersFor, associatePublisher } from "../suppliers";
 
 describe("Suppliers CRUD tests", () => {
 	let db: DB;
-	// Each test run will use a different db
-	// birthday paradox chance of collision for 1k runs is 0.5%)
-	let randomTestRunId: number;
-
-	beforeEach(async () => {
-		randomTestRunId = Math.floor(Math.random() * 100000000);
-		db = await getDB("testdb" + randomTestRunId);
-		await initializeDB(db);
-	});
+	beforeEach(async () => (db = await getRandomDb()));
 
 	it("can create and update a supplier", async () => {
 		await expect(upsertSupplier(db, { name: "Science Books LTD" })).rejects.toThrow("Supplier must have an id");
@@ -34,17 +26,7 @@ describe("Suppliers CRUD tests", () => {
 
 describe("Suppliers/publisher association tests", () => {
 	let db: DB;
-	// Each test run will use a different db
-	// birthday paradox chance of collision for 1k runs is 0.5%)
-	let randomTestRunId: number;
-
-	beforeEach(async () => {
-		randomTestRunId = Math.floor(Math.random() * 100000000);
-		db = await getDB("testdb" + randomTestRunId);
-		await initializeDB(db);
-		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
-		await upsertSupplier(db, { id: 2, name: "Fiction Books LTD" });
-	});
+	beforeEach(async () => (db = await getRandomDb()));
 
 	it("can assign publishers to suppliers", async () => {
 		let sciencePublishers = await getPublishersFor(db, 1);

--- a/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
@@ -4,9 +4,9 @@ import { type DB } from "../types";
 
 import { getDB, initializeDB } from "../db";
 
-import { getAllSuppliers, upsertSupplier } from "../suppliers";
+import { getAllSuppliers, upsertSupplier, getPublishersFor, associatePublisher } from "../suppliers";
 
-describe("Suppliers/publisher association tests", () => {
+describe("Suppliers CRUD tests", () => {
 	let db: DB;
 	// Each test run will use a different db
 	// birthday paradox chance of collision for 1k runs is 0.5%)
@@ -17,6 +17,7 @@ describe("Suppliers/publisher association tests", () => {
 		db = await getDB("testdb" + randomTestRunId);
 		await initializeDB(db);
 	});
+
 	it("can create and update a supplier", async () => {
 		await expect(upsertSupplier(db, { name: "Science Books LTD" })).rejects.toThrow("Supplier must have an id");
 		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
@@ -28,5 +29,35 @@ describe("Suppliers/publisher association tests", () => {
 		await upsertSupplier(db, { id: 1, name: "Science Books inc." });
 		suppliers = await getAllSuppliers(db);
 		expect(suppliers.length).toBe(2);
+	});
+});
+
+describe("Suppliers/publisher association tests", () => {
+	let db: DB;
+	// Each test run will use a different db
+	// birthday paradox chance of collision for 1k runs is 0.5%)
+	let randomTestRunId: number;
+
+	beforeEach(async () => {
+		randomTestRunId = Math.floor(Math.random() * 100000000);
+		db = await getDB("testdb" + randomTestRunId);
+		await initializeDB(db);
+		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
+		await upsertSupplier(db, { id: 2, name: "Fiction Books LTD" });
+	});
+
+	it("can assign publishers to suppliers", async () => {
+		let sciencePublishers = await getPublishersFor(db, 1);
+		expect(sciencePublishers.length).toBe(0);
+
+		await associatePublisher(db, 1, "SciencePublisher");
+		sciencePublishers = await getPublishersFor(db, 1);
+		expect(sciencePublishers).toStrictEqual(["SciencePublisher"]);
+
+		await associatePublisher(db, 2, "SciencePublisher");
+		sciencePublishers = await getPublishersFor(db, 1);
+		expect(sciencePublishers).toStrictEqual([]);
+		const fictionPublishers = await getPublishersFor(db, 2);
+		expect(fictionPublishers).toStrictEqual(["SciencePublisher"]);
 	});
 });

--- a/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/suppliers-publishers.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { type DB } from "../types";
+
+import { getDB, initializeDB } from "../db";
+
+import { getAllSuppliers, upsertSupplier } from "../suppliers";
+
+describe("Suppliers/publisher association tests", () => {
+	let db: DB;
+	// Each test run will use a different db
+	// birthday paradox chance of collision for 1k runs is 0.5%)
+	let randomTestRunId: number;
+
+	beforeEach(async () => {
+		randomTestRunId = Math.floor(Math.random() * 100000000);
+		db = await getDB("testdb" + randomTestRunId);
+		await initializeDB(db);
+	});
+	it("can create and update a supplier", async () => {
+		await expect(upsertSupplier(db, { name: "Science Books LTD" })).rejects.toThrow("Supplier must have an id");
+		await upsertSupplier(db, { id: 1, name: "Science Books LTD" });
+		let suppliers = await getAllSuppliers(db);
+		expect(suppliers.length).toBe(1);
+		await upsertSupplier(db, { id: 2, name: "Phantasy Books LTD" });
+		suppliers = await getAllSuppliers(db);
+		expect(suppliers.length).toBe(2);
+		await upsertSupplier(db, { id: 1, name: "Science Books inc." });
+		suppliers = await getAllSuppliers(db);
+		expect(suppliers.length).toBe(2);
+	});
+});

--- a/apps/web-client/src/lib/db/orders/books.ts
+++ b/apps/web-client/src/lib/db/orders/books.ts
@@ -1,0 +1,25 @@
+import { type DB } from "./types";
+
+export type Book = {
+	isbn: string;
+	title?: string;
+	authors?: string;
+	publisher?: string;
+	price?: number;
+};
+
+export async function upsertBook(db: DB, book: Book) {
+	if (!book.isbn) {
+		throw new Error("Book must have ann ISBN");
+	}
+	await db.exec(
+		`INSERT INTO book (isbn, title, authors, publisher, price)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(isbn) DO UPDATE SET
+            title = COALESCE(?, title),
+            authors = COALESCE(?, authors),
+            publisher = COALESCE(?, publisher),
+            price = COALESCE(?, price);`,
+		[book.isbn, book.title, book.authors, book.publisher, book.price, book.title, book.authors, book.publisher, book.price]
+	);
+}

--- a/apps/web-client/src/lib/db/orders/customers.ts
+++ b/apps/web-client/src/lib/db/orders/customers.ts
@@ -38,7 +38,6 @@ export const getCustomerBooks = async (db: DB, customerId: number): Promise<Cust
 		ORDER BY customer_order_lines.id ASC;`,
 		[customerId]
 	);
-	console.log(await db.execO("SELECT * FROM customer_supplier_order;"));
 	return result.map(marshallCustomerOrderLine);
 };
 

--- a/apps/web-client/src/lib/db/orders/customers.ts
+++ b/apps/web-client/src/lib/db/orders/customers.ts
@@ -1,15 +1,4 @@
-import { type DB } from "./types";
-
-export type Customer = {
-	id?: number;
-	fullname?: string;
-	email?: string;
-	phone?: string;
-	taxId?: string;
-	deposit?: number;
-};
-type CustomerOrderLine = { id: number; isbn: string; quantity: number };
-type Book = { isbn: string; quantity: number };
+import type { DB, Customer, CustomerOrderLine, BookLine } from "./types";
 
 export async function getAllCustomers(db: DB): Promise<Customer[]> {
 	const result = await db.execO<Customer>("SELECT id, fullname, email, deposit FROM customer ORDER BY id ASC;");
@@ -27,7 +16,15 @@ export async function upsertCustomer(db: DB, customer: Customer) {
            fullname = COALESCE(?, fullname),
            email = COALESCE(?, email),
            deposit = COALESCE(?, deposit);`,
-		[customer.id, customer.fullname, customer.email, customer.deposit, customer.fullname, customer.email, customer.deposit]
+		[
+			customer.id,
+			customer.fullname ?? null,
+			customer.email ?? null,
+			customer.deposit ?? null,
+			customer.fullname ?? null,
+			customer.email ?? null,
+			customer.deposit ?? null
+		]
 	);
 }
 
@@ -39,7 +36,7 @@ export const getCustomerBooks = async (db: DB, customerId: number): Promise<Cust
 	return result;
 };
 
-export const addBooksToCustomer = async (db: DB, customerId: number, books: Book[]) => {
+export const addBooksToCustomer = async (db: DB, customerId: number, books: BookLine[]) => {
 	// books is a list of { isbn, quantity }
 	const params = books.map((book) => [customerId, book.isbn, book.quantity]).flat();
 	const sql =

--- a/apps/web-client/src/lib/db/orders/customers.ts
+++ b/apps/web-client/src/lib/db/orders/customers.ts
@@ -4,6 +4,8 @@ export type Customer = {
 	id?: number;
 	fullname?: string;
 	email?: string;
+	phone?: string;
+	taxId?: string;
 	deposit?: number;
 };
 type CustomerOrderLine = { id: number; isbn: string; quantity: number };

--- a/apps/web-client/src/lib/db/orders/db.ts
+++ b/apps/web-client/src/lib/db/orders/db.ts
@@ -84,6 +84,14 @@ export async function initializeDB(db: DB) {
 		PRIMARY KEY (supplier_order_id, isbn)
 	)`);
 	await db.exec("SELECT crsql_as_crr('supplier_order_line');");
+
+	await db.exec(`CREATE TABLE customer_supplier_order (
+    id INTEGER NOT NULL,
+		supplier_order_id INTEGER,
+		customer_order_line_id INTEGER,
+		PRIMARY KEY (id)
+	)`);
+	await db.exec("SELECT crsql_as_crr('customer_supplier_order');");
 }
 
 export const getInitializedDB = async (dbname: string) => {

--- a/apps/web-client/src/lib/db/orders/db.ts
+++ b/apps/web-client/src/lib/db/orders/db.ts
@@ -18,6 +18,16 @@ export async function getDB(dbname: string) {
 }
 
 export async function initializeDB(db: DB) {
+	await db.exec(`CREATE TABLE book (
+		isbn TEXT NOT NULL,
+		title TEXT,
+		authors TEXT,
+		publisher TEXT,
+		price DECIMAL,
+		PRIMARY KEY (isbn)
+	)`);
+	await db.exec("SELECT crsql_as_crr('book');");
+
 	await db.exec(`CREATE TABLE customer (
 		id INTEGER NOT NULL,
 		fullname TEXT,

--- a/apps/web-client/src/lib/db/orders/db.ts
+++ b/apps/web-client/src/lib/db/orders/db.ts
@@ -44,6 +44,21 @@ export async function initializeDB(db: DB) {
 	// Activate the crsql extension
 	await db.exec("SELECT crsql_as_crr('customer');");
 	await db.exec("SELECT crsql_as_crr('customer_order_lines');");
+
+	await db.exec(`CREATE TABLE supplier (
+		id INTEGER NOT NULL,
+		name TEXT,
+		email TEXT,
+		address TEXT,
+		PRIMARY KEY (id)
+	)`);
+	await db.exec("SELECT crsql_as_crr('supplier');");
+	await db.exec(`CREATE TABLE supplier_publisher (
+		supplier_id INTEGER,
+		publisher TEXT NOT NULL,
+		PRIMARY KEY (publisher)
+	)`);
+	await db.exec("SELECT crsql_as_crr('supplier_publisher');");
 }
 
 export const getInitializedDB = async (dbname: string) => {

--- a/apps/web-client/src/lib/db/orders/db.ts
+++ b/apps/web-client/src/lib/db/orders/db.ts
@@ -40,10 +40,10 @@ export async function initializeDB(db: DB) {
 		customer_id TEXT,
 		isbn TEXT,
 		quantity INTEGER,
-		created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-		placed TIMESTAMP,
-		received TIMESTAMP,
-		collected TIMESTAMP,
+		created INTEGER DEFAULT (strftime('%s', 'now') * 1000),
+		placed INTEGER,
+		received INTEGER,
+		collected INTEGER,
 		PRIMARY KEY (id)
 	)`);
 	// We can't  specify the foreign key constraint since cr-sqlite doesn't support it:
@@ -69,6 +69,21 @@ export async function initializeDB(db: DB) {
 		PRIMARY KEY (publisher)
 	)`);
 	await db.exec("SELECT crsql_as_crr('supplier_publisher');");
+
+	await db.exec(`CREATE TABLE supplier_order (
+	  id INTEGER NOT NULL,
+		supplier_id INTEGER,
+		created INTEGER DEFAULT (strftime('%s', 'now') * 1000),
+		PRIMARY KEY (id)
+	)`);
+	await db.exec("SELECT crsql_as_crr('supplier_order');");
+	await db.exec(`CREATE TABLE supplier_order_line (
+		supplier_order_id INTEGER NOT NULL,
+		isbn TEXT NOT NULL,
+		quantity INTEGER NOT NULL DEFAULT 1,
+		PRIMARY KEY (supplier_order_id, isbn)
+	)`);
+	await db.exec("SELECT crsql_as_crr('supplier_order_line');");
 }
 
 export const getInitializedDB = async (dbname: string) => {

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -110,6 +110,10 @@ export async function createSupplierOrder(db: DB, orderLines: SupplierOrderLine[
 				if (line.quantity <= copiesToGo) {
 					// The whole line can be fulfilled
 					await db.exec(`UPDATE customer_order_lines SET placed = (strftime('%s', 'now') * 1000) WHERE id = ?;`, [line.id]);
+					await db.exec(`INSERT INTO customer_supplier_order (customer_order_line_id, supplier_order_id) VALUES (?, ?);`, [
+						line.id,
+						supplierOrderMapping[orderLine.supplier_id]
+					]);
 					copiesToGo -= line.quantity;
 				} else {
 					// Only part of the line can be fulfilled: split the existing order line

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -16,7 +16,15 @@ export async function upsertSupplier(db: DB, supplier: Supplier) {
             name = COALESCE(?, name),
             email = COALESCE(?, email),
             address = COALESCE(?, address);`,
-		[supplier.id, supplier.name, supplier.email, supplier.address, supplier.name, supplier.email, supplier.address]
+		[
+			supplier.id,
+			supplier.name ?? null,
+			supplier.email ?? null,
+			supplier.address ?? null,
+			supplier.name ?? null,
+			supplier.email ?? null,
+			supplier.address ?? null
+		]
 	);
 }
 
@@ -48,7 +56,7 @@ export async function getPossibleSupplerOrderLines(db: DB): Promise<SupplierOrde
         JOIN supplier_publisher ON supplier.id = supplier_publisher.supplier_id
         JOIN book ON supplier_publisher.publisher = book.publisher
         JOIN customer_order_lines ON book.isbn = customer_order_lines.isbn
-      WHERE quantity > 0
+      WHERE quantity > 0 AND placed is NULL
       GROUP BY supplier_id, book.isbn
       ORDER BY book.isbn ASC;`
 	);
@@ -62,7 +70,7 @@ export async function getPossibleSupplerOrderInfos(db: DB): Promise<SupplierOrde
          JOIN supplier_publisher ON supplier.id = supplier_publisher.supplier_id
          JOIN book ON supplier_publisher.publisher = book.publisher
          JOIN customer_order_lines ON book.isbn = customer_order_lines.isbn
-       WHERE quantity > 0
+       WHERE quantity > 0 AND placed is NULL
        GROUP BY supplier.name, supplier_id
        ORDER BY book.isbn ASC;`
 	);

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -135,9 +135,9 @@ export async function getSupplierOrder(db: DB, supplierOrderId: number): Promise
        WHERE supplier_order.id = ?;`,
 		[supplierOrderId]
 	);
-	const result = { supplier_id: orderInfo[0].supplier_id, created: new Date(orderInfo[0].created) };
-	result.lines = orderInfo.map((line) => {
-		return { supplier_id: line.supplier_id, isbn: line.isbn, quantity: line.quantity };
-	});
-	return result;
+	return {
+		supplier_id: orderInfo[0].supplier_id,
+		created: new Date(orderInfo[0].created),
+		lines: orderInfo.map((line) => ({ supplier_id: line.supplier_id, isbn: line.isbn, quantity: line.quantity }))
+	};
 }

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -1,0 +1,28 @@
+import { type DB } from "./types";
+
+export type Supplier = {
+	id?: number;
+	name?: string;
+	email?: string;
+	address?: string;
+};
+
+export async function getAllSuppliers(db: DB): Promise<Supplier[]> {
+	const result = await db.execO<Supplier>("SELECT id, name, email, address FROM supplier ORDER BY id ASC;");
+	return result;
+}
+
+export async function upsertSupplier(db: DB, supplier: Supplier) {
+	if (!supplier.id) {
+		throw new Error("Supplier must have an id");
+	}
+	await db.exec(
+		`INSERT INTO supplier (id, name, email, address)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           name = COALESCE(?, name),
+           email = COALESCE(?, email),
+           address = COALESCE(?, address);`,
+		[supplier.id, supplier.name, supplier.email, supplier.address, supplier.name, supplier.email, supplier.address]
+	);
+}

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -1,11 +1,4 @@
-import { type DB } from "./types";
-
-export type Supplier = {
-	id?: number;
-	name?: string;
-	email?: string;
-	address?: string;
-};
+import type { DB, Supplier, SupplierOrderInfo, SupplierOrderLine } from "./types";
 
 export async function getAllSuppliers(db: DB): Promise<Supplier[]> {
 	const result = await db.execO<Supplier>("SELECT id, name, email, address FROM supplier ORDER BY id ASC;");
@@ -47,8 +40,6 @@ export async function associatePublisher(db: DB, supplierId: number, publisherId
 	);
 }
 
-type SupplierOrderLine = { supplier_id: number; isbn: string; quantity: number };
-
 export async function getPossibleSupplerOrderLines(db: DB): Promise<SupplierOrderLine[]> {
 	// We need to build a query that will yield all books we can order, grouped by supplier
 	const result = await db.execO<{ supplier_id: number; isbn: string; quantity: number }>(
@@ -64,8 +55,6 @@ export async function getPossibleSupplerOrderLines(db: DB): Promise<SupplierOrde
 	return result;
 }
 
-type SupplierOrderInfo = { supplier_id: number; isbn: string; total_book_number: number };
-
 export async function getPossibleSupplerOrderInfos(db: DB): Promise<SupplierOrderInfo[]> {
 	const result = await db.execO<SupplierOrderInfo>(
 		`SELECT supplier.name as supplier_name, supplier_id, SUM(quantity) as total_book_number, SUM(quantity * price) as total_book_price
@@ -79,3 +68,9 @@ export async function getPossibleSupplerOrderInfos(db: DB): Promise<SupplierOrde
 	);
 	return result;
 }
+
+// export async function createSupplierOrder(db: DB, orderLines: SupplierOrderLine[]): Promise<SupplierOrder> {
+// 	/* Creates a new supplier order with the given order lines. Updates customer order lines to reflect the order.
+// 	  Returns the orderinfo as it would be returned by `getSupplierOrder`
+// 	 */
+// }

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -22,6 +22,7 @@ export type DBCustomerOrderLine = {
 	placed?: number; // as milliseconds since epoch
 	received?: number; // as milliseconds since epoch
 	collected?: number; // as milliseconds since epoch
+	supplierOrderIds: string; // Comma separated list of supplier order ids that this book order is part of
 };
 
 export type CustomerOrderLine = {
@@ -33,6 +34,7 @@ export type CustomerOrderLine = {
 	placed?: Date; // Last date when the book order was placed to the supplier
 	received?: Date; // Date when the book order was received from the supplier
 	collected?: Date; // Date when the book order was collected by the customer
+	supplierOrderIds: number[]; // List of supplier order ids that this book order is part of
 };
 export type BookLine = { isbn: string; quantity: number };
 

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -3,6 +3,29 @@
  */
 export { type DB } from "@vlcn.io/crsqlite-wasm";
 
+/* Customer orders/books */
+export type Customer = {
+	id?: number;
+	fullname?: string;
+	email?: string;
+	phone?: string;
+	taxId?: string;
+	deposit?: number;
+};
+export type CustomerOrderLine = { id: number; isbn: string; quantity: number };
+export type BookLine = { isbn: string; quantity: number };
+
+/* Suppliers */
+export type SupplierOrderInfo = { supplier_id: number; isbn: string; total_book_number: number };
+export type SupplierOrderLine = { supplier_id: number; isbn: string; quantity: number };
+
+export type Supplier = {
+	id?: number;
+	name?: string;
+	email?: string;
+	address?: string;
+};
+
 /* These have been lifted from https://github.com/vlcn-io/js/blob/main/packages/direct-connect-common/src/types.ts
 I was unabe to import it from there.
 */

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -12,7 +12,28 @@ export type Customer = {
 	taxId?: string;
 	deposit?: number;
 };
-export type CustomerOrderLine = { id: number; isbn: string; quantity: number };
+
+export type DBCustomerOrderLine = {
+	// A customer order line as it is stored in the database
+	id: number;
+	isbn: string;
+	quantity: number;
+	created: number; // as milliseconds since epoch
+	placed?: number; // as milliseconds since epoch
+	received?: number; // as milliseconds since epoch
+	collected?: number; // as milliseconds since epoch
+};
+
+export type CustomerOrderLine = {
+	// A customer order line to be passed around in the application
+	id: number;
+	isbn: string;
+	quantity: number;
+	created: Date; // Date when the book order was entered
+	placed?: Date; // Last date when the book order was placed to the supplier
+	received?: Date; // Date when the book order was received from the supplier
+	collected?: Date; // Date when the book order was collected by the customer
+};
 export type BookLine = { isbn: string; quantity: number };
 
 /* Suppliers */

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -47,6 +47,12 @@ export type Supplier = {
 	address?: string;
 };
 
+export type SupplierOrder = {
+	supplier_id: number;
+	created: Date;
+	lines: SupplierOrderLine[];
+};
+
 /* These have been lifted from https://github.com/vlcn-io/js/blob/main/packages/direct-connect-common/src/types.ts
 I was unabe to import it from there.
 */


### PR DESCRIPTION
Includes a `book` table for the cr-sqlite db

So far
* possible supplier orders can be enumerated
* supplier orders can be created and customer order lines are updated accordingly
* when a customer order line is included in a supplier order this event is recorded in the `customer_supplier_order` table.