### PR TITLE
Fix/supplier order touchups

### DIFF
--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -13,7 +13,12 @@ import {
 	removeBooksFromCustomer
 } from "../customers";
 // import { createSupplierOrder, getPossibleSupplierOrderLines } from "../suppliers";
-import { createCustomerOrders, getRandomDb, getRandomDbs, syncDBs } from "./lib";
+import {
+	// createCustomerOrders,
+	getRandomDb,
+	getRandomDbs,
+	syncDBs
+} from "./lib";
 
 describe("Db creation tests", () => {
 	it("should allow initializing a database", async () => {

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -132,21 +132,21 @@ describe("Customer order tests", () => {
 	});
 });
 
-describe("Customer order status", () => {
-	let db: DB;
-	beforeEach(async () => {
-		db = await getRandomDb();
-		await createCustomerOrders(db);
-	});
-	// TODO: update this when we have a handler to getPlacedOrderLines
-	// it("can update the timestamp of when a customer order is placed (to supplier)", async () => {
-	// 	const newOrderLines = await getPossibleSupplierOrderLines(db, 1);
+// TODO: update this when we have a handler to getPlacedOrderLines
+// describe("Customer order status", () => {
+// 	let db: DB;
+// 	beforeEach(async () => {
+// 		db = await getRandomDb();
+// 		await createCustomerOrders(db);
+// 	});
+// 	it("can update the timestamp of when a customer order is placed (to supplier)", async () => {
+// 		const newOrderLines = await getPossibleSupplierOrderLines(db, 1);
 
-	// 	await createSupplierOrder(db, newOrderLines);
+// 		await createSupplierOrder(db, newOrderLines);
 
-	// const isbns = [...newOrders[0].lines, ...newOrders[1].lines].map((line) => line.isbn);
-	// await markCustomerOrderAsReceived(db, isbns);
-	// const books = await getCustomerBooks(db, 1);
-	// expect(books[1].received).toBeInstanceOf(Date);
-	// });
-});
+// 	const isbns = [...newOrders[0].lines, ...newOrders[1].lines].map((line) => line.isbn);
+// 	await markCustomerOrderAsReceived(db, isbns);
+// 	const books = await getCustomerBooks(db, 1);
+// 	expect(books[1].received).toBeInstanceOf(Date);
+// 	});
+// });

--- a/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/orders.test.ts
@@ -8,11 +8,11 @@ import {
 	getAllCustomers,
 	upsertCustomer,
 	getCustomerBooks,
-	markCustomerOrderAsReceived,
+	// markCustomerOrderAsReceived,
 	addBooksToCustomer,
 	removeBooksFromCustomer
 } from "../customers";
-import { createSupplierOrder, getPossibleSupplerOrderLines } from "../suppliers";
+// import { createSupplierOrder, getPossibleSupplierOrderLines } from "../suppliers";
 import { createCustomerOrders, getRandomDb, getRandomDbs, syncDBs } from "./lib";
 
 describe("Db creation tests", () => {
@@ -138,11 +138,15 @@ describe("Customer order status", () => {
 		db = await getRandomDb();
 		await createCustomerOrders(db);
 	});
-	it("can update the timestamp of when a customer order is placed (to supplier)", async () => {
-		const newOrders = await createSupplierOrder(db, await getPossibleSupplerOrderLines(db));
-		const isbns = [...newOrders[0].lines, ...newOrders[1].lines].map((line) => line.isbn);
-		await markCustomerOrderAsReceived(db, isbns);
-		const books = await getCustomerBooks(db, 1);
-		expect(books[1].received).toBeInstanceOf(Date);
-	});
+	// TODO: update this when we have a handler to getPlacedOrderLines
+	// it("can update the timestamp of when a customer order is placed (to supplier)", async () => {
+	// 	const newOrderLines = await getPossibleSupplierOrderLines(db, 1);
+
+	// 	await createSupplierOrder(db, newOrderLines);
+
+	// const isbns = [...newOrders[0].lines, ...newOrders[1].lines].map((line) => line.isbn);
+	// await markCustomerOrderAsReceived(db, isbns);
+	// const books = await getCustomerBooks(db, 1);
+	// expect(books[1].received).toBeInstanceOf(Date);
+	// });
 });

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -30,9 +30,6 @@ describe("Supplier order handlers should", () => {
 
 	// TODO: export and match to test data instead of all of this duplication
 	it("Retrieves possible order lines for a specific supplier from unplaced customer orders", async () => {
-		const test = await getPossibleSupplierOrderLines(db, 1);
-		const test2 = await getPossibleSupplierOrderLines(db, 2);
-
 		// Supplier 1 should have the following lines
 		expect(await getPossibleSupplierOrderLines(db, 1)).toEqual([
 			{

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -28,23 +28,73 @@ describe("Supplier order handlers should", () => {
 		]);
 	});
 
+	// TODO: export and match to test data instead of all of this duplication
 	it("Retrieves possible order lines for a specific supplier from unplaced customer orders", async () => {
+		const test = await getPossibleSupplierOrderLines(db, 1);
+		const test2 = await getPossibleSupplierOrderLines(db, 2);
+
 		// Supplier 1 should have the following lines
-		expect(await getPossibleSupplierOrderLines(db, 1)).toStrictEqual([
-			{ supplier_id: 1, isbn: "1", quantity: 1, supplier_name: "Science Books LTD" },
-			{ supplier_id: 1, isbn: "2", quantity: 1, supplier_name: "Science Books LTD" }
+		expect(await getPossibleSupplierOrderLines(db, 1)).toEqual([
+			{
+				supplier_id: 1,
+				supplier_name: "Science Books LTD",
+				isbn: "1",
+				publisher: "MathsAndPhysicsPub",
+				authors: null,
+				title: "Physics",
+				quantity: 1,
+				line_price: 7
+			},
+			{
+				supplier_id: 1,
+				supplier_name: "Science Books LTD",
+				isbn: "2",
+				publisher: "ChemPub",
+				authors: null,
+				title: "Chemistry",
+				quantity: 1,
+				line_price: 13
+			}
 		]);
 		// Supplier 2 lines should have the following lines
-		expect(await getPossibleSupplierOrderLines(db, 2)).toStrictEqual([
-			{ supplier_id: 2, isbn: "3", quantity: 2, supplier_name: "Phantasy Books LTD" }
+		expect(await getPossibleSupplierOrderLines(db, 2)).toEqual([
+			{
+				supplier_id: 2,
+				supplier_name: "Phantasy Books LTD",
+				isbn: "3",
+				publisher: "PhantasyPub",
+				authors: null,
+				title: "The Hobbit",
+				quantity: 2,
+				line_price: 10
+			}
 		]);
 
 		// If we change the supplier for ChemPub to Phantasy Books LTD
 		// the supplier order will reflect that
 		await associatePublisher(db, 2, "ChemPub");
-		expect(await getPossibleSupplierOrderLines(db, 2)).toStrictEqual([
-			{ supplier_id: 2, isbn: "2", quantity: 1, supplier_name: "Phantasy Books LTD" }, // This is now from supplier 2
-			{ supplier_id: 2, isbn: "3", quantity: 2, supplier_name: "Phantasy Books LTD" }
+		expect(await getPossibleSupplierOrderLines(db, 2)).toEqual([
+			// This is now from supplier 2
+			{
+				supplier_id: 2,
+				supplier_name: "Phantasy Books LTD",
+				isbn: "2",
+				publisher: "ChemPub",
+				authors: null,
+				title: "Chemistry",
+				quantity: 1,
+				line_price: 13
+			},
+			{
+				supplier_id: 2,
+				supplier_name: "Phantasy Books LTD",
+				isbn: "3",
+				publisher: "PhantasyPub",
+				authors: null,
+				title: "The Hobbit",
+				quantity: 2,
+				line_price: 10
+			}
 		]);
 	});
 
@@ -52,10 +102,10 @@ describe("Supplier order handlers should", () => {
 		const possibleOrderLines = await getPossibleSupplierOrderLines(db, 1);
 
 		const newOrders = await createSupplierOrder(db, possibleOrderLines);
-		expect(newOrders.length).toStrictEqual(1);
+		expect(newOrders.length).toBe(1);
 
 		const newPossibleOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		expect(newPossibleOrderLines.length).toStrictEqual(0);
+		expect(newPossibleOrderLines.length).toBe(0);
 	});
 
 	it("gets all supplier orders with correct totals", async () => {

--- a/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/orders/__tests__/supplier-order.test.ts
@@ -7,43 +7,54 @@ import { getRandomDb, createCustomerOrders } from "./lib";
 import {
 	associatePublisher,
 	getPlacedSupplierOrders,
-	getPossibleSupplerOrderLines,
+	getPossibleSupplierOrderLines,
 	getPossibleSupplierOrders,
 	createSupplierOrder
 } from "../suppliers";
 
-describe("Suppliers order creation", () => {
+describe("Supplier order handlers should", () => {
 	let db: DB;
 	beforeEach(async () => {
 		db = await getRandomDb();
 		await createCustomerOrders(db);
 	});
 
-	it("sees possible supplier orders from client orders", async () => {
-		expect(await getPossibleSupplerOrderLines(db)).toStrictEqual([
-			{ supplier_id: 1, isbn: "1", quantity: 1, supplier_name: "Science Books LTD" },
-			{ supplier_id: 1, isbn: "2", quantity: 1, supplier_name: "Science Books LTD" },
-			{ supplier_id: 2, isbn: "3", quantity: 2, supplier_name: "Phantasy Books LTD" }
-		]);
+	it("list all pending supplier orders from unplaced customer order lines", async () => {
+		// Customer order lines can be aggregated into these suppliers.
+		// The aggregation includes the total number of books and total price
 		expect(await getPossibleSupplierOrders(db)).toStrictEqual([
 			{ supplier_name: "Phantasy Books LTD", supplier_id: 2, total_book_number: 2, total_book_price: 10 },
 			{ supplier_name: "Science Books LTD", supplier_id: 1, total_book_number: 2, total_book_price: 20 }
 		]);
+	});
+
+	it("Retrieves possible order lines for a specific supplier from unplaced customer orders", async () => {
+		// Supplier 1 should have the following lines
+		expect(await getPossibleSupplierOrderLines(db, 1)).toStrictEqual([
+			{ supplier_id: 1, isbn: "1", quantity: 1, supplier_name: "Science Books LTD" },
+			{ supplier_id: 1, isbn: "2", quantity: 1, supplier_name: "Science Books LTD" }
+		]);
+		// Supplier 2 lines should have the following lines
+		expect(await getPossibleSupplierOrderLines(db, 2)).toStrictEqual([
+			{ supplier_id: 2, isbn: "3", quantity: 2, supplier_name: "Phantasy Books LTD" }
+		]);
+
 		// If we change the supplier for ChemPub to Phantasy Books LTD
 		// the supplier order will reflect that
 		await associatePublisher(db, 2, "ChemPub");
-		expect(await getPossibleSupplerOrderLines(db)).toStrictEqual([
-			{ supplier_id: 1, isbn: "1", quantity: 1, supplier_name: "Science Books LTD" },
+		expect(await getPossibleSupplierOrderLines(db, 2)).toStrictEqual([
 			{ supplier_id: 2, isbn: "2", quantity: 1, supplier_name: "Phantasy Books LTD" }, // This is now from supplier 2
 			{ supplier_id: 2, isbn: "3", quantity: 2, supplier_name: "Phantasy Books LTD" }
 		]);
 	});
 
 	it("creates two new supplier orders", async () => {
-		const possibleOrderLines = await getPossibleSupplerOrderLines(db);
+		const possibleOrderLines = await getPossibleSupplierOrderLines(db, 1);
+
 		const newOrders = await createSupplierOrder(db, possibleOrderLines);
-		expect(newOrders.length).toStrictEqual(2);
-		const newPossibleOrderLines = await getPossibleSupplerOrderLines(db);
+		expect(newOrders.length).toStrictEqual(1);
+
+		const newPossibleOrderLines = await getPossibleSupplierOrderLines(db, 1);
 		expect(newPossibleOrderLines.length).toStrictEqual(0);
 	});
 

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -72,28 +72,7 @@ export async function associatePublisher(db: DB, supplierId: number, publisherId
 		[supplierId, publisherId, supplierId]
 	);
 }
-/**
-  * Retrieves all unplaced customer orders which are equivalent to possible order lines that can be created.
-  * Groups books by supplier based on publisher associations.
-  *
-  * @param db - The database instance to query
-  * @returns Promise resolving to an array of possible order lines with supplie
- and book information
-  */
-export async function getPossibleSupplerOrderLines(db: DB): Promise<SupplierOrderLine[]> {
-	// We need to build a query that will yield all books we can order, grouped by supplier
-	const result = await db.execO<SupplierOrderLine>(
-		`SELECT supplier_id, supplier.name as supplier_name, book.isbn, SUM(quantity) as quantity
-      FROM supplier
-        JOIN supplier_publisher ON supplier.id = supplier_publisher.supplier_id
-        JOIN book ON supplier_publisher.publisher = book.publisher
-        JOIN customer_order_lines ON book.isbn = customer_order_lines.isbn
-      WHERE quantity > 0 AND placed is NULL
-      GROUP BY supplier_id, book.isbn
-      ORDER BY book.isbn ASC;`
-	);
-	return result;
-}
+
 /**
  * Retrieves possible order lines for a specific supplier based on unplaced customer orders.
  *
@@ -101,7 +80,7 @@ export async function getPossibleSupplerOrderLines(db: DB): Promise<SupplierOrde
  * @param supplierId - The ID of the supplier to get order lines for
  * @returns Promise resolving to an array of possible order lines for the specified supplier
  */
-export async function getPossibleOrderLinesForSupplier(db: DB, supplierId: number): Promise<SupplierOrderLine[]> {
+export async function getPossibleSupplierOrderLines(db: DB, supplierId: number): Promise<SupplierOrderLine[]> {
 	// We need to build a query that will yield all books we can order, grouped by supplier
 	const result = await db.execO<SupplierOrderLine>(
 		`SELECT supplier_id, supplier.name as supplier_name, book.isbn, SUM(quantity) as quantity
@@ -110,7 +89,7 @@ export async function getPossibleOrderLinesForSupplier(db: DB, supplierId: numbe
         JOIN book ON supplier_publisher.publisher = book.publisher
         JOIN customer_order_lines ON book.isbn = customer_order_lines.isbn
       WHERE quantity > 0 AND placed is NULL AND supplier_id = ?
-      GROUP BY supplier_id, book.isbn
+      GROUP BY book.isbn
       ORDER BY book.isbn ASC;`,
 		[supplierId]
 	);

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -183,6 +183,9 @@ export async function getPlacedSupplierOrders(db: DB): Promise<SupplierPlacedOrd
 // export async function getPlacedSupplierOrderLines(db: DB, supplier_id: number): Promise<SupplierPlacedOrder[]> {}
 
 /**
+ * TODO: I removed the getSupplierOrder query at the end of this because it seemed unnecessary, and it feels like it should be re-written inline with above structure
+ * this currently returns nothing. We can rethink this
+ * 
  * Creates supplier orders based on provided order lines and updates related customer orders.
  *
  * @param db - The database instance to query
@@ -254,37 +257,4 @@ export async function createSupplierOrder(db: DB, orderLines: SupplierOrderLine[
 			);
 		}
 	});
-	return Promise.all(supplierIds.map((supplierId) => getSupplierOrder(db, supplierOrderMapping[supplierId])));
-}
-/**
- * Retrieves a specific supplier order with all its details.
- *
- * @param db - The database instance to query
- * @param supplierOrderId - The id of the supplier order to retrieve
- * @returns Promise resolving to the supplier order details
- * @throws {Error} If no order is found with the given id
- */
-export async function getSupplierOrder(db: DB, supplierOrderId: number): Promise<SupplierOrder> {
-	const orderInfo = await db.execO<SupplierOrderInfo & SupplierOrderLine & { supplier_order_id: number; created: string }>(
-		`SELECT supplier_order.id as supplier_order_id, created, supplier_id, supplier.name as supplier_name, isbn, quantity
-       FROM supplier_order
-         JOIN supplier ON supplier_order.supplier_id = supplier.id
-         JOIN supplier_order_line ON supplier_order.id = supplier_order_line.supplier_order_id
-       WHERE supplier_order_id = ?;`,
-		[supplierOrderId]
-	);
-	if (!orderInfo.length) {
-		throw Error("No orders found with this Id");
-	}
-	return {
-		supplier_id: orderInfo[0].supplier_id,
-		id: orderInfo[0].supplier_order_id,
-
-		created: new Date(orderInfo[0].created),
-		lines: orderInfo.map((line) => ({
-			supplier_id: line.supplier_id,
-			isbn: line.isbn,
-			quantity: line.quantity
-		}))
-	};
 }

--- a/apps/web-client/src/lib/db/orders/suppliers.ts
+++ b/apps/web-client/src/lib/db/orders/suppliers.ts
@@ -1,4 +1,4 @@
-import type { DB, Supplier, SupplierOrderInfo, SupplierOrderLine, SupplierOrder, SupplierPlacedOrder } from "./types";
+import type { DB, Supplier, SupplierOrderInfo, SupplierOrderLine, SupplierPlacedOrder } from "./types";
 
 /**
  * @fileoverview Supplier order management system

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -61,6 +61,7 @@ export type SupplierOrderLine = {
 };
 
 export type SupplierPlacedOrder = {
+	id: number;
 	supplier_name: string;
 	supplier_id: number;
 	total_book_number: number;

--- a/apps/web-client/src/lib/db/orders/types.ts
+++ b/apps/web-client/src/lib/db/orders/types.ts
@@ -48,7 +48,17 @@ export type BookLine = { isbn: string; quantity: number };
 
 /* Suppliers */
 export type SupplierOrderInfo = { supplier_id: number; isbn: string; total_book_number: number };
-export type SupplierOrderLine = { supplier_id: number; isbn: string; quantity: number };
+export type SupplierOrderLine = {
+	supplier_id: number;
+	supplier_name: string;
+	// TODO: extend from Book type (which properties are optional?)
+	isbn: string;
+	title: string;
+	authors: string;
+	publisher: string;
+	quantity: number;
+	line_price: number;
+};
 
 export type SupplierPlacedOrder = {
 	supplier_name: string;

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { goto, invalidate } from "$app/navigation";
+	import { invalidate } from "$app/navigation";
 
 	import { Truck } from "lucide-svelte";
 
 	import { createSupplierOrder } from "$lib/db/orders/suppliers";
+	import { goto } from "$lib/utils/navigation";
 
 	import type { PageData } from "./$types";
 	import { base } from "$app/paths";

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -53,7 +53,7 @@
 	}
 </script>
 
-<header class="navbar bg-neutral mb-4">
+<header class="navbar mb-4 bg-neutral">
 	<input type="checkbox" value="forest" class="theme-controller toggle" />
 </header>
 
@@ -62,7 +62,7 @@
 		<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 			<div class="card">
 				<div class="card-body gap-y-2 p-0">
-					<div class="bg-base-100 sticky top-0 flex gap-2 pb-3 md:flex-col">
+					<div class="sticky top-0 flex gap-2 bg-base-100 pb-3 md:flex-col">
 						<h1 class="prose card-title">{supplier.name}</h1>
 
 						<div class="flex flex-row items-center justify-between gap-y-2 md:flex-col md:items-start">
@@ -146,7 +146,7 @@
 			</div>
 			{#if canPlaceOrder}
 				<div class="card fixed bottom-4 left-0 z-10 flex w-screen flex-row bg-transparent md:absolute md:bottom-24 md:mx-2 md:w-full">
-					<div class="bg-base-300 mx-2 flex w-full flex-row justify-between px-4 py-2 shadow-lg">
+					<div class="mx-2 flex w-full flex-row justify-between bg-base-300 px-4 py-2 shadow-lg">
 						<dl class="stats flex">
 							<div class="stat flex shrink flex-row place-items-center py-2 max-md:px-4">
 								<div class="stat-title">Selected books:</div>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { invalidate } from "$app/navigation";
+	import { goto, invalidate } from "$app/navigation";
 
 	import { Truck } from "lucide-svelte";
 
 	import { createSupplierOrder } from "$lib/db/orders/suppliers";
 
 	import type { PageData } from "./$types";
+	import { base } from "$app/paths";
 
 	export let data: PageData;
 
@@ -36,6 +37,9 @@
 
 		await createSupplierOrder(data.ordersDb, selection);
 		await invalidate("suppliers:data");
+		// TODO: We could either go to the new supplier order "placed" view when it's created
+		// or we could make sure we go to the "placed" list on the suppliers view "/suppliers?s=placed"
+		await goto(`${base}/orders/suppliers`);
 	}
 
 	function selectPortion(portion: number) {

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
@@ -1,19 +1,13 @@
-import { getPossibleOrderLinesForSupplier } from "$lib/db/orders/suppliers";
-import type { BookEntry } from "@librocco/db";
+import { getPossibleSupplierOrderLines } from "$lib/db/orders/suppliers";
+
 import type { PageLoad } from "./$types";
+
 export const load: PageLoad = async ({ parent, params }) => {
 	const { ordersDb } = await parent();
 
-	const lines = await getPossibleOrderLinesForSupplier(ordersDb, parseInt(params.id));
-	const isbns = lines.map((book) => book.isbn);
-	const bookData = (await ordersDb.execO(`SELECT * FROM book WHERE isbn IN (${isbns.join(", ")})`)) as BookEntry[];
+	const orderLines = await getPossibleSupplierOrderLines(ordersDb, parseInt(params.id));
 
-	const bookDataMap = new Map<string, BookEntry>();
-	bookData.forEach((book) => {
-		bookDataMap.set(book.isbn, book);
-	});
-
-	const supplierOrderLinesWithData = lines.map((line) => ({ ...line, ...bookDataMap.get(line.isbn) }));
-	return { lines, books: supplierOrderLinesWithData, bookDataMap };
+	return { orderLines };
 };
+
 export const ssr = false;


### PR DESCRIPTION
A few additions the to supplier order queries and wiring in:
- Remove the unused query that got all supplier order lines
- Update `getPossibleSupplierOrderLines` to return full book data. Remove map & merge in load funciton, and update references/consumption in the view
- Add more documentation to the supplier file
- Remove the `getSupplierOrder` query used at the end of the `createCustomerOrder` handler. `create` needs some more work. It currently doesn't return anything, but I figure at least that it doesn't need to be running `getSupplierOrder` at the end as it currently does nothing with it. I've added a redirect back to the list view on create (with note to improve). 
- update tests (just enough) to reflect these changes

TODO still: 
- Add `getPlacedOrderLines` - but this needs the missing view
- Add a way to return a single or select `supplier_order` by IDs. Could be an optional arg to `getSupplierOrders`?