### PR TITLE
supplier order creation touchups:

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/reconciliation-order.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/reconciliation-order.test.ts
@@ -33,7 +33,7 @@ describe("Reconciliation order creation", () => {
 		expect(res).toEqual([]);
 
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		// TODO: might be useful to have a way to filter for a few particular ids?
 		// It's only going to be one here...
@@ -52,12 +52,13 @@ describe("Reconciliation order creation", () => {
 			}
 		]);
 	});
+
 	it("can get all finalized reconciliation orders", async () => {
 		const res = await getAllReconciliationOrders(db);
 		expect(res).toEqual([]);
 
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		const supplierOrders = await getPlacedSupplierOrders(db);
 
@@ -77,9 +78,10 @@ describe("Reconciliation order creation", () => {
 			}
 		]);
 	});
+
 	it("can get all currently reconciliating orders", async () => {
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		// TODO: might be useful to have a way to filter for a few particular ids?
 		// It's only going to be one here...
@@ -106,9 +108,10 @@ describe("Reconciliation order creation", () => {
 
 		expect(res2).toMatchObject([]);
 	});
+
 	it("can create a reconciliation order", async () => {
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		// TODO: might be useful to have a way to filter for a few particular ids?
 		// It's only going to be one here...
@@ -129,7 +132,7 @@ describe("Reconciliation order creation", () => {
 
 	it("can update a currently reconciliating order", async () => {
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		// TODO: might be useful to have a way to filter for a few particular ids?
 		// It's only going to be one here...
@@ -189,7 +192,7 @@ describe("Reconciliation order creation", () => {
 
 	it("can finalize a currently reconciliating order", async () => {
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		// TODO: might be useful to have a way to filter for a few particular ids?
 		// It's only going to be one here...
@@ -215,7 +218,7 @@ describe("Reconciliation order creation", () => {
 
 	it("updates existing order line quantity when adding duplicate ISBN", async () => {
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 		const supplierOrders = await getPlacedSupplierOrders(db);
 		const ids = supplierOrders.map((supplierOrder) => supplierOrder.id);
@@ -294,7 +297,7 @@ describe("Reconciliation order creation", () => {
 
 		it("throws error when trying to finalize an already finalized order", async () => {
 			const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-			await createSupplierOrder(db, newSupplierOrderLines);
+			await createSupplierOrder(db, 1, newSupplierOrderLines);
 
 			// TODO: might be useful to have a way to filter for a few particular ids?
 			// It's only going to be one here...
@@ -320,7 +323,7 @@ describe("getUnreconciledSupplierOrders", () => {
 		db = await getRandomDb();
 		await createCustomerOrders(db);
 		const newSupplierOrderLines = await getPossibleSupplierOrderLines(db, 1);
-		await createSupplierOrder(db, newSupplierOrderLines);
+		await createSupplierOrder(db, 1, newSupplierOrderLines);
 	});
 
 	it("should return only unreconciled supplier orders with correct totals", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
@@ -628,14 +628,28 @@ describe("Placing supplier orders", () => {
 		});
 
 		it("retrieve a list of placed supplier orders, filtered by supplier id", async () => {
-			await createSupplierOrder(db, [
+			// Setup: add enough books to customer orders to avoid createSupplierOrder truncating
+			// the quantity ordered, TODO: check for truncating functionality (might not be what we want)
+			await upsertCustomer(db, { id: 3, displayId: "3" });
+			await upsertCustomer(db, { id: 4, displayId: "4" });
+			await upsertCustomer(db, { id: 5, displayId: "5" });
+			await upsertCustomer(db, { id: 6, displayId: "6" });
+
+			await addBooksToCustomer(db, 1, ["1", "2", "3"]);
+			await addBooksToCustomer(db, 2, ["1", "2", "3"]);
+			await addBooksToCustomer(db, 3, ["1", "2", "3"]);
+			await addBooksToCustomer(db, 4, ["1", "2", "3"]);
+			await addBooksToCustomer(db, 4, ["1", "2", "3"]);
+			await addBooksToCustomer(db, 4, ["1", "2", "3"]);
+
+			await createSupplierOrder(db, 1, [
 				{ supplier_id: 1, isbn: "1", quantity: 2 },
 				{ supplier_id: 1, isbn: "2", quantity: 1 }
 			]);
 
-			await createSupplierOrder(db, [{ supplier_id: 2, isbn: "3", quantity: 3 }]);
+			await createSupplierOrder(db, 2, [{ supplier_id: 2, isbn: "3", quantity: 3 }]);
 
-			await createSupplierOrder(db, [
+			await createSupplierOrder(db, 1, [
 				{ supplier_id: 1, isbn: "2", quantity: 3 },
 				{ supplier_id: 1, isbn: "3", quantity: 3 }
 			]);

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
@@ -41,7 +41,7 @@
 
 		const selection = orderLines.filter(({ isbn }) => selectedIsbns.includes(isbn));
 
-		await createSupplierOrder(db, selection);
+		await createSupplierOrder(db, supplier_id, selection);
 		await invalidate("suppliers:data");
 		// TODO: We could either go to the new supplier order "placed" view when it's created
 		// or we could make sure we go to the "placed" list on the suppliers view "/suppliers?s=placed"

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -84,7 +84,7 @@
 
 			const possibleLines = await getPossibleSupplierOrderLines(db, 123);
 
-			await createSupplierOrder(db, possibleLines);
+			await createSupplierOrder(db, 123, possibleLines);
 
 			publisherSupplierCreated = true;
 		}}>Create publisher/supplier</button


### PR DESCRIPTION
* throw an error if trying to create an empty supplier order
* restrict supplier order creation to single supplier order at a time
* edge case: throw an error if trying to create a supplier order with lines belonging to a different supplier
* edge case: check for requested quantity (as specified by params) and required quantity (found in customer order lines) - always take a min of the two
* extend tests to test for aforementioned updates

Fixes #715 