### PR TITLE
Do not download playwright browsers on `rush update`

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -32,6 +32,8 @@ jobs:
       -  #@ rush_build()
       - name: Build the app
         run: cd apps/web-client && rushx build:e2e
+      - name: Download playwright browsers
+        run: cd apps/e2e && npx playwright install
       - name: Run Playwright tests
         run: cd apps/e2e && rushx test:ci
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -126,6 +126,8 @@ jobs:
       run: rush build
     - name: Build the app
       run: cd apps/web-client && rushx build:e2e
+    - name: Download playwright browsers
+      run: cd apps/e2e && npx playwright install
     - name: Run Playwright tests
       run: cd apps/e2e && rushx test:ci
     - uses: actions/upload-artifact@v4

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -11,8 +11,7 @@
 		"typecheck": "tsc",
 		"lint": "prettier --check . && eslint .",
 		"lint:strict": "prettier --check . && eslint . --max-warnings=0",
-		"format": "prettier --write .",
-		"postinstall": "playwright install"
+		"format": "prettier --write ."
 	},
 	"devDependencies": {
 		"@librocco/db": "workspace:*",


### PR DESCRIPTION
@coderabbitai review full

Fixes #573 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced end-to-end testing setup with the addition of a step to download necessary Playwright browsers before tests are executed.

- **Chores**
	- Removed the automatic installation of Playwright dependencies from the `postinstall` script in the `package.json` for the e2e project, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->