### PR TITLE
Fix/db timestamps

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -103,7 +103,7 @@ describe("Customer order tests", () => {
 describe("Customer order tests", () => {
 	let db1: DB, db2: DB;
 	beforeEach(async () => ([db1, db2] = await getRandomDbs()));
-	it("Should sync customer creation", async () => {
+	it.only("Should sync customer creation", async () => {
 		// We create one customer in db1 and a different one in db2
 		let db1Customers: Customer[], db2Customers: Customer[];
 		await upsertCustomer(db1, { fullname: "John Doe", id: 1, email: "john@example.com", deposit: 13.2 });
@@ -111,9 +111,13 @@ describe("Customer order tests", () => {
 		[db1Customers, db2Customers] = await Promise.all([getAllCustomers(db1), getAllCustomers(db2)]);
 		expect(db1Customers.length).toBe(1);
 		expect(db2Customers.length).toBe(1);
+
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+
 		await syncDBs(db1, db2);
 		expect((await getAllCustomers(db2)).length).toBe(2);
 		await syncDBs(db2, db1);
+
 		expect((await getAllCustomers(db1)).length).toBe(2);
 		[db1Customers, db2Customers] = await Promise.all([getAllCustomers(db1), getAllCustomers(db2)]);
 		expect(db1Customers).toMatchObject(db2Customers);

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -114,6 +114,8 @@ describe("Customer order tests", () => {
 		expect(db1Customers.length).toBe(1);
 		expect(db2Customers.length).toBe(1);
 
+		// This tests for a regression we had: we want to ensure that the sync won't update the `updated_at` field
+		// - it should be the same as for the original entry
 		await new Promise((resolve) => setTimeout(resolve, 1000));
 
 		await syncDBs(db1, db2);

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -102,8 +102,10 @@ describe("Customer order tests", () => {
 
 describe("Customer order tests", () => {
 	let db1: DB, db2: DB;
+
 	beforeEach(async () => ([db1, db2] = await getRandomDbs()));
-	it.only("Should sync customer creation", async () => {
+
+	it("Should sync customer creation", async () => {
 		// We create one customer in db1 and a different one in db2
 		let db1Customers: Customer[], db2Customers: Customer[];
 		await upsertCustomer(db1, { fullname: "John Doe", id: 1, email: "john@example.com", deposit: 13.2 });
@@ -122,6 +124,7 @@ describe("Customer order tests", () => {
 		[db1Customers, db2Customers] = await Promise.all([getAllCustomers(db1), getAllCustomers(db2)]);
 		expect(db1Customers).toMatchObject(db2Customers);
 	});
+
 	it("Should keep both updates done at the same time on different dbs", async () => {
 		// We create one customer in db1 and a different one in db2
 		await upsertCustomer(db1, { fullname: "John Doe", id: 1, email: "john@example.com", deposit: 13.2 });

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -148,9 +148,6 @@ describe("Inbound note tests", () => {
 
 		// Attempt to commit the note again
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await commitNote(db, 1);
 		note = await getNoteById(db, 1);
 		expect(note).toEqual(
@@ -178,9 +175,6 @@ describe("Inbound note tests", () => {
 		);
 		const { updatedAt } = note;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await updateNote(db, 1, { displayName: "Updated Note" });
 
 		note = await getNoteById(db, 1);
@@ -505,11 +499,13 @@ describe("Outbound note tests", () => {
 		await addVolumesToNote(db, 3, { isbn: "1111111111", quantity: 3, warehouseId: 2 }); // avlbl: 0, res = -3
 		await addVolumesToNote(db, 3, { isbn: "2222222222", quantity: 4, warehouseId: 2 }); // avlbl: 2, res = -2
 
+		// The transactions are ordered in the reverse order of being added/updated (latest-first) in note view
+		// so the error follows the same ordering
 		expect(commitNote(db, 3)).rejects.toThrow(
 			new OutOfStockError([
-				{ isbn: "1111111111", quantity: 3, warehouseId: 1, available: 2, warehouseName: "Warehouse 1" },
+				{ isbn: "2222222222", quantity: 4, warehouseId: 2, available: 2, warehouseName: "Warehouse 2" },
 				{ isbn: "1111111111", quantity: 3, warehouseId: 2, available: 0, warehouseName: "Warehouse 2" },
-				{ isbn: "2222222222", quantity: 4, warehouseId: 2, available: 2, warehouseName: "Warehouse 2" }
+				{ isbn: "1111111111", quantity: 3, warehouseId: 1, available: 2, warehouseName: "Warehouse 1" }
 			])
 		);
 	});
@@ -533,9 +529,6 @@ describe("Outbound note tests", () => {
 
 		// Attempt to commit the note again
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await commitNote(db, 1);
 		note = await getNoteById(db, 1);
 		expect(note).toEqual(
@@ -563,9 +556,6 @@ describe("Outbound note tests", () => {
 		);
 		const { updatedAt } = note;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await updateNote(db, 1, { displayName: "Updated Note" });
 
 		note = await getNoteById(db, 1);
@@ -583,9 +573,6 @@ describe("Outbound note tests", () => {
 		// The updated at should be newer
 		expect(note.updatedAt > updatedAt).toEqual(true);
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await updateNote(db, 1, { defaultWarehouse: 1 });
 
 		note = await getNoteById(db, 1);
@@ -856,9 +843,6 @@ describe("Book transactions", async () => {
 			})
 		]);
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await addVolumesToNote(db, 1, { isbn: "0987654321", quantity: 5, warehouseId: 1 });
 
 		expect(await getNoteEntries(db, 1)).toEqual([
@@ -875,10 +859,6 @@ describe("Book transactions", async () => {
 		]);
 
 		// Adding a volume without warehouseId should be possible
-		//
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await addVolumesToNote(db, 1, { isbn: "0987654321", quantity: 5 });
 		expect(await getNoteEntries(db, 1)).toEqual([
 			expect.objectContaining({
@@ -963,9 +943,6 @@ describe("Book transactions", async () => {
 		let note = await getNoteById(db, 1);
 		let updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 10, warehouseId: 1 });
 
 		note = await getNoteById(db, 1);
@@ -973,10 +950,6 @@ describe("Book transactions", async () => {
 		updatedAt = note?.updatedAt;
 
 		// Add some more volumes
-		//
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 5, warehouseId: 1 });
 
 		note = await getNoteById(db, 1);
@@ -984,10 +957,6 @@ describe("Book transactions", async () => {
 		updatedAt = note?.updatedAt;
 
 		// Should also work with txn update
-		//
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await updateNoteTxn(db, 1, { isbn: "1234567890", warehouseId: 1 }, { quantity: 7, warehouseId: 1 });
 
 		note = await getNoteById(db, 1);
@@ -995,10 +964,6 @@ describe("Book transactions", async () => {
 		updatedAt = note?.updatedAt;
 
 		// Should also work when removing a txn
-		//
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await removeNoteTxn(db, 1, { isbn: "1234567890", warehouseId: 1 });
 
 		note = await getNoteById(db, 1);
@@ -1014,9 +979,7 @@ describe("Book transactions", async () => {
 
 		// Add multiple entries with different updated_at times
 		await addVolumesToNote(db, 1, { isbn: "0987654321", quantity: 5, warehouseId: 1 });
-		await new Promise((res) => setTimeout(res, 1000)); // Ensure different timestamps
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 10, warehouseId: 1 });
-		await new Promise((res) => setTimeout(res, 1000)); // Ensure different timestamps
 		await addVolumesToNote(db, 1, { isbn: "1122334455", quantity: 8, warehouseId: 1 });
 
 		const entries = await getNoteEntries(db, 1);
@@ -1102,7 +1065,6 @@ describe("Book transactions", async () => {
 
 		// Add initial transactions
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 10, warehouseId: 1 });
-		await new Promise((res) => setTimeout(res, 1000)); // Ensure different timestamps
 		await addVolumesToNote(db, 1, { isbn: "0987654321", quantity: 5, warehouseId: 1 });
 
 		// Check before updating
@@ -1130,7 +1092,6 @@ describe("Book transactions", async () => {
 		// Add initial transactions
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 10, warehouseId: 1 });
 		await addVolumesToNote(db, 1, { isbn: "1234567890", quantity: 5, warehouseId: 2 });
-		await new Promise((res) => setTimeout(res, 1000)); // Ensure different timestamps
 		await addVolumesToNote(db, 1, { isbn: "0987654321", quantity: 5, warehouseId: 1 });
 		expect(await getNoteEntries(db, 1)).toEqual([
 			expect.objectContaining({ isbn: "0987654321" }),
@@ -1237,9 +1198,6 @@ describe("Note custom items", async () => {
 		let note = await getNoteById(db, 1);
 		const updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await upsertNoteCustomItem(db, 1, { id: 1, title: "Custom Item 1", price: 100 });
 
 		const items = await getNoteCustomItems(db, 1);
@@ -1264,9 +1222,6 @@ describe("Note custom items", async () => {
 		let note = await getNoteById(db, 1);
 		const updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await upsertNoteCustomItem(db, 1, { id: 1, title: "Updated Custom Item 1", price: 150 });
 
 		const items = await getNoteCustomItems(db, 1);
@@ -1291,9 +1246,6 @@ describe("Note custom items", async () => {
 		let note = await getNoteById(db, 1);
 		const updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await removeNoteCustomItem(db, 1, 1);
 
 		const items = await getNoteCustomItems(db, 1);
@@ -1312,9 +1264,6 @@ describe("Note custom items", async () => {
 		let note = await getNoteById(db, 1);
 		const updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await upsertNoteCustomItem(db, 1, { id: 1, title: "Custom Item 1", price: 100 });
 
 		const items = await getNoteCustomItems(db, 1);
@@ -1334,9 +1283,6 @@ describe("Note custom items", async () => {
 		let note = await getNoteById(db, 1);
 		const updatedAt = note?.updatedAt;
 
-		// The DB saves updated_at with second intervals
-		// Wait for a second to observe the updated_at updated between writes
-		await new Promise((res) => setTimeout(res, 1000));
 		await removeNoteCustomItem(db, 1, 1);
 
 		note = await getNoteById(db, 1);
@@ -1360,8 +1306,8 @@ describe("Note custom items", async () => {
 		await upsertNoteCustomItem(db, 1, { id: 1, title: "Item 1", price: 10 });
 		await upsertNoteCustomItem(db, 2, { id: 1, title: "Item 2", price: 12 });
 
-		expect(await getNoteCustomItems(db, 1)).toEqual([{ id: 1, title: "Item 1", price: 10 }]);
-		expect(await getNoteCustomItems(db, 2)).toEqual([{ id: 1, title: "Item 2", price: 12 }]);
+		expect(await getNoteCustomItems(db, 1)).toEqual([{ id: 1, title: "Item 1", price: 10, updatedAt: expect.any(Date) }]);
+		expect(await getNoteCustomItems(db, 2)).toEqual([{ id: 1, title: "Item 2", price: 12, updatedAt: expect.any(Date) }]);
 	});
 });
 

--- a/apps/web-client/src/lib/db/cr-sqlite/customers.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/customers.ts
@@ -49,7 +49,7 @@ export async function upsertCustomer(db: DB, customer: Customer) {
          ON CONFLICT(id) DO UPDATE SET
            fullname = COALESCE(?, fullname),
            email = COALESCE(?, email),
-           updated_at = excluded.updated_at,
+           updated_at = ?,
            deposit = COALESCE(?, deposit);`,
 		[
 			customer.id,
@@ -59,6 +59,7 @@ export async function upsertCustomer(db: DB, customer: Customer) {
 			timestamp,
 			customer.fullname ?? null,
 			customer.email ?? null,
+			timestamp,
 			customer.deposit ?? null
 		]
 	);

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -302,12 +302,12 @@ export async function addVolumesToNote(db: DB, noteId: number, volume: VolumeSto
 		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(isbn, note_id, warehouse_id) DO UPDATE SET
 			quantity = book_transaction.quantity + excluded.quantity,
-			updated_at = excluded.updated_at
+			updated_at = ?
 	`;
 
 	await db.tx(async (txDb) => {
 		const timestamp = Date.now();
-		await txDb.exec(insertOrUpdateTxnStmt, [isbn, quantity, warehouseId, noteId, timestamp]);
+		await txDb.exec(insertOrUpdateTxnStmt, [isbn, quantity, warehouseId, noteId, timestamp, timestamp]);
 		await txDb.exec(`UPDATE note SET updated_at = ? WHERE id = ?`, [timestamp, noteId]);
 	});
 }

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -13,7 +13,7 @@ export type Customer = {
 	phone?: string;
 	taxId?: string;
 	deposit?: number;
-	updatedAt?: number;
+	updatedAt?: Date;
 };
 
 export type BookData = {

--- a/pkg/shared/db-schemas/init.sql
+++ b/pkg/shared/db-schemas/init.sql
@@ -147,70 +147,19 @@ CREATE TABLE book_transaction (
 	quantity INTEGER NOT NULL DEFAULT 0,
 	note_id INTEGER NOT NULL,
 	warehouse_id INTEGER,
-	updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000),
+	updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
 	committed_at INTEGER,
 	PRIMARY KEY (isbn, note_id, warehouse_id)
 );
 
-CREATE TRIGGER update_note_timestamp_after_insert
-AFTER INSERT ON book_transaction
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.note_id AND committed = 0;
-END;
-
-CREATE TRIGGER update_note_timestamp_after_update
-AFTER UPDATE ON book_transaction
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.note_id AND committed = 0;
-END;
-
-CREATE TRIGGER update_note_timestamp_after_delete
-AFTER DELETE ON book_transaction
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = OLD.note_id AND committed = 0;
-END;
 
 CREATE TABLE custom_item (
 	id INTEGER NOT NULL,
 	title TEXT,
 	price DECIMAL,
 	note_id INTEGER,
+	updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
 	PRIMARY KEY (id, note_id)
 );
 
-CREATE TRIGGER update_note_timestamp_after_custom_item_insert
-AFTER INSERT ON custom_item
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.note_id AND committed = 0;
-END;
-
-CREATE TRIGGER update_note_timestamp_after_custom_item_update
-AFTER UPDATE ON custom_item
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.note_id AND committed = 0;
-END;
-
-CREATE TRIGGER update_note_timestamp_after_custom_item_delete
-AFTER DELETE ON custom_item
-FOR EACH ROW
-BEGIN
-    UPDATE note
-    SET updated_at = (strftime('%s', 'now') * 1000)
-    WHERE id = OLD.note_id AND committed = 0;
-END;
 

--- a/pkg/shared/db-schemas/init.sql
+++ b/pkg/shared/db-schemas/init.sql
@@ -3,7 +3,7 @@ CREATE TABLE customer (
 	fullname TEXT,
 	email TEXT,
 	deposit DECIMAL,
-	updatedAt INTEGER DEFAULT (strftime('%s', 'now') * 1000),
+	updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000),
 	PRIMARY KEY (id)
 );
 
@@ -17,33 +17,6 @@ CREATE TABLE customer_order_lines (
 	collected INTEGER,
 	PRIMARY KEY (id)
 );
-
-CREATE TRIGGER update_customer_timestamp_upsert_customer
-AFTER UPDATE ON customer
-FOR EACH ROW
-BEGIN
-	UPDATE customer
-    SET updatedAt = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.id;
-END;
-
-CREATE TRIGGER update_customer_timestamp_insert
-AFTER INSERT ON customer_order_lines
-FOR EACH ROW
-BEGIN
-    UPDATE customer
-    SET updatedAt = (strftime('%s', 'now') * 1000)
-    WHERE id = NEW.customer_id;
-END;
-
-CREATE TRIGGER update_customer_timestamp_delete
-AFTER DELETE ON customer_order_lines
-FOR EACH ROW
-BEGIN
-    UPDATE customer
-    SET updatedAt = (strftime('%s', 'now') * 1000)
-    WHERE id = OLD.customer_id;
-END;
 
 -- We can't  specify the foreign key constraint since cr-sqlite doesn't support it:
 -- Table customer_order_lines has checked foreign key constraints. CRRs may have foreign keys


### PR DESCRIPTION
Fixes #647 

Removes all DB timestamp triggers and explicitly sets the timestamp (with ms-precision) for both orders and inventory sides of the DB

Includes #650 
