### PR TITLE
refactor 'createSupplierOrder' to accept explicit id - significantly simplifying test code

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -16,7 +16,7 @@ import {
 	getCustomerDetails,
 	getCustomerOrderList
 } from "../customers";
-import { associatePublisher, createSupplierOrder, getPlacedSupplierOrders, upsertSupplier } from "../suppliers";
+import { associatePublisher, createSupplierOrder, upsertSupplier } from "../suppliers";
 import { upsertBook } from "../books";
 import { addOrderLinesToReconciliationOrder, createReconciliationOrder, finalizeReconciliationOrder } from "../order-reconciliation";
 
@@ -670,17 +670,14 @@ describe("Customer order Collection", () => {
 		await upsertSupplier(db, { id: 1 });
 		await associatePublisher(db, 1, "pub1");
 
-		await createSupplierOrder(db, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
-
-		const placedSupplierOrders = await getPlacedSupplierOrders(db);
-		const placedOrderLineIds = placedSupplierOrders.map((order) => order.id);
+		await createSupplierOrder(db, 1, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
 
 		const customerOrderLines = await getCustomerOrderLines(db, 1);
 		const customerOrderLineIds = customerOrderLines.map((order) => order.id);
 
 		// Mark the books as received
 		// await markCustomerOrderAsReceived(db, orderLineIds);
-		await createReconciliationOrder(db, 1, placedOrderLineIds);
+		await createReconciliationOrder(db, 1, [1]);
 		await addOrderLinesToReconciliationOrder(db, 1, [
 			{ isbn: "9780000000001", quantity: 1 },
 			{ isbn: "9780000000001", quantity: 1 }
@@ -701,7 +698,7 @@ describe("Customer order Collection", () => {
 		await upsertSupplier(db, { id: 1 });
 		await associatePublisher(db, 1, "pub1");
 
-		await createSupplierOrder(db, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
+		await createSupplierOrder(db, 1, 1, [{ isbn: "9780000000001", quantity: 2, supplier_id: 1 }]);
 
 		const customerOrderLines = await getCustomerOrderLines(db, 1);
 		const orderLineIds = customerOrderLines.map((order) => order.id);
@@ -739,7 +736,7 @@ describe("Customer order Collection", () => {
 		await associatePublisher(db, 1, "pub1");
 
 		// Order books from supplier
-		await createSupplierOrder(db, 1, [
+		await createSupplierOrder(db, 1, 1, [
 			{
 				isbn: "9780000000001",
 				quantity: 2, // Order enough for both customers

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
@@ -179,9 +179,8 @@ describe("New supplier orders:", () => {
 			await addBooksToCustomer(db, customer2.id, [book1.isbn, book1.isbn]);
 
 			// Create one supplier order (we need it to simulate the overdelivery)
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
-			const [{ id: supplierOrderId }] = await getPlacedSupplierOrders(db, { supplierId: supplier1.id });
-			await createReconciliationOrder(db, 1, [supplierOrderId]);
+			await createSupplierOrder(db, 1, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createReconciliationOrder(db, 1, [1]);
 			// 1 to reconcile, 1 to overdeliver
 			await addOrderLinesToReconciliationOrder(db, 1, [{ isbn: book1.isbn, quantity: 2 }]);
 			await finalizeReconciliationOrder(db, 1);
@@ -344,9 +343,8 @@ describe("New supplier orders:", () => {
 			await addBooksToCustomer(db, customer2.id, [book1.isbn, book1.isbn]);
 
 			// Create one supplier order (we need it to simulate the overdelivery)
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
-			const [{ id: supplierOrderId }] = await getPlacedSupplierOrders(db, { supplierId: supplier1.id });
-			await createReconciliationOrder(db, 1, [supplierOrderId]);
+			await createSupplierOrder(db, 1, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createReconciliationOrder(db, 1, [1]);
 			// 1 to reconcile, 1 to overdeliver
 			await addOrderLinesToReconciliationOrder(db, 1, [{ isbn: book1.isbn, quantity: 2 }]);
 			await finalizeReconciliationOrder(db, 1);
@@ -366,7 +364,7 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn]);
 			await addBooksToCustomer(db, customer2.id, [book2.isbn]);
 
-			await createSupplierOrder(db, 1, [
+			await createSupplierOrder(db, 1, 1, [
 				{ isbn: book1.isbn, quantity: 1, supplier_id: 1 },
 				{ isbn: book2.isbn, quantity: 1, supplier_id: 1 }
 			]);
@@ -393,7 +391,7 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn]);
 			await addBooksToCustomer(db, customer2.id, [book1.isbn, book2.isbn]);
 
-			await createSupplierOrder(db, 1, [
+			await createSupplierOrder(db, 1, 1, [
 				{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }, // 2 are required by customer orders, but only 1 ordered
 				{ isbn: book2.isbn, quantity: 1, supplier_id: 1 }
 			]);
@@ -426,7 +424,7 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, customer2.id, [book1.isbn]);
 			await addBooksToCustomer(db, 3, [book1.isbn]);
 
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book1.isbn, quantity: 2, supplier_id: supplier1.id }]);
+			await createSupplierOrder(db, 1, supplier1.id, [{ isbn: book1.isbn, quantity: 2, supplier_id: supplier1.id }]);
 
 			expect(await getCustomerOrderLines(db, customer1.id)).toEqual([
 				expect.objectContaining({ isbn: book1.isbn, placed: expect.any(Date) })
@@ -451,7 +449,7 @@ describe("Placing supplier orders", () => {
 			].join("\n");
 
 			expect(
-				createSupplierOrder(db, 1, [
+				createSupplierOrder(db, 1, 1, [
 					{ isbn: book1.isbn, quantity: 1, supplier_id: 1 },
 					{ isbn: book2.isbn, quantity: 1, supplier_id: 2 }
 				])
@@ -471,7 +469,7 @@ describe("Placing supplier orders", () => {
 
 			// Create the order
 			const possibleOrderLines = await getPossibleSupplierOrderLines(db, supplierId);
-			await createSupplierOrder(db, supplierId, possibleOrderLines);
+			await createSupplierOrder(db, 1, supplierId, possibleOrderLines);
 
 			// Verify order was created with zero price
 			const [placedOrder] = await getPlacedSupplierOrders(db);
@@ -482,29 +480,29 @@ describe("Placing supplier orders", () => {
 		// NOTE: this is an edge case, and the UI probably shouldn't allow it.
 		// Maybe this could also be handled by the UI allowing it, but showing an error message if attempted
 		it("throw an error when trying to create a supplier order with no order lines", async () => {
-			expect(createSupplierOrder(db, 1, [])).rejects.toThrow("No order lines provided");
+			expect(createSupplierOrder(db, 1, 1, [])).rejects.toThrow("No order lines provided");
 		});
 
 		it("timestamp supplier order's 'created' with ms precision", async () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn, book2.isbn]);
 
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: supplier1.id }]);
-			const [supplierOrder1] = await getPlacedSupplierOrders(db);
-			expect(Date.now() - supplierOrder1.created).toBeLessThan(300);
+			await createSupplierOrder(db, 1, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: supplier1.id }]);
+			const [s1] = await getPlacedSupplierOrders(db);
+			expect(Date.now() - s1.created).toBeLessThan(300);
 
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book2.isbn, quantity: 1, supplier_id: supplier1.id }]);
-			const [supplierOrder2] = await getPlacedSupplierOrders(db);
-			expect(Date.now() - supplierOrder2.created).toBeLessThan(300);
+			await createSupplierOrder(db, 2, supplier1.id, [{ isbn: book2.isbn, quantity: 1, supplier_id: supplier1.id }]);
+			const [s2] = await getPlacedSupplierOrders(db);
+			expect(Date.now() - s2.created).toBeLessThan(300);
 		});
 
 		it("timestamp customer order lines' 'placed' with ms precision", async () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn, book2.isbn]);
 
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: supplier1.id }]);
+			await createSupplierOrder(db, 1, supplier1.id, [{ isbn: book1.isbn, quantity: 1, supplier_id: supplier1.id }]);
 			const [customerOrderLine1] = await getCustomerOrderLines(db, customer1.id);
 			expect(Date.now() - customerOrderLine1.placed.getTime()).toBeLessThan(300);
 
-			await createSupplierOrder(db, supplier1.id, [{ isbn: book2.isbn, quantity: 1, supplier_id: supplier1.id }]);
+			await createSupplierOrder(db, 2, supplier1.id, [{ isbn: book2.isbn, quantity: 1, supplier_id: supplier1.id }]);
 			const [, customerOrderLine2] = await getCustomerOrderLines(db, customer1.id);
 			expect(Date.now() - customerOrderLine2.placed.getTime()).toBeLessThan(300);
 		});
@@ -512,7 +510,7 @@ describe("Placing supplier orders", () => {
 		it("create a customer order line - supplier order relation for each time the same line is ordered from the supplier", async () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn]);
 
-			await createSupplierOrder(db, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createSupplierOrder(db, 1, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
 			expect(await getCustomerOrderLineHistory(db, customer1.id)).toHaveLength(1);
 
 			// This is a case when the book hadn't been delivered and had been ordered again (one or more times)
@@ -521,13 +519,13 @@ describe("Placing supplier orders", () => {
 			await db.exec("UPDATE customer_order_lines SET placed = NULL"); // NOTE: this is the only line so it works without elaborate WHERE clause
 
 			// Order again
-			await createSupplierOrder(db, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createSupplierOrder(db, 2, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
 			expect(await getCustomerOrderLineHistory(db, customer1.id)).toHaveLength(2);
 
 			// Explicitly remove the placed on the customer order line, so as to simulate the book not being delivered (ready for reordering)
 			await db.exec("UPDATE customer_order_lines SET placed = NULL"); // NOTE: this is the only line so it works without elaborate WHERE clause
 
-			await createSupplierOrder(db, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createSupplierOrder(db, 3, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
 			expect(await getCustomerOrderLineHistory(db, customer1.id)).toHaveLength(3);
 		});
 
@@ -535,7 +533,7 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, customer1.id, [book1.isbn]);
 			let lastUpdate: number;
 
-			await createSupplierOrder(db, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
+			await createSupplierOrder(db, 1, 1, [{ isbn: book1.isbn, quantity: 1, supplier_id: 1 }]);
 			await getCustomerOrderLineHistory(db, customer1.id).then(([{ placed }]) => (lastUpdate = placed.getTime()));
 			expect(Date.now() - lastUpdate).toBeLessThan(300);
 
@@ -714,14 +712,14 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, 4, ["1", "2", "3"]);
 			await addBooksToCustomer(db, 4, ["1", "2", "3"]);
 
-			await createSupplierOrder(db, 1, [
+			await createSupplierOrder(db, 1, 1, [
 				{ supplier_id: 1, isbn: "1", quantity: 2 },
 				{ supplier_id: 1, isbn: "2", quantity: 1 }
 			]);
 
-			await createSupplierOrder(db, 2, [{ supplier_id: 2, isbn: "3", quantity: 3 }]);
+			await createSupplierOrder(db, 2, 2, [{ supplier_id: 2, isbn: "3", quantity: 3 }]);
 
-			await createSupplierOrder(db, 1, [
+			await createSupplierOrder(db, 3, 1, [
 				{ supplier_id: 1, isbn: "2", quantity: 3 },
 				{ supplier_id: 1, isbn: "3", quantity: 3 }
 			]);
@@ -749,13 +747,13 @@ describe("Placing supplier orders", () => {
 			await addBooksToCustomer(db, 1, ["1", "2", "3", "4"]);
 
 			// Supplier order 1 - reconciled (finalized)
-			await createSupplierOrder(db, 1, [{ supplier_id: 1, isbn: "1", quantity: 1 }]);
+			await createSupplierOrder(db, 2, 1, [{ supplier_id: 1, isbn: "1", quantity: 1 }]);
 			// Supplier order 2 - reconciled (not finalized)
-			await createSupplierOrder(db, 1, [{ supplier_id: 1, isbn: "2", quantity: 1 }]);
+			await createSupplierOrder(db, 3, 1, [{ supplier_id: 1, isbn: "2", quantity: 1 }]);
 			// Supplier order 3 - not reconciled
-			await createSupplierOrder(db, 1, [{ supplier_id: 1, isbn: "3", quantity: 1 }]);
+			await createSupplierOrder(db, 4, 1, [{ supplier_id: 1, isbn: "3", quantity: 1 }]);
 			// Supplier order 4 - not reconciled
-			await createSupplierOrder(db, 1, [{ supplier_id: 1, isbn: "4", quantity: 1 }]);
+			await createSupplierOrder(db, 5, 1, [{ supplier_id: 1, isbn: "4", quantity: 1 }]);
 
 			const [{ id: s4 }, { id: s3 }, { id: s2 }, { id: s1 }] = await getPlacedSupplierOrders(db);
 

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
@@ -35,13 +35,17 @@
 	$: canPlaceOrder = selectedBooks.length > 0;
 
 	async function handlePlaceOrder() {
+		/**@TODO replace randomId with incremented id */
+		// get latest/biggest id and increment by 1
+
 		if (!canPlaceOrder) {
 			return;
 		}
 
 		const selection = orderLines.filter(({ isbn }) => selectedIsbns.includes(isbn));
 
-		await createSupplierOrder(db, supplier_id, selection);
+		const id = Math.floor(Math.random() * 1000000); // Temporary ID generation
+		await createSupplierOrder(db, id, supplier_id, selection);
 		await invalidate("suppliers:data");
 		// TODO: We could either go to the new supplier order "placed" view when it's created
 		// or we could make sure we go to the "placed" list on the suppliers view "/suppliers?s=placed"


### PR DESCRIPTION
Instead of this:

```ts
await createSupplierOrder(db, supplierId, lines)
const [{ id: supplierOrderId }] = await getPlacedSupplierOrders(db)
// Do something - like create a reconciliation order
await createReconciliationOrder(db, [supplierOrderId])
```

We can simply do:

```ts
const id = 1
await createSupplierOrder(db, id, supplierId, lines)
// const [{ id: supplierOrderId }] = await getPlacedSupplierOrders(db) -> not necessary
// Do something - like create a reconciliation order
await createReconciliationOrder(db, [id])
```