### PR TITLE
silence svelte check (`rushx typecheck` warnings - display only errors):

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -18,7 +18,7 @@
 		"story:preview": "storybook preview",
 		"test": "vitest --ui",
 		"test:ci": "vitest --",
-		"typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold warning",
+		"typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold error",
 		"typesafe-i18n": "typesafe-i18n",
 		"typesafe-i18n-check": "typesafe-i18n --no-watch && git diff --quiet || (echo 'Error: Changes detected in i18n files. Please commit the changes.' && exit 1)"
 	},


### PR DESCRIPTION
	* warnings just get in the way
	* sometimes easier when working with aider to merely `/run rushx typecheck` (this prevents unnecessary noise)