### PR TITLE
attempt fix: upload playwright 'test-results' to CI summary (used for offline reconstruction of failed test flows)

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -67,7 +67,7 @@ jobs:
         if: always()
         with:
           name: playwright-test-results
-          path: apps/e2e/playwright-report
+          path: apps/e2e/test-results
           retention-days: 30
 
   lint-and-typecheck:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -189,7 +189,7 @@ jobs:
       if: always()
       with:
         name: playwright-test-results
-        path: apps/e2e/playwright-report
+        path: apps/e2e/test-results
         retention-days: 30
   lint-and-typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#779 deals with uploading of playwright report to librocco server, in order to host the test result summary. However, it changes the uploaded artifact `test-results` (allowing for full reconstruction of the failed test run, locally, using Playwright UI) to `playwright-report` a static HTML summary - which, while convenient for hosted summary, isn't very useful for trace reconstruction.

I'm hoping that the change I made here will enable artifact uploads (the way I'm used to), but not interfere with the newly added functionality of summary hosting