### PR TITLE
refactor the collection tests to fit with the rest:

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -1,24 +1,22 @@
-import { beforeEach, describe, it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { type DB, type Customer, OrderLineStatus } from "../types";
 
-import { markCustomerOrderAsReceived, getRandomDb } from "./lib";
+import { getRandomDb } from "./lib";
 
 import {
 	upsertCustomer,
 	getCustomerOrderLines,
-	markCustomerOrderAsCollected,
+	markCustomerOrderLinesAsCollected,
 	addBooksToCustomer,
 	removeBooksFromCustomer,
 	getCustomerDisplayIdSeq,
 	isDisplayIdUnique,
-	markCustomerOrderLineAsCollected,
 	getCustomerDetails,
 	getCustomerOrderList
 } from "../customers";
-import { associatePublisher, createSupplierOrder, upsertSupplier } from "../suppliers";
+
 import { upsertBook } from "../books";
-import { addOrderLinesToReconciliationOrder, createReconciliationOrder, finalizeReconciliationOrder } from "../order-reconciliation";
 
 describe("Customer orders", () => {
 	describe("upsertCustomer should", () => {
@@ -430,21 +428,81 @@ describe("Customer order lines", () => {
 		});
 	});
 
-	describe("markCustomerOrderLineAsCollected should", () => {
+	describe("markCustomerOrderLinesAsCollected should", () => {
+		it("mark received order lines as collected", async () => {
+			const db = await getRandomDb();
+
+			await addBooksToCustomer(db, 1, ["1", "2"]);
+
+			const [{ id: l1 }, { id: l2 }] = await getCustomerOrderLines(db, 1);
+
+			await markCustomerOrderLinesAsCollected(db, [l1, l2]);
+
+			expect(await getCustomerOrderLines(db, 1)).toEqual([
+				expect.objectContaining({ collected: expect.any(Date) }),
+				expect.objectContaining({ collected: expect.any(Date) })
+			]);
+		});
+
+		it("mark only the required lines (not the whole order)", async () => {
+			const db = await getRandomDb();
+
+			await addBooksToCustomer(db, 1, ["1", "2", "3"]);
+
+			const [{ id: l1 }, { id: l2 }] = await getCustomerOrderLines(db, 1);
+
+			await markCustomerOrderLinesAsCollected(db, [l1, l2]);
+
+			expect(await getCustomerOrderLines(db, 1)).toEqual([
+				expect.objectContaining({ collected: expect.any(Date) }),
+				expect.objectContaining({ collected: expect.any(Date) }),
+				expect.objectContaining({ collected: undefined })
+			]);
+		});
+
+		it("not confuse the lines with the same ISBN", async () => {
+			const db = await getRandomDb();
+
+			await addBooksToCustomer(db, 1, ["1", "1", "1"]);
+
+			const [{ id: l1 }, { id: l2 }] = await getCustomerOrderLines(db, 1);
+
+			await markCustomerOrderLinesAsCollected(db, [l1, l2]);
+
+			expect(await getCustomerOrderLines(db, 1)).toEqual([
+				expect.objectContaining({ collected: expect.any(Date) }),
+				expect.objectContaining({ collected: expect.any(Date) }),
+				expect.objectContaining({ collected: undefined })
+			]);
+		});
+
+		it("not interfere with other customer orders", async () => {
+			const db = await getRandomDb();
+
+			await addBooksToCustomer(db, 1, ["1"]);
+			await addBooksToCustomer(db, 2, ["1"]);
+
+			const [{ id: l1 }] = await getCustomerOrderLines(db, 1);
+
+			await markCustomerOrderLinesAsCollected(db, [l1]);
+
+			expect(await getCustomerOrderLines(db, 1)).toEqual([expect.objectContaining({ collected: expect.any(Date) })]);
+			expect(await getCustomerOrderLines(db, 2)).toEqual([expect.objectContaining({ collected: undefined })]);
+		});
+
 		it("timestamp customer order lines' 'collected' with ms precision", async () => {
 			const db = await getRandomDb();
 
-			await upsertCustomer(db, { fullname: "John Doe", id: 1, displayId: "1" });
 			await addBooksToCustomer(db, 1, ["1", "2"]);
 
-			const [{ id: line1Id }] = await getCustomerOrderLines(db, 1);
-			await markCustomerOrderLineAsCollected(db, line1Id);
+			const [{ id: l1 }] = await getCustomerOrderLines(db, 1);
+			await markCustomerOrderLinesAsCollected(db, [l1]);
 
 			const [line1] = await getCustomerOrderLines(db, 1);
 			expect(Date.now() - line1.collected.getTime()).toBeLessThan(300);
 
-			const [{ id: line2Id }] = await getCustomerOrderLines(db, 1);
-			await markCustomerOrderLineAsCollected(db, line2Id);
+			const [{ id: l2 }] = await getCustomerOrderLines(db, 1);
+			await markCustomerOrderLinesAsCollected(db, [l2]);
 
 			const [line2] = await getCustomerOrderLines(db, 1);
 			expect(Date.now() - line2.collected.getTime()).toBeLessThan(300);
@@ -656,151 +714,5 @@ describe("Stress tests", () => {
 		const books = await getCustomerOrderLines(db, 1);
 		expect(books.length).toBe(10 * howMany);
 		expect(duration).toBeLessThanOrEqual(800);
-	});
-});
-
-describe("Customer order Collection", () => {
-	let db: DB;
-
-	beforeEach(async () => (db = await getRandomDb()));
-
-	it("should mark received order lines as collected", async () => {
-		await addBooksToCustomer(db, 1, ["9780000000001", "9780000000001"]);
-		await upsertBook(db, { isbn: "9780000000001", publisher: "pub1", title: "title1", authors: "author1", price: 10 });
-		await upsertSupplier(db, { id: 1 });
-		await associatePublisher(db, 1, "pub1");
-
-		await createSupplierOrder(db, 1, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
-
-		const customerOrderLines = await getCustomerOrderLines(db, 1);
-		const customerOrderLineIds = customerOrderLines.map((order) => order.id);
-
-		// Mark the books as received
-		// await markCustomerOrderAsReceived(db, orderLineIds);
-		await createReconciliationOrder(db, 1, [1]);
-		await addOrderLinesToReconciliationOrder(db, 1, [
-			{ isbn: "9780000000001", quantity: 1 },
-			{ isbn: "9780000000001", quantity: 1 }
-		]);
-		await finalizeReconciliationOrder(db, 1);
-
-		// Mark as collected
-		await markCustomerOrderAsCollected(db, customerOrderLineIds);
-
-		const updatedLines = await getCustomerOrderLines(db, 1);
-
-		expect(updatedLines[0].collected).toBeInstanceOf(Date);
-		expect(updatedLines[1].collected).toBeInstanceOf(Date);
-	});
-	it("should mark received order lines as collected", async () => {
-		await addBooksToCustomer(db, 1, ["9780000000001", "9780000000001"]);
-		await upsertBook(db, { isbn: "9780000000001", publisher: "pub1", title: "title1", authors: "author1", price: 10 });
-		await upsertSupplier(db, { id: 1 });
-		await associatePublisher(db, 1, "pub1");
-
-		await createSupplierOrder(db, 1, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
-
-		const customerOrderLines = await getCustomerOrderLines(db, 1);
-		const orderLineIds = customerOrderLines.map((order) => order.id);
-
-		// Mark the books as received
-		await markCustomerOrderAsReceived(db, orderLineIds);
-
-		// Mark as collected
-		await markCustomerOrderAsCollected(db, orderLineIds);
-
-		const updatedLines = await getCustomerOrderLines(db, 1);
-
-		expect(updatedLines[0].collected).toBeInstanceOf(Date);
-		expect(updatedLines[1].collected).toBeInstanceOf(Date);
-	});
-
-	it("should allow collecting specific customer orders when multiple customers order the same book", async () => {
-		// Create two customers
-		await upsertCustomer(db, { fullname: "Customer 1", id: 1, displayId: "1" });
-		await upsertCustomer(db, { fullname: "Customer 2", id: 2, displayId: "2" });
-
-		// Both customers order the same book
-		await addBooksToCustomer(db, 1, ["9780000000001"]);
-		await addBooksToCustomer(db, 2, ["9780000000001"]);
-
-		// Set up book and supplier
-		await upsertBook(db, {
-			isbn: "9780000000001",
-			publisher: "pub1",
-			title: "title1",
-			authors: "author1",
-			price: 10
-		});
-		await upsertSupplier(db, { id: 1 });
-		await associatePublisher(db, 1, "pub1");
-
-		// Order books from supplier
-		await createSupplierOrder(db, 1, 1, [
-			{
-				isbn: "9780000000001",
-				quantity: 2, // Order enough for both customers
-				supplier_id: 1
-			}
-		]);
-
-		// Get order lines for both customers
-		const customer1OrderLines = await getCustomerOrderLines(db, 1);
-		const customer2OrderLines = await getCustomerOrderLines(db, 2);
-
-		// Mark both orders as received
-		await markCustomerOrderAsReceived(db, [customer1OrderLines[0].id, customer2OrderLines[0].id]);
-
-		// Only mark customer 2's order as collected
-		await markCustomerOrderAsCollected(db, [customer2OrderLines[0].id]);
-
-		// Verify final state
-		const finalCustomer1Lines = await getCustomerOrderLines(db, 1);
-		const finalCustomer2Lines = await getCustomerOrderLines(db, 2);
-
-		// Customer 1's order should be received but not collected
-		expect(finalCustomer1Lines[0].received).toBeInstanceOf(Date);
-		expect(finalCustomer1Lines[0].collected).toBeUndefined();
-
-		// Customer 2's order should be both received and collected
-		expect(finalCustomer2Lines[0].received).toBeInstanceOf(Date);
-		expect(finalCustomer2Lines[0].collected).toBeInstanceOf(Date);
-	});
-
-	it("should only mark as collected if book is placed and received", async () => {
-		await addBooksToCustomer(db, 1, ["9780000000001"]);
-
-		const customerOrderLines = await getCustomerOrderLines(db, 1);
-		const orderLineIds = customerOrderLines.map((order) => order.id);
-		// Try to mark as collected without placing/receiving first
-		await markCustomerOrderAsCollected(db, orderLineIds);
-
-		const lines = await getCustomerOrderLines(db, 1);
-		// Should not be marked as collected
-		expect(lines[0].collected).toBeUndefined();
-	});
-
-	it("should not affect books that are already collected", async () => {
-		await addBooksToCustomer(db, 1, ["9780000000001"]);
-
-		const customerOrderLines = await getCustomerOrderLines(db, 1);
-		const orderLineIds = customerOrderLines.map((order) => order.id);
-		// Mark as received
-		await markCustomerOrderAsReceived(db, orderLineIds);
-
-		// Mark as collected first time
-		await markCustomerOrderAsCollected(db, orderLineIds);
-		const firstUpdate = await getCustomerOrderLines(db, 1);
-		const firstCollectedDate = firstUpdate[0].collected;
-
-		// Wait a moment to ensure timestamps would be different
-		await new Promise((resolve) => setTimeout(resolve, 100));
-
-		// Try to mark as collected again
-		await markCustomerOrderAsCollected(db, orderLineIds);
-		const secondUpdate = await getCustomerOrderLines(db, 1);
-
-		// Collection date should not have changed
-		expect(secondUpdate[0].collected).toEqual(firstCollectedDate);
 	});
 });

--- a/apps/web-client/src/lib/db/cr-sqlite/customers.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/customers.ts
@@ -333,21 +333,22 @@ export const markCustomerOrderAsCollected = async (db: DB, ids: number[]): Promi
 		 UPDATE customer_order_lines
             SET collected = ?
             WHERE id IN (${placeholders})
-            AND collected IS NULL AND received IS NOT NULL
             ;`,
 			[timestamp, ...ids]
 		);
 	});
 };
 
-export const markCustomerOrderLineAsCollected = async (db: DB, lineId: number): Promise<void> => {
+export const markCustomerOrderLinesAsCollected = async (db: DB, ids: number[]): Promise<void> => {
+	if (!ids.length) return;
+
 	const timestamp = Date.now();
 	await db.exec(
 		`
 			UPDATE customer_order_lines
 			SET collected = ?
-			WHERE id = ?
+			WHERE id IN (${multiplyString("?", ids.length)})
 		`,
-		[timestamp, lineId]
+		[timestamp, ...ids]
 	);
 };

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -24,7 +24,7 @@
 		removeBooksFromCustomer,
 		isDisplayIdUnique,
 		upsertCustomer,
-		markCustomerOrderLineAsCollected
+		markCustomerOrderLinesAsCollected
 	} from "$lib/db/cr-sqlite/customers";
 
 	import { scannerSchema } from "$lib/forms/schemas";
@@ -108,11 +108,11 @@
 
 	// #endregion dialog
 
-	const handleDeleteLine = async (lineId) => {
+	const handleDeleteLine = async (lineId: number) => {
 		await removeBooksFromCustomer(db, customerId, [lineId]);
 	};
 	const handleCollect = async (id: number) => {
-		await markCustomerOrderLineAsCollected(db, id);
+		await markCustomerOrderLinesAsCollected(db, [id]);
 	};
 
 	let scanInputRef: HTMLInputElement = null;


### PR DESCRIPTION
* refactor the tests
* remove unnecessary tests/functionality
* delete the duplicate functions -> replace with 'markCustomerOrderLinesAsCollected'

Fixes #766 
