### PR TITLE
Create a table for listing currently reconciling orders

### DIFF
--- a/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
@@ -4,6 +4,7 @@
 	import { base } from "$app/paths";
 	import { goto } from "$lib/utils/navigation";
 	import type { ReconciliationOrder } from "$lib/db/cr-sqlite/types";
+	import { appPath } from "$lib/paths";
 
 	function handleUpdateOrder(reconciliationOrderId: number) {
 		goto(`${base}/orders/suppliers/reconcile/${reconciliationOrderId}`);
@@ -16,9 +17,9 @@
 		<thead>
 			<tr>
 				<th scope="col">Order Id</th>
-				<th scope="col">Supplier Order Ids</th>
+				<th scope="col"></th>
 				<th scope="col">Last Updated</th>
-				<th scope="col">Created</th>
+				<th scope="col"></th>
 				<th scope="col"><span class="sr-only">Update order</span></th>
 			</tr>
 		</thead>
@@ -27,7 +28,12 @@
 				<tr class="hover focus-within:bg-base-200">
 					<td>{id}</td>
 					<!-- @TODO replace with supplierOrderIds parse array??? -->
-					<td>Includes Orders #{(JSON.parse(supplier_order_ids) || []).join(", ")}</td>
+					<td
+						>Includes Orders
+						{#each supplier_order_ids as supplier_id}
+							<a class="hover:underline" href={appPath("supplier_order_status", supplier_id)}>#{supplier_id} </a>
+						{/each}
+					</td>
 					<td>
 						<span class="badge-accent badge-outline badge badge-md gap-x-2 py-2.5">
 							<span class="sr-only">Last updated</span>
@@ -35,17 +41,11 @@
 							<time dateTime={new Date(updatedAt).toISOString()}>{new Date(updatedAt).toLocaleString()}</time>
 						</span></td
 					>
-					<td>
-						<span class="badge-accent badge-outline badge badge-md gap-x-2 py-2.5">
-							<span class="sr-only">Created</span>
-							<ClockArrowUp size={16} aria-hidden />
-							<time dateTime={new Date(created).toISOString()}>{new Date(created).toDateString()}</time>
-						</span></td
-					>
+					<td> </td>
 					<td class="text-right">
 						<button class="btn-primary btn-sm btn flex-nowrap gap-x-2.5" on:click={() => handleUpdateOrder(id)}>
 							<Scan aria-hidden focusable="false" size={20} />
-							Update Order
+							Continue
 						</button>
 					</td>
 				</tr>

--- a/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import { ClockArrowUp, Scan } from "lucide-svelte";
+
+	import { base } from "$app/paths";
+	import { goto } from "$lib/utils/navigation";
+	import type { ReconciliationOrder } from "$lib/db/cr-sqlite/types";
+
+	function handleUpdateOrder(reconciliationOrderId: number) {
+		goto(`${base}/orders/suppliers/reconcile/${reconciliationOrderId}`);
+	}
+	export let orders: Array<ReconciliationOrder>;
+</script>
+
+<div class="overflow-x-auto">
+	<table class="table-lg table whitespace-nowrap">
+		<thead>
+			<tr>
+				<th scope="col">Order Id</th>
+				<th scope="col">Supplier Order Ids</th>
+				<th scope="col">Last Updated</th>
+				<th scope="col">Created</th>
+				<th scope="col"><span class="sr-only">Update order</span></th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each orders as { id, supplier_order_ids, created, updatedAt }}
+				<tr class="hover focus-within:bg-base-200">
+					<td>{id}</td>
+					<!-- @TODO replace with supplierOrderIds parse array??? -->
+					<td>Includes Orders #{(JSON.parse(supplier_order_ids) || []).join(", ")}</td>
+					<td>
+						<span class="badge-accent badge-outline badge badge-md gap-x-2 py-2.5">
+							<span class="sr-only">Last updated</span>
+							<ClockArrowUp size={16} aria-hidden />
+							<time dateTime={new Date(updatedAt).toISOString()}>{new Date(updatedAt).toLocaleString()}</time>
+						</span></td
+					>
+					<td>
+						<span class="badge-accent badge-outline badge badge-md gap-x-2 py-2.5">
+							<span class="sr-only">Created</span>
+							<ClockArrowUp size={16} aria-hidden />
+							<time dateTime={new Date(created).toISOString()}>{new Date(created).toDateString()}</time>
+						</span></td
+					>
+					<td class="text-right">
+						<button class="btn-primary btn-sm btn flex-nowrap gap-x-2.5" on:click={() => handleUpdateOrder(id)}>
+							<Scan aria-hidden focusable="false" size={20} />
+							Update Order
+						</button>
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.table-lg td {
+		padding-top: 1rem;
+		padding-bottom: 1rem;
+	}
+</style>

--- a/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
@@ -47,7 +47,22 @@ ascending
  */
 export async function getAllReconciliationOrders(db: DB): Promise<ReconciliationOrder[]> {
 	const result = await db.execO<ReconciliationOrder>(
-		"SELECT id, supplier_order_ids, finalized, updatedAt, created FROM reconciliation_order ORDER BY id ASC;"
+		`SELECT id, supplier_order_ids, finalized, updatedAt, created FROM reconciliation_order
+			ORDER BY id ASC;`
+	);
+	return result;
+}
+/**
+ * Retrieves currently reconciling orders, ordered by ID
+ascending
+ * @param db
+ * @returns ReconciliationOrder array
+ */
+export async function getReconcilingOrders(db: DB): Promise<ReconciliationOrder[]> {
+	const result = await db.execO<ReconciliationOrder>(
+		`SELECT id, supplier_order_ids, finalized, updatedAt, created FROM reconciliation_order
+			WHERE finalized = 0
+			ORDER BY id ASC;`
 	);
 	return result;
 }

--- a/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
@@ -45,26 +45,19 @@ ascending
  * @param db
  * @returns ReconciliationOrder array
  */
-export async function getAllReconciliationOrders(db: DB): Promise<ReconciliationOrder[]> {
+export async function getAllReconciliationOrders(db: DB, finalized?: boolean): Promise<ReconciliationOrder[]> {
 	const result = await db.execO<ReconciliationOrder>(
 		`SELECT id, supplier_order_ids, finalized, updatedAt, created FROM reconciliation_order
+		${finalized !== undefined && `WHERE finalized = ${finalized ? 1 : 0}`}
 			ORDER BY id ASC;`
 	);
-	return result;
-}
-/**
- * Retrieves currently reconciling orders, ordered by ID
-ascending
- * @param db
- * @returns ReconciliationOrder array
- */
-export async function getReconcilingOrders(db: DB): Promise<ReconciliationOrder[]> {
-	const result = await db.execO<ReconciliationOrder>(
-		`SELECT id, supplier_order_ids, finalized, updatedAt, created FROM reconciliation_order
-			WHERE finalized = 0
-			ORDER BY id ASC;`
-	);
-	return result;
+
+	const parsedRes = [];
+	for (const order of result) {
+		const parsedSup = JSON.parse(order.supplier_order_ids);
+		parsedRes.push({ ...order, supplier_order_ids: parsedSup });
+	}
+	return parsedRes;
 }
 
 /**

--- a/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
@@ -43,6 +43,8 @@ import type {
  * Retrieves all reconciliation orders from the database, ordered by ID
 ascending
  * @param db
+ * @param finalized - an optional boolean that's used to query finalized or non finalized orders
+ * if not provided, all orders are fetched
  * @returns ReconciliationOrder array
  */
 export async function getAllReconciliationOrders(db: DB, finalized?: boolean): Promise<ReconciliationOrder[]> {

--- a/apps/web-client/src/lib/stores/supplier-order-filters.ts
+++ b/apps/web-client/src/lib/stores/supplier-order-filters.ts
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
 
-export type SupplierOrderFilterStatus = "unordered" | "ordered";
+export type SupplierOrderFilterStatus = "unordered" | "ordered" | "reconciling";
 
 export const supplierOrderFilterStatus = writable<SupplierOrderFilterStatus>("unordered");

--- a/apps/web-client/src/routes/orders/suppliers/+layout.ts
+++ b/apps/web-client/src/routes/orders/suppliers/+layout.ts
@@ -1,6 +1,6 @@
 import { getInitializedDB } from "$lib/db/cr-sqlite";
 
-import { getUnreconciledSupplierOrders, getReconcilingOrders } from "$lib/db/cr-sqlite/order-reconciliation";
+import { getUnreconciledSupplierOrders, getAllReconciliationOrders } from "$lib/db/cr-sqlite/order-reconciliation";
 import { getPossibleSupplierOrders } from "$lib/db/cr-sqlite/suppliers";
 
 import type { LayoutLoad } from "./$types";
@@ -11,7 +11,7 @@ export const load: LayoutLoad = async ({ depends }) => {
 	const { db, rx } = await getInitializedDB("librocco-current-db");
 	const possibleOrdersInfo = await getPossibleSupplierOrders(db);
 	const placedOrders = await getUnreconciledSupplierOrders(db);
-	const reconcilingOrders = await getReconcilingOrders(db);
+	const reconcilingOrders = await getAllReconciliationOrders(db, false);
 
 	return { placedOrders, possibleOrders: possibleOrdersInfo, ordersDb: db, rx, reconcilingOrders };
 };

--- a/apps/web-client/src/routes/orders/suppliers/+layout.ts
+++ b/apps/web-client/src/routes/orders/suppliers/+layout.ts
@@ -1,7 +1,8 @@
 import { getInitializedDB } from "$lib/db/cr-sqlite";
-import { getUnreconciledSupplierOrders } from "$lib/db/cr-sqlite/order-reconciliation";
 
+import { getUnreconciledSupplierOrders, getReconcilingOrders } from "$lib/db/cr-sqlite/order-reconciliation";
 import { getPossibleSupplierOrders } from "$lib/db/cr-sqlite/suppliers";
+
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = async ({ depends }) => {
@@ -10,8 +11,9 @@ export const load: LayoutLoad = async ({ depends }) => {
 	const { db, rx } = await getInitializedDB("librocco-current-db");
 	const possibleOrdersInfo = await getPossibleSupplierOrders(db);
 	const placedOrders = await getUnreconciledSupplierOrders(db);
+	const reconcilingOrders = await getReconcilingOrders(db);
 
-	return { placedOrders, possibleOrders: possibleOrdersInfo, ordersDb: db, rx };
+	return { placedOrders, possibleOrders: possibleOrdersInfo, ordersDb: db, rx, reconcilingOrders };
 };
 
 export const ssr = false;

--- a/apps/web-client/src/routes/orders/suppliers/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/+page.svelte
@@ -126,7 +126,6 @@
 					>
 						Reconciling
 					</button>
-					<button class="btn-outline btn-sm btn" disabled> Received </button>
 					<button class="btn-outline btn-sm btn" disabled> Completed </button>
 				</div>
 				{#if $supplierOrderFilterStatus === "unordered"}

--- a/apps/web-client/src/routes/orders/suppliers/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/+page.svelte
@@ -11,6 +11,7 @@
 	import { base } from "$app/paths";
 	import { supplierOrderFilterStatus, type SupplierOrderFilterStatus } from "$lib/stores/supplier-order-filters";
 	import UnorderedTable from "$lib/components/supplier-orders/UnorderedTable.svelte";
+	import ReconcilingTable from "$lib/components/supplier-orders/ReconcilingTable.svelte";
 	import OrderedTable from "$lib/components/supplier-orders/OrderedTable.svelte";
 	import type { LayoutData } from "./$types";
 	import { createReconciliationOrder } from "$lib/db/cr-sqlite/order-reconciliation";
@@ -34,6 +35,7 @@
 	} = newOrderDialog;
 
 	$: hasOrderedOrders = data.placedOrders.length;
+	$: hasReconcilingOrders = data.reconcilingOrders.length;
 
 	function setFilter(status: SupplierOrderFilterStatus) {
 		supplierOrderFilterStatus.set(status);
@@ -115,13 +117,24 @@
 					>
 						Ordered
 					</button>
+					<button
+						class="btn-sm btn {$supplierOrderFilterStatus === 'reconciling' ? 'btn-primary' : 'btn-outline'}"
+						on:click={() => setFilter("reconciling")}
+						aria-pressed={$supplierOrderFilterStatus === "reconciling"}
+						disabled={!hasReconcilingOrders}
+						data-testid="reconciling-list"
+					>
+						Reconciling
+					</button>
 					<button class="btn-outline btn-sm btn" disabled> Received </button>
 					<button class="btn-outline btn-sm btn" disabled> Completed </button>
 				</div>
 				{#if $supplierOrderFilterStatus === "unordered"}
 					<UnorderedTable orders={data.possibleOrders} />
-				{:else}
+				{:else if $supplierOrderFilterStatus === "ordered"}
 					<OrderedTable orders={data.placedOrders} on:reconcile={handleReconcile} />
+				{:else}
+					<ReconcilingTable orders={data.reconcilingOrders} />
 				{/if}
 			{/if}
 		</div>


### PR DESCRIPTION
Fixes #694 
- A new table component for displaying reconciliation orders
- Introduced a new function getReconcilingOrders which queries the database for orders that are not finalized (finalized = 0)
- Added test for retrieving reconciling orders (getReconcilingOrders).
- Added a new SupplierOrderFilterStatus value: "reconciling"
- Added getReconcilingOrders to the load function
