### PR TITLE
fix null values in customer order list (in '/customers' page):

### DIFF
--- a/apps/web-client/src/routes/debug/+page.svelte
+++ b/apps/web-client/src/routes/debug/+page.svelte
@@ -9,7 +9,7 @@
 	import { getInitializedDB } from "$lib/db/cr-sqlite";
 	import { dbNamePersisted } from "$lib/db";
 
-	import exampleData from "./example_data";
+	import exampleData from "./example_data.sql?raw";
 
 	$: ({ nav: tNav } = $LL);
 

--- a/apps/web-client/src/routes/debug/example_data.sql
+++ b/apps/web-client/src/routes/debug/example_data.sql
@@ -1,4 +1,3 @@
-const exampleData = `
 -- Books
 INSERT INTO book (isbn, title, authors, publisher, price) VALUES
 ('9781234567897', 'The Art of Learning', 'Josh Waitzkin', 'Scholastic', 15.99),
@@ -19,9 +18,9 @@ INSERT INTO supplier_publisher (supplier_id, publisher) VALUES
 (2, 'Ace');
 
 -- Customers
-INSERT INTO customer (id, fullname, email, deposit) VALUES
-(1, 'Alice Smith', 'alice.smith@example.com', 50.00),
-(2, 'Bob Johnson', 'bob.johnson@example.com', 30.00);
+INSERT INTO customer (id, display_id, fullname, email, deposit) VALUES
+(1, '1', 'Alice Smith', 'alice.smith@example.com', 50.00),
+(2, '2', 'Bob Johnson', 'bob.johnson@example.com', 30.00);
 
 -- Customer Order Lines
 INSERT INTO customer_order_lines (id, customer_id, isbn, placed, received, collected) VALUES
@@ -51,4 +50,3 @@ INSERT INTO reconciliation_order_lines (reconciliation_order_id, isbn) VALUES
  	(2, '9788804797142');
 `;
 
-export default exampleData;

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -132,13 +132,13 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each filteredOrders as { id, fullname, email = "", displayId }}
+						{#each filteredOrders as { id, fullname, email, displayId }}
 							<tr class="hover focus-within:bg-base-200">
 								<td>
 									<dl class="flex flex-col gap-y-1">
 										<dt class="sr-only">Customer details</dt>
 										<dd>{fullname}</dd>
-										<dd class="text-sm">{email}</dd>
+										<dd class="text-sm">{email ?? ""}</dd>
 									</dl>
 								</td>
 								<td>


### PR DESCRIPTION
* update 'getAllCustomerOrderLines' query to return customer 'display_id'
* update data generation in '/debug' page to also generate customer 'display_id' values
* provide a fallback for missing 'email' values