### PR TITLE
reinstate customer order line - supplier order relation:

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/suppliers.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/suppliers.ts
@@ -399,6 +399,13 @@ export async function createSupplierOrder(
 			await db.exec(`UPDATE customer_order_lines SET placed = ? WHERE id IN ${idsPlaceholder}`, [timestamp, ...customerOrderLineIds]);
 
 			await db.exec("INSERT INTO supplier_order_line (supplier_order_id, isbn, quantity) VALUES (?, ?, ?)", [orderId, isbn, quantity]);
+
+			// Create customer order line - supplier order relations - keeping track of all times a customer order line was ordered from the supplier
+			const values = customerOrderLineIds.map((cLineId) => [cLineId, timestamp, orderId]);
+			await db.exec(
+				`INSERT INTO customer_order_line_supplier_order (customer_order_line_id, placed, supplier_order_id) VALUES ${multiplyString("(?, ?, ?)", values.length)}`,
+				values.flat()
+			);
 		}
 	});
 }

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -43,6 +43,16 @@ export type CustomerOrderLine = {
 	collected?: Date; // Date when the book order was collected by the customer
 } & BookDataCols;
 
+export type CustomerOrderLineHistoryDB = {
+	supplierOrderId: number;
+	placed: number;
+};
+
+export type CustomerOrderLineHistory = {
+	supplierOrderId: number;
+	placed: Date;
+};
+
 /* Suppliers */
 
 /**

--- a/pkg/shared/db-schemas/init.sql
+++ b/pkg/shared/db-schemas/init.sql
@@ -93,6 +93,14 @@ CREATE TABLE reconciliation_order_lines (
 );
 SELECT crsql_as_crr('reconciliation_order_lines');
 
+CREATE TABLE customer_order_line_supplier_order (
+	customer_order_line_id INTEGER NOT NULL,
+	supplier_order_id INTEGER NOT NULL,
+	placed INTEGER DEFAULT 0,
+	PRIMARY KEY (customer_order_line_id, supplier_order_id)
+);
+SELECT crsql_as_crr('customer_order_line_supplier_order');
+
 CREATE TABLE warehouse (
 	-- 0 id is reserved -- when warehouse id is unassigned (in a book txn for ex.) we're defaulting to 0
 	-- using 0 instead of NULL as 0 = 0 and NULL != NULL


### PR DESCRIPTION
* create customer_order_line_supplier_order table
* each time a customer order line is a part of a supplier order - add an entry (with timestamp) to the join table
* create and test 'getCustomerOrderLineHistory' - a function to retrieve all the times a customer order line had been placed with the supplier

Fixes #716 

Does so ☝️ without touching on #737 