### PR TITLE
e2e test fix

### DIFF
--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -50,7 +50,7 @@ testOrders("should show correct comparison when quantities match ordered amounts
 	await page.keyboard.press("Enter");
 	// scanned quantity === delivered quantity
 	await expect(firstRow.getByRole("cell", { name: placedOrderLinesWithSup1[0].isbn })).toBeVisible();
-	await expect(firstRow.getByRole("cell", { name: `2`, exact: true })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "2", exact: true })).toBeVisible();
 
 	await page.getByRole("button", { name: "Compare" }).first().click();
 
@@ -92,7 +92,7 @@ testOrders("should correctly increment quantities when scanning same ISBN multip
 
 	const secondRow = table.getByRole("row").nth(2);
 
-	await expect(firstRow.getByRole("cell", { name: "2" })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "2", exact: true })).toBeVisible();
 
 	await isbnInput.fill(books[0].isbn);
 	await page.keyboard.press("Enter");
@@ -274,7 +274,7 @@ testOrders("should show correct delivery stats in commit view", async ({ page, b
 	await page.keyboard.press("Enter");
 
 	// Check the quantity is updated before...
-	await expect(firstRow.getByRole("cell", { name: "2" }).first()).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "2", exact: true }).first()).toBeVisible();
 
 	// ... moving to compare
 	await page.getByRole("button", { name: "Compare" }).first().click();
@@ -383,7 +383,7 @@ testOrders("should be able to continue reconciliation", async ({ page, books, su
 	// Verify previously scanned books are still present
 	await expect(firstRow.getByText(supplierOrders[0].lines[0].isbn)).toBeVisible();
 	// Verify quantity has increased
-	await expect(firstRow.getByRole("cell", { name: "2" })).toBeVisible();
+	await expect(firstRow.getByRole("cell", { name: "2", exact: true })).toBeVisible();
 
 	await page.getByRole("button", { name: "Compare" }).first().click();
 

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
@@ -5,7 +5,9 @@ import type { PlacedSupplierOrder, PossibleSupplierOrder } from "$lib/db/cr-sqli
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async ({ depends, parent }) => {
+	depends("books:data");
 	depends("suppliers:data");
+	depends("customers:order_lines");
 
 	const { dbCtx } = await parent();
 


### PR DESCRIPTION
Fix ambiguity with quantity cell (`2`) in reconciliation order tests 

Wait for 100ms before navigation (to try and make sure the indexeddb txns have passed before navigation)
