### PR TITLE
Fix/e2e fixtures

### DIFF
--- a/apps/e2e/helpers/cr-sqlite.ts
+++ b/apps/e2e/helpers/cr-sqlite.ts
@@ -327,7 +327,7 @@ export async function associatePublisher(db: DB, params: { supplierId: number; p
  * References the original createSupplierOrder function.
  * @see apps/web-client/src/lib/db/cr-sqlite/suppliers.ts:createSupplierOrder
  */
-export async function createSupplierOrder(db: DB, orderLines: PossibleSupplierOrderLine[]) {
+export async function createSupplierOrder(db: DB, orderLines: Pick<PossibleSupplierOrderLine, "isbn" | "supplier_id" | "quantity">[]) {
 	/** @TODO Rewrite this function to accomodate for removing quantity in customerOrderLine */
 	// Creates one or more supplier orders with the given order lines. Updates customer order lines to reflect the order.
 	// Returns one or more `SupplierOrder` as they would be returned by `getSupplierOrder`

--- a/apps/e2e/helpers/cr-sqlite.ts
+++ b/apps/e2e/helpers/cr-sqlite.ts
@@ -269,7 +269,7 @@ export const addBooksToCustomer = async (db: DB, params: { customerId: number; b
      INSERT INTO customer_order_lines (customer_id, isbn)
      VALUES ${multiplyString("(?,?)", bookIsbns.length)} RETURNING customer_id;`;
 
-	const id = await db.exec(sql, sqlParams);
+	await db.exec(sql, sqlParams);
 };
 
 // #endregion customerOrders

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -1,6 +1,6 @@
 import { baseURL } from "@/integration/constants";
 
-import { PlacedSupplierOrder, PlacedSupplierOrderLine } from "./types";
+import { Customer, Supplier } from "./types";
 import {
 	addBooksToCustomer,
 	addOrderLinesToReconciliationOrder,
@@ -8,29 +8,16 @@ import {
 	createReconciliationOrder,
 	createSupplierOrder,
 	finalizeReconciliationOrder,
-	getCustomerOrderLineStatus,
-	getPlacedSupplierOrderLines,
 	getPlacedSupplierOrders,
 	upsertBook,
 	upsertCustomer,
 	upsertSupplier
 } from "./cr-sqlite";
 import { getDbHandle } from "./db";
-import { DBCustomerOrderLine } from "./types";
 import test, { JSHandle } from "@playwright/test";
 import { DB } from "@vlcn.io/crsqlite-wasm";
+import { BookData } from "@librocco/shared";
 
-type OrderTestFixture = {
-	customers: { id: number; fullname: string; email: string; displayId: string }[];
-	books: { isbn: string; authors: string; title: string; publisher: string; price: number }[];
-	placedOrders: {
-		order: PlacedSupplierOrder;
-		lines: PlacedSupplierOrderLine[];
-	}[];
-	customerOrderLines: DBCustomerOrderLine[];
-	supplier: { id: number; name: string; email: string };
-	dbHandle: JSHandle<DB>;
-};
 const books = [
 	{ isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10 },
 	{ isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20 },
@@ -40,60 +27,217 @@ const books = [
 	{ isbn: "8888", authors: "author6", title: "title6", publisher: "pub2", price: 60 },
 	{ isbn: "7777", authors: "author7", title: "title7", publisher: "pub1", price: 70 }
 ];
+
+const suppliers = [{ id: 1, name: "Sup1", email: "sup1@gmail.com" }];
+
 const customers = [
 	{ id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" },
 	{ id: 2, fullname: "Jane Doe", email: "jane@gmail.com", displayId: "2" },
 	{ id: 3, fullname: "Don Joe", email: "don@gmail.com", displayId: "3" }
 ];
 
-const customer = { id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1" };
-const supplier = { id: 1, name: "sup1" };
-export const testOrders = test.extend<OrderTestFixture>({
-	customers: async ({ page }, use) => {
-		await page.goto(baseURL);
+type FixtureCustomerOrderLine = {
+	isbn: string;
+	customerId: number;
+};
 
-		const dbHandle = await getDbHandle(page);
+const customerOrderLines = [
+	{ isbn: "1234", customerId: 1 },
+	{ isbn: "4321", customerId: 1 }
+];
 
-		// dbHandler
-		await dbHandle.evaluate(upsertCustomer, customers[0]);
-		await dbHandle.evaluate(upsertCustomer, customers[1]);
-		await dbHandle.evaluate(upsertCustomer, customers[2]);
+type FixtureSupplierOrderLine = {
+	isbn: string;
+	quantity: number;
+	supplier_id: number;
+	supplier_name: string;
+};
 
-		await use(customers);
+type FixtureSupplierOrder = {
+	order: {
+		supplier_id: number;
+		supplier_name: string;
+	};
+	lines: FixtureSupplierOrderLine[];
+};
+
+const supplierOrders: FixtureSupplierOrder[] = [
+	{
+		order: { supplier_id: 1, supplier_name: "sup1" },
+		lines: [
+			{ isbn: "1234", supplier_id: 1, supplier_name: "sup1", quantity: 2 },
+			{ isbn: "5678", supplier_id: 1, supplier_name: "sup1", quantity: 1 }
+		]
 	},
-	books: async ({ page }, use) => {
+	{
+		order: { supplier_id: 1, supplier_name: "sup1" },
+		lines: [
+			{ isbn: "5678", supplier_id: 1, supplier_name: "sup1", quantity: 3 },
+			{ isbn: "9999", supplier_id: 1, supplier_name: "sup1", quantity: 2 },
+			{ isbn: "7777", supplier_id: 1, supplier_name: "sup1", quantity: 1 }
+		]
+	},
+	{
+		order: { supplier_id: 2, supplier_name: "sup2" },
+		lines: [
+			{ isbn: "4321", supplier_id: 2, supplier_name: "sup2", quantity: 1 },
+			{ isbn: "8765", supplier_id: 2, supplier_name: "sup2", quantity: 1 },
+			{ isbn: "8888", supplier_id: 2, supplier_name: "sup2", quantity: 1 }
+		]
+	}
+];
+
+type OrderTestFixture = {
+	dbHandle: JSHandle<DB>;
+
+	/**
+	 * Data:
+	 *
+	 * isbn: "1234", authors: "author1", title: "title1", publisher: "pub1", price: 10
+	 * isbn: "4321", authors: "author2", title: "title2", publisher: "pub2", price: 20
+	 * isbn: "5678", authors: "author3", title: "title3", publisher: "pub1", price: 30
+	 * isbn: "8765", authors: "author4", title: "title4", publisher: "pub2", price: 40
+	 * isbn: "9999", authors: "author5", title: "title5", publisher: "pub1", price: 50
+	 * isbn: "8888", authors: "author6", title: "title6", publisher: "pub2", price: 60
+	 * isbn: "7777", authors: "author7", title: "title7", publisher: "pub1", price: 70
+	 */
+	books: BookData[];
+
+	/**
+	 * Data:
+	 *
+	 * id: 1, fullname: "John Doe", email: "john@gmail.com", displayId: "1"
+	 * id: 2, fullname: "Jane Doe", email: "jane@gmail.com", displayId: "2"
+	 * id: 3, fullname: "Don Joe",  email: "don@gmail.com",  displayId: "3"
+	 */
+	customers: Customer[];
+
+	/**
+	 * Data:
+	 *
+	 * isbn: "1234", customerId: 1, status: delivered
+	 * isbn: "4321", customerId: 1, status: placed
+	 */
+	customerOrderLines: FixtureCustomerOrderLine[];
+
+	/**
+	 * Data:
+	 *
+	 * id: 1, name: "Sup1", email: "sup1@gmail.com"
+	 */
+	suppliers: Supplier[];
+
+	/**
+	 * Data:
+	 *
+	 * Customer order lines:
+	 *	customerId: 1, isbn: "1234"
+	 * 	customerId: 1, isbn: "5678"
+	 * 	customerId: 1, isbn: "8888"
+	 * 	customerId: 2, isbn: "5678"
+	 * 	customerId: 2, isbn: "8765"
+	 * 	customerId: 2, isbn: "4321"
+	 * 	customerId: 2, isbn: "7777"
+	 * 	customerId: 3, isbn: "1234"
+	 * 	customerId: 3, isbn: "9999"
+	 *
+	 * Suppliers:
+	 *  id: 1, name: "sup1"
+	 *  id: 2, name: "sup2"
+	 *
+	 * Supplier orders:
+	 *  ID: unknown, supplier id: 1
+	 * 	 isbn: "1234", quantity: 2
+	 * 	 isbn: "5678", quantity: 1
+	 *
+	 *  ID: unknown, supplier id: 1
+	 * 	 isbn: "5678", quantity: 3
+	 * 	 isbn: "9999", quantity: 2
+	 * 	 isbn: "7777", quantity: 1
+	 *
+	 *  ID: unknown, supplier id: 2
+	 * 	 isbn: "4321", quantity: 1
+	 * 	 isbn: "8765", quantity: 1
+	 * 	 isbn: "8888", quantity: 1
+	 */
+	supplierOrders: FixtureSupplierOrder[];
+};
+
+// NOTE: In order to order to avoid circular depenedencies within fixtures, the best prectice is
+// for each fixture to depend only on the fixtures that are declared before it.
+export const testOrders = test.extend<OrderTestFixture>({
+	dbHandle: async ({ page }, use) => {
 		await page.goto(baseURL);
 
 		const dbHandle = await getDbHandle(page);
+		await use(dbHandle);
+	},
 
-		await dbHandle.evaluate(upsertBook, books[0]);
-		await dbHandle.evaluate(upsertBook, books[1]);
-		await dbHandle.evaluate(upsertBook, books[2]);
-		await dbHandle.evaluate(upsertBook, books[3]);
-		await dbHandle.evaluate(upsertBook, books[4]);
-		await dbHandle.evaluate(upsertBook, books[5]);
-		await dbHandle.evaluate(upsertBook, books[6]);
-
+	books: async ({ dbHandle }, use) => {
+		for (const book of books) {
+			await dbHandle.evaluate(upsertBook, book);
+		}
 		await use(books);
 	},
-	placedOrders: async ({ page }, use) => {
+
+	suppliers: async ({ dbHandle }, use) => {
+		for (const supplier of suppliers) {
+			await dbHandle.evaluate(upsertSupplier, supplier);
+		}
+		await use(suppliers);
+	},
+
+	customers: async ({ dbHandle }, use) => {
+		for (const customer of customers) {
+			await dbHandle.evaluate(upsertCustomer, customer);
+		}
+		await use(customers);
+	},
+
+	customerOrderLines: async ({ dbHandle, books, customers, suppliers }, use) => {
+		depends(customers);
+		depends(suppliers);
+
+		const supplierOrderLine = {
+			...books[0],
+			supplier_id: 1,
+			supplier_name: "Sup1",
+			quantity: 1,
+			line_price: 10
+		};
+
+		for (const line of customerOrderLines) {
+			await dbHandle.evaluate(addBooksToCustomer, { customerId: line.customerId, bookIsbns: [line.isbn] });
+		}
+
+		// TODO: Check this - doesn't seem like a clean, modular setup - we should probably set this up explicitly (SQL)
+		// as, to my understanding, the purpose is to get some diversity in order line states
+		//
+		// NOTE: Alternative would be to move this to a separate fixture. In that case we would need to be careful about the order of fixture execution
+		// so as to not create circular dependencies
+		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
+		await dbHandle.evaluate(createSupplierOrder, [supplierOrderLine]);
+
+		const placedOrders = await dbHandle.evaluate(getPlacedSupplierOrders);
+
+		const placedOrderIds = placedOrders.map((placedOrder) => placedOrder.id);
+		const reconciliationOrderId = await dbHandle.evaluate(createReconciliationOrder, placedOrderIds);
+
+		await dbHandle.evaluate(addOrderLinesToReconciliationOrder, { id: reconciliationOrderId, newLines: [supplierOrderLine] });
+		await dbHandle.evaluate(finalizeReconciliationOrder, reconciliationOrderId);
+
+		await use(customerOrderLines);
+	},
+
+	supplierOrders: async ({ page, books }, use) => {
+		depends(books);
+
 		await page.goto(baseURL);
 		const dbHandle = await getDbHandle(page);
 
-		// await dbHandle.evaluate(upsertCustomer, customer);
-
-		// await dbHandle.evaluate(upsertBook, books[0]);
-		// await dbHandle.evaluate(upsertBook, books[1]);
-
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[0].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[2].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[0].id, bookIsbns: [books[5].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[2].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[3].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[1].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[1].id, bookIsbns: [books[6].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[2].id, bookIsbns: [books[0].isbn] });
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: customers[2].id, bookIsbns: [books[4].isbn] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: ["1234", "5678", "8888"] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: 2, bookIsbns: ["5678", "8765", "4321", "7777"] });
+		await dbHandle.evaluate(addBooksToCustomer, { customerId: 3, bookIsbns: ["1234", "9999"] });
 
 		await dbHandle.evaluate(upsertSupplier, { id: 1, name: "sup1" });
 		await dbHandle.evaluate(upsertSupplier, { id: 2, name: "sup2" });
@@ -101,77 +245,54 @@ export const testOrders = test.extend<OrderTestFixture>({
 		await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
 		await dbHandle.evaluate(associatePublisher, { supplierId: 2, publisherId: "pub2" });
 
-		await dbHandle.evaluate(createSupplierOrder, [
-			{ ...books[0], supplier_id: 1, supplier_name: "sup1", quantity: 2, line_price: 20 },
-			{ ...books[2], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 30 }
-		]);
-		await dbHandle.evaluate(createSupplierOrder, [
-			{ ...books[2], supplier_id: 1, supplier_name: "sup1", quantity: 3, line_price: 90 },
-			{ ...books[4], supplier_id: 1, supplier_name: "sup1", quantity: 2, line_price: 100 },
-			{ ...books[6], supplier_id: 1, supplier_name: "sup1", quantity: 1, line_price: 70 }
-		]);
+		for (const { lines } of supplierOrders) {
+			await dbHandle.evaluate(createSupplierOrder, lines);
+		}
 
-		await dbHandle.evaluate(createSupplierOrder, [
-			{ ...books[1], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 20 },
-			{ ...books[3], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 40 },
-			{ ...books[5], supplier_id: 2, supplier_name: "sup2", quantity: 1, line_price: 60 }
-		]);
-
-		const placedOrders = await dbHandle.evaluate(getPlacedSupplierOrders);
-
-		const orderIds = placedOrders.map((order) => order.id);
-		const placedOrderLines = await dbHandle.evaluate(getPlacedSupplierOrderLines, orderIds);
-
-		// : {order: PlacedSupplierOrder, lines: PlacedSupplierOrderLines}[]
-		const orderAndLines = placedOrders.map((order) => ({
-			order,
-			lines: placedOrderLines.filter((line) => line.supplier_order_id === order.id)
-		}));
-
-		/** @TODO replace with supplier id when supplier_order spec is merged in */
-		await use(orderAndLines);
-	},
-	customerOrderLines: async ({ page }, use) => {
-		await page.goto(baseURL);
-
-		const supplierOrderLine = { ...books[0], supplier_id: supplier.id, supplier_name: supplier.name, quantity: 1, line_price: 10 };
-		const dbHandle = await getDbHandle(page);
-		await dbHandle.evaluate(upsertCustomer, customer);
-
-		await dbHandle.evaluate(upsertBook, books[0]);
-		await dbHandle.evaluate(upsertBook, books[1]);
-		await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn, books[1].isbn] });
-		await dbHandle.evaluate(upsertSupplier, supplier);
-		await dbHandle.evaluate(associatePublisher, { supplierId: supplier.id, publisherId: "pub1" });
-		await dbHandle.evaluate(createSupplierOrder, [supplierOrderLine]);
-
-		const placedOrders = await dbHandle.evaluate(getPlacedSupplierOrders);
-
-		const placedOrderIds = placedOrders.map((placedOrder) => placedOrder.id);
-		const reconciliationOrderId = await dbHandle.evaluate(createReconciliationOrder, placedOrderIds);
-		await dbHandle.evaluate(addOrderLinesToReconciliationOrder, { id: reconciliationOrderId, newLines: [supplierOrderLine] });
-		await dbHandle.evaluate(finalizeReconciliationOrder, reconciliationOrderId);
-
-		const customerOrderLines = await dbHandle.evaluate(getCustomerOrderLineStatus, customer.id);
-
-		await use(customerOrderLines);
-	},
-	supplier: async ({ page }, use) => {
-		await page.goto(baseURL);
-
-		const supplier = { id: 1, name: "Sup1", email: "sup1@gmail.com" };
-
-		const dbHandle = await getDbHandle(page);
-
-		await dbHandle.evaluate(upsertSupplier, supplier);
-		// await dbHandle.evaluate(associatePublisher, { supplierId: 1, publisherId: "pub1" });
-
-		await use(supplier);
-	},
-	dbHandle: async ({ page }, use) => {
-		await page.goto(baseURL);
-
-		const dbHandle = await getDbHandle(page);
-		await use(dbHandle);
+		await use(supplierOrders);
 	}
 });
+
+/**
+ * This is a noop function used to reference a fixture in case when we want the fixture to run (as a test setup),
+ * but we don't use it in the test code block.
+ *
+ * @example
+ *
+ * Say we want to use a fixture 'customer' that sets up the DB state with a given customer, we can use the customer to make assertions.
+ *
+ * ```ts
+ * testOrders("customer exists in the DB", async ({page, customer}) => {
+ *	 await page.getByText(customer.email);
+ * })
+ * ```
+ *
+ * This is all well and great as we're referencing the customer (destructured param from the callback) in the test block:
+ * this makes sure the fixture runs before the test block.
+ *
+ * However, sometimes we want to make sure the fixture runs before the test, but we don't reference it in the test block.
+ * ```ts
+ * testOrders("customer exists in the DB", async ({page}) => {
+ *	 // 'customer' is not referenced here so the fixture won't run
+ * })
+ * ```
+ *
+ * Now, we can merely declare the customer without using it, like so:
+ * ```ts
+ * testOrders("customer exists in the DB", async ({page, customer}) => {})
+ * ```
+ * But that would cause problems with the linter as it would complain about the unused variable.
+ *
+ * The cleanest (albeit useless) way to make sure the fixture runs is to use this function as a reference:
+ * ```ts
+ * testOrders("customer exists in the DB", async ({page, customer}) => {
+ *   // This makes the fixture run (setup the DB) without us necessarily referencing the data in the code
+ *   // Additinal + IMO is that we explicitly declare which fixtures we depend on - a documentation of sorts
+ *   depends(customer);
+ * })
+ * ```
+ *
+ */
+export const depends = (x: any) => {
+	x; // This does nothing
+};

--- a/apps/e2e/helpers/types.ts
+++ b/apps/e2e/helpers/types.ts
@@ -310,11 +310,9 @@ export interface FieldConstructor<L extends Record<string, any>, K extends keyof
 // #region customerOrder
 export type Customer = {
 	id?: number;
+	displayId: string;
 	fullname?: string;
 	email?: string;
-	phone?: string;
-	taxId?: string;
-	displayId: string;
 	deposit?: number;
 	updatedAt?: Date;
 };

--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -4,7 +4,7 @@ import { baseURL } from "./constants";
 
 import { testOrders } from "@/helpers/fixtures";
 import { getDbHandle } from "@/helpers";
-import { addBooksToCustomer, getCustomerOrderLineStatus } from "@/helpers/cr-sqlite";
+import { addBooksToCustomer } from "@/helpers/cr-sqlite";
 
 test("should create a new customer order", async ({ page }) => {
 	await page.goto(`${baseURL}orders/customers/`);
@@ -136,9 +136,8 @@ testOrders("should delete books from a customer order", async ({ page, books }) 
 	await expect(firstRow.getByRole("cell", { name: books[0].isbn })).not.toBeVisible();
 });
 
-testOrders("should mark order lines as collected", async ({ page, customers, customerOrderLines }) => {
+testOrders("should mark order lines as collected", async ({ page, customerOrderLines }) => {
 	await page.goto(`${baseURL}orders/customers/1/`);
-	const dbHandle = await getDbHandle(page);
 
 	const table = page.getByRole("table");
 	const firstBookRow = table.getByRole("row").nth(1);
@@ -150,12 +149,6 @@ testOrders("should mark order lines as collected", async ({ page, customers, cus
 
 	await firstBookRow.getByRole("button", { name: "Collect📚" }).click();
 
-	const lines = await dbHandle.evaluate(getCustomerOrderLineStatus, customers[0].id);
-
-	// NOTE: using "it" locale as the app is primarily developed for an italian book store,
-	// We need to explicitly specify this to account for ambiguity in E2E, TODO: use some more robust way to handle this (in general case)
-	const received = new Date(lines[0].received).toISOString().slice(0, 10);
 	await expect(firstBookRow.getByRole("button", { name: "Collect📚" })).not.toBeVisible();
 	await expect(firstBookRow.getByText("Collected")).toBeVisible();
-	await expect(firstBookRow.getByText(received)).toBeVisible();
 });

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -24,7 +24,9 @@ testOrders("should show correct initial state of reconciliation page", async ({ 
 testOrders("should show correct comparison when quantities match ordered amounts", async ({ page, books, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByText("Reconcile").first().click();
 
 	const table = page.getByRole("table");
@@ -112,7 +114,8 @@ testOrders("should correctly increment quantities when scanning same ISBN multip
 testOrders("should show over-delivery when scanned quantities are more than ordered amounts", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByText("Reconcile").first().click();
 
 	const isbnInput = page.getByPlaceholder("Enter ISBN of delivered books");
@@ -146,8 +149,10 @@ testOrders(
 		await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 		await page.getByText("Ordered").nth(1).click();
-		await page.getByRole("checkbox").nth(1).click();
+
+		// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
 		await page.getByRole("checkbox").nth(2).click();
+		await page.getByRole("checkbox").nth(3).click();
 
 		await page.getByText("Reconcile").first().click();
 
@@ -197,7 +202,9 @@ testOrders("should show unmatched deliveries when ordered books do not match sca
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 
 	await page.getByText("Reconcile").first().click();
 
@@ -243,8 +250,11 @@ testOrders("should show unmatched deliveries when ordered books do not match sca
 
 testOrders("should show correct delivery stats in commit view", async ({ page, books, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
+
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByText("Reconcile").first().click();
 	await expect(page.getByText("Reconcile Deliveries")).toBeVisible();
 
@@ -288,8 +298,8 @@ testOrders("should be able to select multiple supplier orders to reconcile at on
 
 	await page.getByText("Ordered").nth(1).click();
 
-	// Select multiple orders via checkboxes
-	await page.getByRole("checkbox").nth(1).click();
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByRole("checkbox").nth(2).click();
 
 	await page.getByText("Reconcile").first().click();
@@ -340,7 +350,9 @@ testOrders("should be able to continue reconciliation", async ({ page, books, su
 	// Navigate to supplier orders and start reconciliation
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByText("Reconcile").first().click();
 
 	// Scan some books
@@ -389,7 +401,9 @@ testOrders("should be able to commit reconciliation", async ({ page, customers, 
 	// Navigate to supplier orders and start reconciliation
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	await page.getByText("Ordered").nth(1).click();
-	await page.getByRole("checkbox").nth(1).click();
+
+	// NOTE: supplier orders are sorted by 'created' in descending order: order 1 = last one in the list (idk why the 1 offset for the whole lies)
+	await page.getByRole("checkbox").nth(3).click();
 	await page.getByText("Reconcile").first().click();
 
 	// scan ordered book

--- a/apps/e2e/integration/supplier_order.spec.ts
+++ b/apps/e2e/integration/supplier_order.spec.ts
@@ -117,17 +117,21 @@ testOrders(
 testOrders("should show a placed supplier order with the correct details", async ({ page, suppliers: [supplier], books }) => {
 	const dbHandle = await getDbHandle(page);
 
-	await dbHandle.evaluate(createSupplierOrder, [
-		{
-			supplier_id: supplier.id,
-			supplier_name: supplier.name,
-			isbn: books[0].isbn,
-			line_price: books[0].price,
-			quantity: 1,
-			title: books[0].title,
-			authors: books[0].authors
-		}
-	]);
+	await dbHandle.evaluate(createSupplierOrder, {
+		id: 1,
+		supplierId: supplier.id,
+		orderLines: [
+			{
+				supplier_id: supplier.id,
+				supplier_name: supplier.name,
+				isbn: books[0].isbn,
+				line_price: books[0].price,
+				quantity: 1,
+				title: books[0].title,
+				authors: books[0].authors
+			}
+		]
+	});
 
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 	page.getByRole("button", { name: "Ordered" }).nth(1).click();

--- a/apps/e2e/integration/supplier_order.spec.ts
+++ b/apps/e2e/integration/supplier_order.spec.ts
@@ -19,7 +19,7 @@ testOrders("should show empty state when no customer orders exist", async ({ pag
 
 	await expect(page.getByRole("dialog")).toBeVisible();
 });
-testOrders("should show list of unordered orders", async ({ page, supplier, books }) => {
+testOrders("should show list of unordered orders", async ({ page, suppliers: [supplier], books }) => {
 	const dbHandle = await getDbHandle(page);
 
 	await dbHandle.evaluate(addBooksToCustomer, { customerId: 1, bookIsbns: [books[0].isbn, books[1].isbn] });
@@ -37,7 +37,7 @@ testOrders("should show list of unordered orders", async ({ page, supplier, book
 });
 testOrders(
 	"should allow a new supplier order to be placed from a batch of possible customer order lines",
-	async ({ page, supplier, books, customers }) => {
+	async ({ page, suppliers: [supplier], books, customers }) => {
 		const dbHandle = await getDbHandle(page);
 
 		await dbHandle.evaluate(associatePublisher, { supplierId: supplier.id, publisherId: "pub1" });
@@ -114,7 +114,7 @@ testOrders(
 	}
 );
 
-testOrders("should show a placed supplier order with the correct details", async ({ page, supplier, books }) => {
+testOrders("should show a placed supplier order with the correct details", async ({ page, suppliers: [supplier], books }) => {
 	const dbHandle = await getDbHandle(page);
 
 	await dbHandle.evaluate(createSupplierOrder, [


### PR DESCRIPTION
This is a 1st pass over e2e fixtures updates. Considering everything we've discussed, this could be the only pass in the direction I'd suggested:
- simplifies fixtures a bit - if a fixture depends on some data setup already done by another fixtures, it is chained after it
- makes sure setup goes in one way:
```ts
// Imagine we're using the following data
const  orderLines = [
   orderline1,
   orderline2
]

// Instead of this
await insertOrderLines(db)
const lines = await getOrderLines(db)
await use(lines) // use the lines retrieved from DB for assertions

// We do this
await insertOrderLines(db)
await use(orderLines) // use the original data for assertions
```
- provides JSDoc over each fixture (type) definition - so that we can have a quick access to exact values (hidden behind the variable - fixture data)
- adds `depends(fixture)` noop function - this was already in, prior to discussion so I left it, but it can probably be removed 
- TEMP: uses the same logic for `createSupplierOrder` as in the web client (this is TEMP as it will be replaced with reference to the original function in #761 -- however, the mentioned PR depends on this to fix the failing e2e more easily)
- ~~fixes~~ **-> updates** reconciliation e2e tests to pass with (updated) `createSupplierOrder` - using ms timestamps and providing for different ordering of supplier orders in the UI (the order in the UI causes an issue as tests depend on it and is different with the updated code - ms timestamps), "updates", not "fixes" as the reconciliation UI functionality, and e2e tests are somewhat buggy and should be reviewed altogether (this just makes them pass in more/less the same way as is the current situation in `main`)

To reflect on the discussion we had:
- I've provided the JSDoc lookup for the fixtures data with the goal of using explicit values (and using the JSDoc for easy lookup) when writing the tests, and avoid opacity of referencing fixture data as variables, however, as the majority prefers variable references, this works both ways as I can now see JSDoc of a particular variable and know the value that "hides" behind it, so 👍 👍 
- `depends` - @delasous had expressed some concerns over deviating from the norm (std. Playwright library), but, if we stick to using fixtures as data (references), it is useless either way and should probably be removed
