### PR TITLE
Fixes and improvements to the debug page

### DIFF
--- a/apps/web-client/src/lib/__testData__/debugData.sql
+++ b/apps/web-client/src/lib/__testData__/debugData.sql
@@ -26,8 +26,10 @@ INSERT INTO customer (id, display_id, fullname, email, deposit) VALUES
 INSERT INTO customer_order_lines (id, customer_id, isbn, placed, received, collected) VALUES
 (1, 1, '9781234567897', 1, 0, 0),
 (2, 1, '9788804797142', 1, 1, 0),
-(3, 2, '9780385504201', 1, 1, 1),
-(4, 2, '9780553296983', 1, 0, 0);
+(3, 1, '9780385504201', 0, 0, 0),
+(4, 2, '9780385504201', 1, 1, 1),
+(5, 2, '9780553296983', 1, 0, 0),
+(6, 2, '9781234567897', 0, 0, 0);
 
 -- Supplier Orders
 INSERT INTO supplier_order (id, supplier_id, created) VALUES

--- a/apps/web-client/src/lib/__testData__/debugData.sql
+++ b/apps/web-client/src/lib/__testData__/debugData.sql
@@ -48,5 +48,3 @@ INSERT INTO reconciliation_order (supplier_order_ids, finalized) VALUES
 INSERT INTO reconciliation_order_lines (reconciliation_order_id, isbn) VALUES
  	(1, '9781234567897'),
  	(2, '9788804797142');
-`;
-

--- a/apps/web-client/src/routes/debug/+page.svelte
+++ b/apps/web-client/src/routes/debug/+page.svelte
@@ -31,10 +31,9 @@
 
 	let isLoading = true;
 
-	let query = "SELECT * FROM reconciliation_order_lines LIMIT 10;";
+	let query = "SELECT * FROM book LIMIT 10;";
 	let queryResult = null;
 	let errorMessage = null;
-	let loading = false;
 
 	const tableData = [
 		{ label: "Books", value: () => book },
@@ -235,9 +234,9 @@
 						<div class="mr-5 flex flex-col py-2">
 							<textarea bind:value={query} id="query"></textarea>
 
-							<button class="btn-sm btn" on:click={executeQuery} disabled={loading}>
+							<button class="btn-sm btn" on:click={executeQuery} disabled={isLoading}>
 								<Play size={20} />
-								{loading ? "Executing..." : "Run Query"}
+								{isLoading ? "Executing..." : "Run Query"}
 							</button>
 
 							{#if queryResult || errorMessage}

--- a/apps/web-client/src/routes/debug/+page.svelte
+++ b/apps/web-client/src/routes/debug/+page.svelte
@@ -152,7 +152,7 @@
 		const db = await getInitializedDB(dbName);
 
 		try {
-			queryResult = await db.db.exec(query);
+			queryResult = await db.db.execO(query);
 		} catch (error) {
 			errorMessage = error;
 		} finally {


### PR DESCRIPTION
Related to issue #722 .

This PR fixes a bug in the debug page which caused a console error when resetting the database. The issue was caused by the `reconciliation_order_lines` table not being properly resetted.

Additionally this implements a database query interface useful for debugging (thank you @silviot for suggesting this).

Example SQL data was moved out of the routes directory into the `lib/__testData__` directory which is probably the place where it belongs.
