### PR TITLE
Reconciliation order e2e tests

### DIFF
--- a/apps/e2e/helpers/cr-sqlite.ts
+++ b/apps/e2e/helpers/cr-sqlite.ts
@@ -1,5 +1,6 @@
 import type { DB } from "@vlcn.io/crsqlite-wasm";
-import { Customer, PlacedSupplierOrder, PlacedSupplierOrderLine, Supplier, PossibleSupplierOrderLine, BookData } from "./types";
+import { Customer, PlacedSupplierOrder, PlacedSupplierOrderLine, Supplier, PossibleSupplierOrderLine } from "./types";
+import { BookData } from "@librocco/shared";
 
 // #region books
 

--- a/apps/e2e/helpers/cr-sqlite.ts
+++ b/apps/e2e/helpers/cr-sqlite.ts
@@ -1,5 +1,5 @@
 import type { DB } from "@vlcn.io/crsqlite-wasm";
-import { Customer, Supplier, SupplierOrderLine } from "./types";
+import { Customer, PlacedSupplierOrder, PlacedSupplierOrderLine, Supplier, SupplierOrderLine } from "./types";
 
 // #region books
 
@@ -337,4 +337,53 @@ export async function createReconciliationOrder(db: DB, supplierOrderIds: number
 		supplierOrderIds
 	);
 	return recondOrder[0].id;
+}
+export async function getPlacedSupplierOrders(db: DB): Promise<PlacedSupplierOrder[]> {
+	const result = await db.execO<PlacedSupplierOrder>(
+		`SELECT
+            so.id,
+            so.supplier_id,
+            s.name as supplier_name,
+            so.created,
+            COALESCE(SUM(sol.quantity), 0) as total_book_number,
+			SUM(COALESCE(book.price, 0) * sol.quantity) as total_book_price
+        FROM supplier_order so
+        JOIN supplier s ON s.id = so.supplier_id
+		LEFT JOIN supplier_order_line sol ON sol.supplier_order_id = so.id
+		LEFT JOIN book ON sol.isbn = book.isbn
+        WHERE so.created IS NOT NULL
+        GROUP BY so.id, so.supplier_id, s.name, so.created
+        ORDER BY so.created DESC;`
+	);
+	return result;
+}
+export async function getPlacedSupplierOrderLines(db: DB, supplier_order_ids: number[]): Promise<PlacedSupplierOrderLine[]> {
+	if (!supplier_order_ids.length) {
+		return [];
+	}
+	const multiplyString = (str: string, n: number) => Array(n).fill(str).join(", ");
+
+	const query = `
+        SELECT
+            sol.supplier_order_id,
+            sol.isbn,
+            sol.quantity,
+			COALESCE(book.price, 0) * sol.quantity as line_price,
+			COALESCE(book.title, 'N/A') AS title,
+			COALESCE(book.authors, 'N/A') AS authors,
+            so.supplier_id,
+            so.created,
+            s.name AS supplier_name,
+            SUM(sol.quantity) OVER (PARTITION BY sol.supplier_order_id) AS total_book_number,
+            SUM(COALESCE(book.price, 0) * sol.quantity) OVER (PARTITION BY sol.supplier_order_id) AS total_book_price
+		FROM supplier_order_line AS sol
+		LEFT JOIN book ON sol.isbn = book.isbn
+        JOIN supplier_order so ON so.id = sol.supplier_order_id
+        JOIN supplier s ON s.id = so.supplier_id
+        WHERE sol.supplier_order_id IN (${multiplyString("?", supplier_order_ids.length)})
+		GROUP BY sol.supplier_order_id, sol.isbn
+        ORDER BY sol.supplier_order_id, sol.isbn ASC;
+    `;
+
+	return db.execO<PlacedSupplierOrderLine>(query, supplier_order_ids);
 }

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -20,7 +20,8 @@ type OrderTestFixture = {
 };
 const books = [
 	{ isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10 },
-	{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 }
+	{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 },
+	{ isbn: "5678", authors: "author3", title: "title3", publisher: "pub1", price: 30 }
 ];
 const customer = { id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" };
 export const testOrders = test.extend<OrderTestFixture>({
@@ -42,6 +43,7 @@ export const testOrders = test.extend<OrderTestFixture>({
 		// dbHandler
 		await dbHandle.evaluate(upsertBook, books[0]);
 		await dbHandle.evaluate(upsertBook, books[1]);
+		await dbHandle.evaluate(upsertBook, books[2]);
 
 		await use(books);
 	},
@@ -55,6 +57,7 @@ export const testOrders = test.extend<OrderTestFixture>({
 		// await dbHandle.evaluate(upsertBook, books[1]);
 
 		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[2].isbn] });
 
 		await dbHandle.evaluate(upsertSupplier, { id: 1, name: "sup1" });
 		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
@@ -64,7 +67,6 @@ export const testOrders = test.extend<OrderTestFixture>({
 
 		const orderIds = placedOrders.map((order) => order.id);
 		const placedOrderLines = await dbHandle.evaluate(getPlacedSupplierOrderLines, orderIds);
-		console.log(placedOrderLines);
 		/** @TODO replace with supplier id when supplier_order spec is merged in */
 		await use(placedOrderLines);
 	}

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -1,18 +1,31 @@
 import { baseURL } from "@/integration/constants";
 import test from "@playwright/test";
-import { upsertBook, upsertCustomer } from "./cr-sqlite";
+import {
+	associatePublisher,
+	upsertBook,
+	upsertCustomer,
+	addBooksToCustomer,
+	upsertSupplier,
+	createSupplierOrder,
+	getPlacedSupplierOrderLines,
+	getPlacedSupplierOrders
+} from "./cr-sqlite";
 import { getDbHandle } from "./db";
+import { PlacedSupplierOrderLine } from "./types";
 
 type OrderTestFixture = {
 	customer: { id: number; fullname: string; email: string; displayId: string };
 	books: { isbn: string; authors: string; title: string; publisher: string; price: number }[];
+	placedOrderLines: PlacedSupplierOrderLine[];
 };
-
+const books = [
+	{ isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10 },
+	{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 }
+];
+const customer = { id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" };
 export const testOrders = test.extend<OrderTestFixture>({
 	customer: async ({ page }, use) => {
 		await page.goto(baseURL);
-
-		const customer = { id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" };
 
 		const dbHandle = await getDbHandle(page);
 
@@ -24,10 +37,6 @@ export const testOrders = test.extend<OrderTestFixture>({
 	books: async ({ page }, use) => {
 		await page.goto(baseURL);
 
-		const books = [
-			{ isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10 },
-			{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 }
-		];
 		const dbHandle = await getDbHandle(page);
 
 		// dbHandler
@@ -35,5 +44,28 @@ export const testOrders = test.extend<OrderTestFixture>({
 		await dbHandle.evaluate(upsertBook, books[1]);
 
 		await use(books);
+	},
+	placedOrderLines: async ({ page }, use) => {
+		await page.goto(baseURL);
+		const dbHandle = await getDbHandle(page);
+
+		// await dbHandle.evaluate(upsertCustomer, customer);
+
+		// await dbHandle.evaluate(upsertBook, books[0]);
+		// await dbHandle.evaluate(upsertBook, books[1]);
+
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn] });
+
+		await dbHandle.evaluate(upsertSupplier, { id: 1, name: "sup1" });
+		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
+
+		await dbHandle.evaluate(createSupplierOrder, [{ ...books[0], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 10 }]);
+		const placedOrders = await dbHandle.evaluate(getPlacedSupplierOrders);
+
+		const orderIds = placedOrders.map((order) => order.id);
+		const placedOrderLines = await dbHandle.evaluate(getPlacedSupplierOrderLines, orderIds);
+		console.log(placedOrderLines);
+		/** @TODO replace with supplier id when supplier_order spec is merged in */
+		await use(placedOrderLines);
 	}
 });

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -11,29 +11,43 @@ import {
 	getPlacedSupplierOrders
 } from "./cr-sqlite";
 import { getDbHandle } from "./db";
-import { PlacedSupplierOrderLine } from "./types";
+import { PlacedSupplierOrder, PlacedSupplierOrderLine } from "./types";
 
 type OrderTestFixture = {
-	customer: { id: number; fullname: string; email: string; displayId: string };
+	customers: { id: number; fullname: string; email: string; displayId: string }[];
 	books: { isbn: string; authors: string; title: string; publisher: string; price: number }[];
-	placedOrderLines: PlacedSupplierOrderLine[];
+	placedOrders: {
+		order: PlacedSupplierOrder;
+		lines: PlacedSupplierOrderLine[];
+	}[];
 };
 const books = [
 	{ isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10 },
 	{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 },
-	{ isbn: "5678", authors: "author3", title: "title3", publisher: "pub1", price: 30 }
+	{ isbn: "5678", authors: "author3", title: "title3", publisher: "pub1", price: 30 },
+	{ isbn: "8765", authors: "author4", title: "title4", publisher: "pub2", price: 40 },
+	{ isbn: "9999", authors: "author5", title: "title5", publisher: "pub1", price: 50 },
+	{ isbn: "8888", authors: "author6", title: "title6", publisher: "pub2", price: 60 },
+	{ isbn: "7777", authors: "author7", title: "title7", publisher: "pub1", price: 70 }
 ];
-const customer = { id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" };
+const customers = [
+	{ id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" },
+	{ id: 2, fullname: "Jane Doe", email: "jane@gmail.com", displayId: "2" },
+	{ id: 3, fullname: "Don Joe", email: "don@gmail.com", displayId: "3" }
+];
+
 export const testOrders = test.extend<OrderTestFixture>({
-	customer: async ({ page }, use) => {
+	customers: async ({ page }, use) => {
 		await page.goto(baseURL);
 
 		const dbHandle = await getDbHandle(page);
 
 		// dbHandler
-		await dbHandle.evaluate(upsertCustomer, customer);
+		await dbHandle.evaluate(upsertCustomer, customers[0]);
+		await dbHandle.evaluate(upsertCustomer, customers[1]);
+		await dbHandle.evaluate(upsertCustomer, customers[2]);
 
-		await use(customer);
+		await use(customers);
 	},
 	books: async ({ page }, use) => {
 		await page.goto(baseURL);
@@ -44,10 +58,14 @@ export const testOrders = test.extend<OrderTestFixture>({
 		await dbHandle.evaluate(upsertBook, books[0]);
 		await dbHandle.evaluate(upsertBook, books[1]);
 		await dbHandle.evaluate(upsertBook, books[2]);
+		await dbHandle.evaluate(upsertBook, books[3]);
+		await dbHandle.evaluate(upsertBook, books[4]);
+		await dbHandle.evaluate(upsertBook, books[5]);
+		await dbHandle.evaluate(upsertBook, books[6]);
 
 		await use(books);
 	},
-	placedOrderLines: async ({ page }, use) => {
+	placedOrders: async ({ page }, use) => {
 		await page.goto(baseURL);
 		const dbHandle = await getDbHandle(page);
 
@@ -56,18 +74,50 @@ export const testOrders = test.extend<OrderTestFixture>({
 		// await dbHandle.evaluate(upsertBook, books[0]);
 		// await dbHandle.evaluate(upsertBook, books[1]);
 
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[2].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[0].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[2].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[5].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[2].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[3].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[1].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[6].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[2].id, bookIsbns: [books[0].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[2].id, bookIsbns: [books[4].isbn] });
 
 		await dbHandle.evaluate(upsertSupplier, { id: 1, name: "sup1" });
-		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
+		await dbHandle.evaluate(upsertSupplier, { id: 2, name: "sup2" });
 
-		await dbHandle.evaluate(createSupplierOrder, [{ ...books[0], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 10 }]);
+		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
+		await dbHandle.evaluate(associatePublisher, { supplierId: 2, publisherId: "pub2" });
+
+		await dbHandle.evaluate(createSupplierOrder, [
+			{ ...books[0], supplier_id: 1, supplier_name: "sup1", quantity: 2, line_price: 20 },
+			{ ...books[2], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 30 }
+		]);
+		await dbHandle.evaluate(createSupplierOrder, [
+			{ ...books[2], supplier_id: 1, supplier_name: "sup1", quantity: 3, line_price: 90 },
+			{ ...books[4], supplier_id: 1, supplier_name: "sup1", quantity: 2, line_price: 100 },
+			{ ...books[6], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 70 }
+		]);
+
+		await dbHandle.evaluate(createSupplierOrder, [
+			{ ...books[1], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 20 },
+			{ ...books[3], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 40 },
+			{ ...books[5], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 60 }
+		]);
+
 		const placedOrders = await dbHandle.evaluate(getPlacedSupplierOrders);
 
 		const orderIds = placedOrders.map((order) => order.id);
 		const placedOrderLines = await dbHandle.evaluate(getPlacedSupplierOrderLines, orderIds);
+
+		// : {order: PlacedSupplierOrder, lines: PlacedSupplierOrderLines}[]
+		const orderAndLines = placedOrders.map((order) => ({
+			order,
+			lines: placedOrderLines.filter((line) => line.supplier_order_id === order.id)
+		}));
+
 		/** @TODO replace with supplier id when supplier_order spec is merged in */
-		await use(placedOrderLines);
+		await use(orderAndLines);
 	}
 });

--- a/apps/e2e/helpers/types.ts
+++ b/apps/e2e/helpers/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Locator, Page } from "@playwright/test";
 
-import type { NoteState, NoteTempState, EntityListView, WebClientView, TestId } from "@librocco/shared";
+import type { NoteState, NoteTempState, EntityListView, WebClientView, TestId, BookData } from "@librocco/shared";
 import { SearchFieldInterface } from "./searchField";
 
 /** A util type used to "pick" a subset of the given (union type) */
@@ -338,3 +338,28 @@ export type SupplierOrderLine = {
 	quantity: number;
 	line_price: number;
 };
+export type PossibleSupplierOrderLine = {
+	quantity: number;
+	line_price: number;
+} & SupplierJoinData &
+	Pick<BookData, "isbn" | "title" | "authors">;
+
+export type SupplierJoinData = {
+	supplier_id: number;
+	supplier_name: string;
+};
+export type PlacedSupplierOrderLine = {
+	supplier_order_id: number;
+	created: number;
+	total_book_number: number;
+	total_book_price: number;
+} & PossibleSupplierOrderLine;
+export type PossibleSupplierOrder = {
+	total_book_number: number;
+	total_book_price: number;
+} & SupplierJoinData;
+
+export type PlacedSupplierOrder = {
+	id: number;
+	created: number;
+} & PossibleSupplierOrder;

--- a/apps/e2e/helpers/types.ts
+++ b/apps/e2e/helpers/types.ts
@@ -327,29 +327,6 @@ export type Supplier = {
 	address?: string;
 };
 
-export type PossibleSupplierOrderLine = {
-	quantity: number;
-	line_price: number;
-} & SupplierJoinData &
-	Pick<BookData, "isbn" | "title" | "authors">;
-
-export type SupplierJoinData = {
-	supplier_id: number;
-	supplier_name: string;
-};
-
-export type BookData = {
-	isbn: string;
-	title?: string;
-	price?: number;
-	year?: string;
-	authors?: string;
-	publisher?: string;
-	editedBy?: string;
-	outOfPrint?: boolean;
-	category?: string;
-};
-
 export type SupplierOrder = {
 	supplier_id: number;
 	created: Date;

--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -6,7 +6,7 @@ import { testOrders } from "@/helpers/fixtures";
 import { getDbHandle } from "@/helpers";
 import { addBooksToCustomer } from "@/helpers/cr-sqlite";
 
-test.skip("should create a new customer order", async ({ page }) => {
+test("should create a new customer order", async ({ page }) => {
 	await page.goto(`${baseURL}orders/customers/`);
 	await page.getByRole("button", { name: "New Order" }).first().click();
 

--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -24,15 +24,15 @@ test("should create a new customer order", async ({ page }) => {
 	await expect(page.getByText("new@example.com")).toBeVisible();
 });
 
-testOrders("should show list of In Progress orders", async ({ page, customer }) => {
+testOrders("should show list of In Progress orders", async ({ page, customers }) => {
 	await page.goto(`${baseURL}orders/customers/`);
 	page.getByRole("button", { name: "In Progress" });
 
-	await expect(page.getByText(customer.fullname)).toBeVisible();
-	await expect(page.getByText(customer.email)).toBeVisible();
+	await expect(page.getByText(customers[0].fullname)).toBeVisible();
+	await expect(page.getByText(customers[0].email)).toBeVisible();
 });
 
-testOrders("should allow navigation to a specific order", async ({ page, customer, books }) => {
+testOrders("should allow navigation to a specific order", async ({ page, customers, books }) => {
 	const dbHandle = await getDbHandle(page);
 
 	await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn] });
@@ -42,8 +42,8 @@ testOrders("should allow navigation to a specific order", async ({ page, custome
 	await updateButton.click();
 	await page.waitForURL(`${baseURL}orders/customers/1/`);
 
-	await expect(page.getByText(customer.fullname)).toBeVisible();
-	await expect(page.getByText(customer.email)).toBeVisible();
+	await expect(page.getByText(customers[0].fullname)).toBeVisible();
+	await expect(page.getByText(customers[0].email)).toBeVisible();
 
 	await expect(page.getByText(books[0].isbn).first()).toBeVisible();
 	await expect(page.getByText(books[0].title).first()).toBeVisible();
@@ -58,12 +58,12 @@ testOrders("should allow navigation to a specific order", async ({ page, custome
 	await expect(page.getByText(books[1].isbn)).toBeVisible();
 });
 
-testOrders("should update a customer details", async ({ page, customer }) => {
+testOrders("should update a customer details", async ({ page, customers }) => {
 	await page.goto(`${baseURL}orders/customers/1/`);
 
 	const newCustomer = { fullname: "New Customer", email: "new@gmail.com", deposit: "10" };
-	await expect(page.getByText(customer.fullname)).toBeVisible();
-	await expect(page.getByText(customer.email)).toBeVisible();
+	await expect(page.getByText(customers[0].fullname)).toBeVisible();
+	await expect(page.getByText(customers[0].email)).toBeVisible();
 
 	await page.getByLabel("Edit customer order name, email or deposit").click();
 	const dialog = page.getByRole("dialog");
@@ -82,28 +82,32 @@ testOrders("should update a customer details", async ({ page, customer }) => {
 	await expect(page.getByText(`€${newCustomer.deposit}`)).toBeVisible();
 });
 
-testOrders("should add books to a customer order", async ({ page, customer, books }) => {
+testOrders("should add books to a customer order", async ({ page, customers, books }) => {
 	await page.goto(`${baseURL}orders/customers/1/`);
 
-	await expect(page.getByText(customer.fullname)).toBeVisible();
-	await expect(page.getByText(customer.email)).toBeVisible();
+	await expect(page.getByText(customers[0].fullname)).toBeVisible();
+	await expect(page.getByText(customers[0].email)).toBeVisible();
+
+	const table = page.getByRole("table");
+	const firstRow = table.getByRole("row").nth(1);
+	const secondRow = table.getByRole("row").nth(2);
 
 	const isbnField = page.getByRole("textbox");
 	isbnField.fill(books[0].isbn);
 	isbnField.press("Enter");
 
-	await expect(page.getByText(books[0].isbn)).toBeVisible();
-	await expect(page.getByText(books[0].title)).toBeVisible();
-	await expect(page.getByText(books[0].authors)).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: books[0].isbn })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: books[0].title })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: books[0].authors })).toBeVisible();
 	await expect(page.getByText("Draft")).toBeVisible();
 
-	isbnField.fill("5678");
+	isbnField.fill(books[2].isbn);
 	isbnField.press("Enter");
 
-	await expect(page.getByText("5678")).toBeVisible();
-	await expect(page.getByText("N/A").first()).toBeVisible();
-	await expect(page.getByText("N/A").nth(1)).toBeVisible();
-	await expect(page.getByText("0", { exact: true })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: books[2].isbn })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: books[2].title })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: books[2].authors })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: `${books[2].price}` })).toBeVisible();
 	await expect(page.getByText("Draft").nth(1)).toBeVisible();
 });
 

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -1,36 +1,22 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "./constants";
-import { getDashboard } from "@/helpers";
-
-test.beforeEach(async ({ page }) => {
-	await page.goto(baseURL);
-	await getDashboard(page).waitFor();
-
-	page.getByLabel("Main navigation");
-	page.getByRole("listitem").last().click();
-	const nav = page.getByLabel("Main navigation");
-	await nav.waitFor();
-	await page.getByLabel("CreateReconciliationOrder").waitFor();
-	page.getByLabel("CreateReconciliationOrder").click();
-	await expect(page.getByLabel("CreateReconciliationOrder")).toBeDisabled();
-
-	await page.reload();
-	await page.getByText("Ordered").nth(1).click();
-
-	await page.getByRole("checkbox").nth(1).click();
-
-	await page.getByText("Reconcile").first().click();
-
-	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
-});
+import { testOrders } from "@/helpers/fixtures";
 
 // * Note: its helpful to make an assertion after each <enter> key
 // as it seems that Playwright may start running assertions before page data has fully caught up
 
-test("should show correct delivery stats in commit view", async ({ page }) => {
+testOrders("should show correct delivery stats in commit view", async ({ page, books, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
+	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
+
 	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
 	const table = page.getByRole("table");
+	const firstRow = table.getByRole("row").nth(1);
+	firstRow.getByRole("cell", { name: placedOrderLines[0].isbn });
 
 	await isbnInput.fill("1111111111");
 	await page.keyboard.press("Enter");
@@ -50,7 +36,8 @@ test("should show correct delivery stats in commit view", async ({ page }) => {
 
 	await expect(page.getByText("Total delivered:")).toBeVisible();
 
-	await expect(table.getByText("123456789")).toBeVisible();
+	await expect(table.getByText(books[0].isbn)).toBeVisible();
+
 	await expect(table.getByText("1111111111")).toBeVisible();
 
 	await page.waitForTimeout(1000);
@@ -58,9 +45,18 @@ test("should show correct delivery stats in commit view", async ({ page }) => {
 	await expect(page.getByText("2 / 1")).toBeVisible();
 });
 
-test("should correctly increment quantities when scanning same ISBN multiple times", async ({ page }) => {
-	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+testOrders("should correctly increment quantities when scanning same ISBN multiple times", async ({ page, books, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
+	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
+
 	const table = page.getByRole("table");
+	const firstRow = table.getByRole("row").nth(1);
+	firstRow.getByRole("cell", { name: placedOrderLines[0].isbn });
+
+	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
 
 	await isbnInput.fill("1111111111");
 	await page.keyboard.press("Enter");
@@ -71,20 +67,24 @@ test("should correctly increment quantities when scanning same ISBN multiple tim
 	await isbnInput.fill("1111111111");
 	await page.keyboard.press("Enter");
 
-	// Check the quantity is updated
-	// TODO: more specific selectors for table cells?
-	await expect(table.getByText("2")).toBeVisible();
+	const secondRow = table.getByRole("row").nth(2);
 
-	await isbnInput.fill("2222222222");
+	await expect(firstRow.getByRole("cell", { name: "2" })).toBeVisible();
+
+	console.log(books[0]);
+	await isbnInput.fill(books[0].isbn);
 	await page.keyboard.press("Enter");
 
 	// Check new isbn row is visible
-	await expect(table.getByText("2222222222")).toBeVisible();
+	await expect(table.getByText(books[0].isbn)).toBeVisible();
 
 	await isbnInput.fill("1111111111");
 	await page.keyboard.press("Enter");
 
 	// Check the 111111 row quantity is updated
-	await expect(table.getByText("3")).toBeVisible();
-	await expect(table.getByRole("cell", { name: "1", exact: true })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "1111111111" })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "3" })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: books[0].isbn })).toBeVisible();
+
+	await expect(secondRow.getByRole("cell", { name: "1", exact: true })).toBeVisible();
 });

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -2,8 +2,6 @@ import { expect } from "@playwright/test";
 
 import { baseURL } from "./constants";
 import { testOrders } from "@/helpers/fixtures";
-import { createSupplierOrder } from "@/helpers/cr-sqlite";
-import { getDbHandle } from "@/helpers";
 
 // * Note: its helpful to make an assertion after each <enter> key
 // as it seems that Playwright may start running assertions before page data has fully caught up
@@ -22,7 +20,7 @@ testOrders("should show correct initial state of reconciliation page", async ({ 
 	await expect(page.getByRole("button", { name: "Compare" })).toHaveCount(1);
 	await expect(page.getByRole("button", { name: "Compare" }).nth(1)).not.toBeVisible();
 });
-testOrders("should show correct comparison when quantities match ordered amounts", async ({ page, books, placedOrders }) => {
+testOrders("should show correct comparison when quantities match ordered amounts", async ({ page, placedOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
 	await page.getByRole("checkbox").nth(1).click();

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -2,10 +2,207 @@ import { expect } from "@playwright/test";
 
 import { baseURL } from "./constants";
 import { testOrders } from "@/helpers/fixtures";
+import { createSupplierOrder } from "@/helpers/cr-sqlite";
+import { getDbHandle } from "@/helpers";
 
 // * Note: its helpful to make an assertion after each <enter> key
 // as it seems that Playwright may start running assertions before page data has fully caught up
+testOrders("should show correct initial state of reconciliation page", async ({ page, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
 
+	// Verify initial UI elements
+	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
+	await expect(page.getByPlaceholder("Enter ISBN of delivered books")).toBeVisible();
+	await expect(page.getByText(placedOrderLines[0].isbn)).not.toBeVisible();
+});
+testOrders("should show correct comparison when quantities match ordered amounts", async ({ page, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
+
+	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+	await isbnInput.fill(placedOrderLines[0].isbn);
+	await page.keyboard.press("Enter");
+
+	await page.getByRole("button", { name: "Compare" }).click();
+
+	// Verify comparison view
+	const table = page.getByRole("table");
+	const supplierNameRow = table.getByRole("row").nth(1);
+	supplierNameRow.getByRole("cell", { name: placedOrderLines[0].supplier_name });
+
+	const firstRow = table.getByRole("row").nth(2);
+	firstRow.getByRole("cell", { name: placedOrderLines[0].isbn });
+	await expect(firstRow.getByRole("checkbox")).toBeChecked();
+
+	await expect(page.getByText("Total delivered:")).toBeVisible();
+	await expect(page.getByText("1 / 1")).toBeVisible(); // Assuming 1 was ordered
+});
+
+testOrders("should correctly increment quantities when scanning same ISBN multiple times", async ({ page, books, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
+	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
+
+	const table = page.getByRole("table");
+	const firstRow = table.getByRole("row").nth(1);
+	firstRow.getByRole("cell", { name: placedOrderLines[0].isbn });
+
+	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+
+	await isbnInput.fill("1111111111");
+	await page.keyboard.press("Enter");
+
+	// Wait for the first row to be added
+	await expect(table.getByText("1111111111")).toBeVisible();
+
+	await isbnInput.fill("1111111111");
+	await page.keyboard.press("Enter");
+
+	const secondRow = table.getByRole("row").nth(2);
+
+	await expect(firstRow.getByRole("cell", { name: "2" })).toBeVisible();
+
+	await isbnInput.fill(books[0].isbn);
+	await page.keyboard.press("Enter");
+
+	// Check new isbn row is visible
+	await expect(table.getByText(books[0].isbn)).toBeVisible();
+
+	await isbnInput.fill("1111111111");
+	await page.keyboard.press("Enter");
+
+	// Check the 111111 row quantity is updated
+	await expect(firstRow.getByRole("cell", { name: "1111111111" })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "3" })).toBeVisible();
+	await expect(secondRow.getByRole("cell", { name: books[0].isbn })).toBeVisible();
+
+	await expect(secondRow.getByRole("cell", { name: "1", exact: true })).toBeVisible();
+});
+testOrders("should show over-delivery when scanned quantities are more than ordered amounts", async ({ page, placedOrderLines }) => {
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+	await page.getByText("Reconcile").first().click();
+
+	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+
+	// Scan more than ordered
+	await isbnInput.fill(placedOrderLines[0].isbn);
+	await page.keyboard.press("Enter");
+
+	const table = page.getByRole("table");
+	const firstRow = table.getByRole("row").nth(1);
+	await expect(firstRow.getByRole("cell", { name: placedOrderLines[0].isbn }).first()).toBeVisible();
+
+	await isbnInput.fill(placedOrderLines[0].isbn);
+	await page.keyboard.press("Enter");
+
+	await expect(firstRow.getByRole("cell", { name: placedOrderLines[0].isbn }).first()).toBeVisible();
+
+	await page.getByRole("button", { name: "Compare" }).nth(1).click();
+
+	const supplierNameRow = table.getByRole("row").nth(1);
+	supplierNameRow.getByRole("cell", { name: placedOrderLines[0].supplier_name });
+
+	// Verify comparison shows over-delivery
+	await expect(page.getByText("2 / 1")).toBeVisible();
+});
+testOrders(
+	"should show under-delivery when ordered books are not scanned or the scanned quantities are less than ordered amounts",
+	async ({ page, placedOrderLines, books }) => {
+		// Navigate to reconciliation
+		const dbHandle = await getDbHandle(page);
+		await dbHandle.evaluate(createSupplierOrder, [{ ...books[2], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 10 }]);
+		await page.goto(`${baseURL}orders/suppliers/orders/`);
+
+		await page.getByText("Ordered").nth(1).click();
+		await page.getByRole("checkbox").nth(1).click();
+		await page.getByRole("checkbox").nth(2).click();
+
+		await page.getByText("Reconcile").first().click();
+
+		const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+
+		// Scan less quantity than ordered
+		// From fixtures we know placedOrderLines[0] has quantity: 1
+		await isbnInput.fill(placedOrderLines[0].isbn);
+		await page.keyboard.press("Enter");
+
+		// Move to comparison view
+		await page.getByRole("button", { name: "Compare" }).click();
+
+		// Verify comparison table structure
+		const table = page.getByRole("table");
+
+		// Check supplier name row
+		const supplierNameRow = table.getByRole("row").nth(1);
+		await expect(supplierNameRow.getByRole("cell", { name: placedOrderLines[0].supplier_name })).toBeVisible();
+
+		// Check book details row
+		const bookRow = table.getByRole("row").nth(2);
+		await expect(bookRow.getByRole("cell", { name: placedOrderLines[0].isbn })).toBeVisible();
+
+		// Verify delivery stats show under-delivery
+		await expect(page.getByText("Total delivered:")).toBeVisible();
+		await expect(page.getByText("1 / 2")).toBeVisible(); // Assuming 2 were ordered, 1 scanned
+
+		// Optional: Verify any visual indicators of under-delivery
+		// This depends on your UI implementation
+		// await expect(bookRow.getByRole("cell").nth(4)).toHaveClass("text-warning"); // Example
+	}
+);
+testOrders("should show unmatched deliveriesy when ordered books do not match scanned books", async ({ page, placedOrderLines, books }) => {
+	// Navigate to reconciliation
+	await page.goto(`${baseURL}orders/suppliers/orders/`);
+
+	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("checkbox").nth(1).click();
+
+	await page.getByText("Reconcile").first().click();
+
+	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
+
+	// Scan non ordered books
+	await isbnInput.fill(placedOrderLines[0].isbn);
+	await page.keyboard.press("Enter");
+
+	const table = page.getByRole("table");
+	await expect(table.getByText(placedOrderLines[0].isbn)).toBeVisible();
+
+	await isbnInput.fill(books[2].isbn);
+	await page.keyboard.press("Enter");
+
+	await expect(table.getByText(books[2].isbn)).toBeVisible();
+
+	// Move to comparison view
+	await page.getByRole("button", { name: "Compare" }).nth(1).click();
+
+	// Verify comparison table structure
+
+	// Check supplier name row
+	const unmatchedRow = table.getByRole("row").nth(1);
+	await expect(unmatchedRow.getByRole("cell", { name: "unmatched" })).toBeVisible();
+
+	// Check book details row
+	const unmatchedBookRow = table.getByRole("row").nth(2);
+	await expect(unmatchedBookRow.getByRole("cell", { name: books[2].isbn })).toBeVisible();
+
+	const supplierNameRow = table.getByRole("row").nth(3);
+	await expect(supplierNameRow.getByRole("cell", { name: placedOrderLines[0].supplier_name })).toBeVisible();
+
+	const matchedBookRow = table.getByRole("row").nth(4);
+	await expect(matchedBookRow.getByRole("cell", { name: placedOrderLines[0].isbn })).toBeVisible();
+
+	await expect(page.getByText("Total delivered:")).toBeVisible();
+	await expect(page.getByText("2 / 1")).toBeVisible();
+});
 testOrders("should show correct delivery stats in commit view", async ({ page, books, placedOrderLines }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
@@ -43,48 +240,4 @@ testOrders("should show correct delivery stats in commit view", async ({ page, b
 	await page.waitForTimeout(1000);
 
 	await expect(page.getByText("2 / 1")).toBeVisible();
-});
-
-testOrders("should correctly increment quantities when scanning same ISBN multiple times", async ({ page, books, placedOrderLines }) => {
-	await page.goto(`${baseURL}orders/suppliers/orders/`);
-	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
-	await page.getByText("Reconcile").first().click();
-	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
-
-	const table = page.getByRole("table");
-	const firstRow = table.getByRole("row").nth(1);
-	firstRow.getByRole("cell", { name: placedOrderLines[0].isbn });
-
-	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
-
-	await isbnInput.fill("1111111111");
-	await page.keyboard.press("Enter");
-
-	// Wait for the first row to be added
-	await expect(table.getByText("1111111111")).toBeVisible();
-
-	await isbnInput.fill("1111111111");
-	await page.keyboard.press("Enter");
-
-	const secondRow = table.getByRole("row").nth(2);
-
-	await expect(firstRow.getByRole("cell", { name: "2" })).toBeVisible();
-
-	console.log(books[0]);
-	await isbnInput.fill(books[0].isbn);
-	await page.keyboard.press("Enter");
-
-	// Check new isbn row is visible
-	await expect(table.getByText(books[0].isbn)).toBeVisible();
-
-	await isbnInput.fill("1111111111");
-	await page.keyboard.press("Enter");
-
-	// Check the 111111 row quantity is updated
-	await expect(firstRow.getByRole("cell", { name: "1111111111" })).toBeVisible();
-	await expect(firstRow.getByRole("cell", { name: "3" })).toBeVisible();
-	await expect(secondRow.getByRole("cell", { name: books[0].isbn })).toBeVisible();
-
-	await expect(secondRow.getByRole("cell", { name: "1", exact: true })).toBeVisible();
 });

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -254,7 +254,7 @@
 										{#if getOrderLineStatus({ placed: placedTime, received: receivedTime, collected: collectedTime }) === "collected"}
 											<span class="badge-success badge">Collected</span>
 										{:else if getOrderLineStatus({ placed: placedTime, received: receivedTime, collected: collectedTime }) === "received"}
-											<span class="badge-info badge">Delievered</span>
+											<span class="badge-info badge">Delivered</span>
 										{:else if getOrderLineStatus({ placed: placedTime, received: receivedTime, collected: collectedTime }) === "placed"}
 											<span class="badge-warning badge">Placed</span>
 										{:else}

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -19,15 +19,12 @@
 	import OrderedTable from "$lib/components/supplier-orders/OrderedTable.svelte";
 
 	import { createReconciliationOrder } from "$lib/db/cr-sqlite/order-reconciliation";
-	import { associatePublisher, createSupplierOrder, getPossibleSupplierOrderLines, upsertSupplier } from "$lib/db/cr-sqlite/suppliers";
-	import { addBooksToCustomer, getCustomerDisplayIdSeq, upsertCustomer } from "$lib/db/cr-sqlite/customers";
+	import { getCustomerDisplayIdSeq, upsertCustomer } from "$lib/db/cr-sqlite/customers";
 	import { upsertBook } from "$lib/db/cr-sqlite/books";
 
 	export let data: PageData;
 
 	$: db = data?.dbCtx?.db;
-
-	let publisherSupplierCreated = false;
 
 	const newOrderDialog = createDialog(defaultDialogConfig);
 	const {
@@ -63,32 +60,6 @@
 
 <header class="navbar mb-4 bg-neutral">
 	<input type="checkbox" value="forest" class="theme-controller toggle" />
-
-	<button
-		class="bg-white"
-		disabled={publisherSupplierCreated}
-		aria-label="CreateReconciliationOrder"
-		on:click={async () => {
-			await upsertBook(db, {
-				isbn: "123456789",
-				title: "Book 1",
-				authors: "Author 1",
-				price: 10,
-				publisher: "abcPub"
-			});
-
-			await upsertCustomer(db, { id: 1, displayId: "1", email: "cus@tom.er", fullname: "cus tomer", deposit: 100 });
-			await addBooksToCustomer(db, 1, ["123456789"]);
-			await upsertSupplier(db, { id: 123, name: "abcSup" });
-			await associatePublisher(db, 123, "abcPub");
-
-			const possibleLines = await getPossibleSupplierOrderLines(db, 123);
-
-			await createSupplierOrder(db, possibleLines);
-
-			publisherSupplierCreated = true;
-		}}>Create publisher/supplier</button
-	>
 </header>
 
 <main class="h-screen">


### PR DESCRIPTION
Fixes #667 
reconciliation process e2e tests:
 - Use fixtures instead of button that creates state
 - Initial page state and UI element verification                                                                                 
 - ISBN scanning functionality and quantity tracking                                                                              
 - Delivery discrepancy scenarios:                                                                                                
   - Exact match quantities                                                                                                       
   - Over-delivery detection                                                                                                      
   - Under-delivery detection                                                                                                     
   - Unmatched deliveries handling   