### PR TITLE
Review/reconciliation e2e pt1

### DIFF
--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -60,20 +60,21 @@ type FixtureSupplierOrder = {
 		id: number;
 		supplier_id: number;
 		supplier_name: string;
+		totalBooks: number;
 	};
 	lines: FixtureSupplierOrderLine[];
 };
 
 const supplierOrders: FixtureSupplierOrder[] = [
 	{
-		order: { id: 1, supplier_id: 1, supplier_name: "sup1" },
+		order: { id: 1, supplier_id: 1, supplier_name: "sup1", totalBooks: 3 },
 		lines: [
 			{ isbn: "1234", supplier_id: 1, supplier_name: "sup1", quantity: 2 },
 			{ isbn: "5678", supplier_id: 1, supplier_name: "sup1", quantity: 1 }
 		]
 	},
 	{
-		order: { id: 2, supplier_id: 1, supplier_name: "sup1" },
+		order: { id: 2, supplier_id: 1, supplier_name: "sup1", totalBooks: 6 },
 		lines: [
 			{ isbn: "5678", supplier_id: 1, supplier_name: "sup1", quantity: 3 },
 			{ isbn: "9999", supplier_id: 1, supplier_name: "sup1", quantity: 2 },
@@ -81,7 +82,7 @@ const supplierOrders: FixtureSupplierOrder[] = [
 		]
 	},
 	{
-		order: { id: 3, supplier_id: 2, supplier_name: "sup2" },
+		order: { id: 3, supplier_id: 2, supplier_name: "sup2", totalBooks: 3 },
 		lines: [
 			{ isbn: "4321", supplier_id: 2, supplier_name: "sup2", quantity: 1 },
 			{ isbn: "8765", supplier_id: 2, supplier_name: "sup2", quantity: 1 },

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -3,8 +3,6 @@ import { expect } from "@playwright/test";
 import { baseURL } from "./constants";
 import { depends, testOrders } from "@/helpers/fixtures";
 
-// * Note: its helpful to make an assertion after each <enter> key
-// as it seems that Playwright may start running assertions before page data has fully caught up
 testOrders("should show correct initial state of reconciliation page", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
@@ -773,7 +771,7 @@ testOrders("should handle multiple quantity adjustments", async ({ page, supplie
 		.waitFor();
 });
 
-testOrders.skip("should maintain correct totals after multiple quantity adjustments", async ({ page, supplierOrders, books }) => {
+testOrders("should maintain correct totals after multiple quantity adjustments", async ({ page, supplierOrders, books }) => {
 	depends(supplierOrders);
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
@@ -835,13 +833,14 @@ testOrders.skip("should maintain correct totals after multiple quantity adjustme
 	await page.getByRole("button", { name: "Compare" }).first().click();
 
 	// Verify updated total
-	// TODO: Check this, it seems fishy -- decreasing line 2 should result in 0 quantity,
-	// hence: book 1 x 2 (delivered - out of 2 ordered) + book 2 x 0 (delivered) = 2 / book1 x 2 (ordered) + book 2 x 1 (ordered) = 3
-	// overdelivered book 1 shouldn't make the delivered count - at most 2 of book 1 (delivered quantity) should make the delivered count
-	await expect(page.getByText("3 / 3")).toBeVisible();
+	// book 1 - ordered 2, scanned 3 = contributes 2 to total delivered (out of quantity ordered)
+	//   - 3rd is overdelivery and doesn't count
+	// book 2 - ordered 1, scanned 0
+	// Total: 2 + 0 = 2 (delivered) / 2 + 1 = 3 (ordered)
+	await expect(page.getByText("2 / 3")).toBeVisible();
 });
 
-testOrders.skip("should allow supplier orders to be reconciled again after deletion", async ({ page, supplierOrders }) => {
+testOrders("should allow supplier orders to be reconciled again after deletion", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -970,7 +969,7 @@ testOrders("should allow deletion after comparing books", async ({ page, supplie
 		.filter({ has: page.getByRole("cell", { name: "1", exact: true }) })
 		.waitFor();
 
-	await page.getByRole("button", { name: "Compare" }).click();
+	await page.getByRole("button", { name: "Compare" }).first().click();
 
 	// Delete from compare view
 	await page.getByRole("button", { name: "Delete reconciliation order" }).click();
@@ -1016,9 +1015,8 @@ testOrders("should allow deletion of empty reconciliation order", async ({ page,
 	await expect(page.getByText("Ordered", { exact: true })).toBeVisible();
 });
 
-// TODO: Skipped this so as to not fail in 'main' with refactor under way
 // NOTE: This test seems a bit redundant, considering the above tests
-testOrders.skip("should navigate correctly after deletion", async ({ page, supplierOrders }) => {
+testOrders("should navigate correctly after deletion", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -8,7 +8,7 @@ testOrders("should show correct initial state of reconciliation page", async ({ 
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: checking for initial state using all 3 supplier orders
 	for (const order of supplierOrders) {
@@ -45,7 +45,7 @@ testOrders("should show correct comparison when quantities match ordered amounts
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -107,7 +107,7 @@ testOrders("should correctly increment quantities when scanning same ISBN multip
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -169,7 +169,7 @@ testOrders("should show over-delivery when scanned quantities are more than orde
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -219,7 +219,7 @@ testOrders(
 
 		const table = page.getByRole("table");
 
-		await page.getByText("Ordered").nth(1).click();
+		await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 		// NOTE: using the first two orders (from the fixture)
 		// NOTE: At the time of this writing, first two orders belonged to the same supplier
@@ -273,7 +273,7 @@ testOrders("should show unmatched deliveries when ordered books do not match sca
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -348,7 +348,7 @@ testOrders("regression: unmatched books shouldn't affect the Total delivered cou
 	// Navigate to reconciliation
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 	await page.getByRole("checkbox").nth(1).click();
 
 	await page.getByText("Reconcile").first().click();
@@ -380,7 +380,7 @@ testOrders("should show correct delivery stats in commit view", async ({ page, b
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -446,7 +446,7 @@ testOrders("should be able to select multiple supplier orders to reconcile at on
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first two orders (from the fixture)
 	// NOTE: At the time of this writing, first two orders belonged to the same supplier
@@ -503,7 +503,7 @@ testOrders("should be able to continue reconciliation", async ({ page, books, su
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -566,7 +566,7 @@ testOrders("should be able to commit reconciliation", async ({ page, customers, 
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	const { order } = supplierOrders[0];
@@ -617,7 +617,7 @@ testOrders("should handle quantity adjustments correctly", async ({ page, suppli
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -662,7 +662,7 @@ testOrders("should remove line when quantity reaches zero", async ({ page, suppl
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -706,7 +706,7 @@ testOrders("should handle multiple quantity adjustments", async ({ page, supplie
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -772,7 +772,7 @@ testOrders("should maintain correct totals after multiple quantity adjustments",
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -840,7 +840,7 @@ testOrders("should allow supplier orders to be reconciled again after deletion",
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// Select multiple orders
 	// NOTE: using the first two orders (from the fixture)
@@ -881,7 +881,7 @@ testOrders("should allow supplier orders to be reconciled again after deletion",
 	await expect(page.getByText("Ordered", { exact: true })).toBeVisible();
 
 	// Should be able to start new reconciliation with same orders
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	await relevantOrders.nth(0).getByRole("checkbox").click();
 	await relevantOrders.nth(1).getByRole("checkbox").click();
@@ -895,7 +895,7 @@ testOrders("should not delete reconciliation order when canceling deletion", asy
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -939,7 +939,7 @@ testOrders("should allow deletion after comparing books", async ({ page, supplie
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -982,7 +982,7 @@ testOrders("should allow deletion of empty reconciliation order", async ({ page,
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)
@@ -1013,7 +1013,7 @@ testOrders("should navigate correctly after deletion", async ({ page, supplierOr
 
 	const table = page.getByRole("table");
 
-	await page.getByText("Ordered").nth(1).click();
+	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	// NOTE: using the first order (from the fixture) for the test
 	// (not really relevant for this test, but we want to make sure it's, in fact, an order row, not a header)

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 
 import { baseURL } from "./constants";
-import { depends, testOrders } from "@/helpers/fixtures";
+import { testOrders } from "@/helpers/fixtures";
 
 testOrders("should show correct initial state of reconciliation page", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
@@ -164,7 +164,7 @@ testOrders("should correctly increment quantities when scanning same ISBN multip
 		.waitFor();
 });
 
-testOrders("should show over-delivery when scanned quantities are more than ordered amounts", async ({ page, books, supplierOrders }) => {
+testOrders("should show over-delivery when scanned quantities are more than ordered amounts", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -376,7 +376,6 @@ testOrders("regression: unmatched books shouldn't affect the Total delivered cou
 });
 
 testOrders("should show correct delivery stats in commit view", async ({ page, books, supplierOrders }) => {
-	depends(supplierOrders);
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -613,7 +612,6 @@ testOrders("should be able to commit reconciliation", async ({ page, customers, 
 });
 
 testOrders("should handle quantity adjustments correctly", async ({ page, supplierOrders }) => {
-	depends(supplierOrders);
 	// Navigate and start reconciliation
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
@@ -660,7 +658,6 @@ testOrders("should handle quantity adjustments correctly", async ({ page, suppli
 });
 
 testOrders("should remove line when quantity reaches zero", async ({ page, supplierOrders }) => {
-	depends(supplierOrders);
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -704,8 +701,7 @@ testOrders("should remove line when quantity reaches zero", async ({ page, suppl
 		.waitFor({ state: "detached" });
 });
 
-testOrders("should handle multiple quantity adjustments", async ({ page, supplierOrders, books }) => {
-	depends(supplierOrders);
+testOrders("should handle multiple quantity adjustments", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -771,8 +767,7 @@ testOrders("should handle multiple quantity adjustments", async ({ page, supplie
 		.waitFor();
 });
 
-testOrders("should maintain correct totals after multiple quantity adjustments", async ({ page, supplierOrders, books }) => {
-	depends(supplierOrders);
+testOrders("should maintain correct totals after multiple quantity adjustments", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");
@@ -982,10 +977,7 @@ testOrders("should allow deletion after comparing books", async ({ page, supplie
 	await expect(page.getByText("Ordered", { exact: true })).toBeVisible();
 });
 
-testOrders("should allow deletion of empty reconciliation order", async ({ page, supplierOrders, books }) => {
-	books;
-	supplierOrders;
-
+testOrders("should allow deletion of empty reconciliation order", async ({ page, supplierOrders }) => {
 	await page.goto(`${baseURL}orders/suppliers/orders/`);
 
 	const table = page.getByRole("table");

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -601,7 +601,6 @@ testOrders("should be able to commit reconciliation", async ({ page, customers, 
 	await page.getByRole("button", { name: "Commit" }).nth(1).click();
 	await dialog.getByRole("button", { name: "Confirm" }).click();
 	await expect(dialog).not.toBeVisible();
-	await page.reload();
 
 	//more assertions to give time for the line to be updated to delivered
 
@@ -870,17 +869,9 @@ testOrders("should allow supplier orders to be reconciled again after deletion",
 
 	await expect(page.getByRole("dialog")).toBeHidden();
 
-	await page.waitForURL("**/orders/suppliers/orders/");
-	await page.waitForTimeout(1000);
-
-	// Verify back at supplier orders
-	await page.reload();
-
-	// Verify back at supplier orders
-	// stalling here to give time for the page to load the deleted orders
-	await expect(page.getByText("Ordered", { exact: true })).toBeVisible();
-
 	// Should be able to start new reconciliation with same orders
+	// NOTE: We're should be redirected back to 'orders/suppliers/orders/' after deletion
+	// No need for additional assertions - this button being there is an implicit test + interaction for the next step
 	await page.getByRole("button", { name: "Ordered", exact: true }).click();
 
 	await relevantOrders.nth(0).getByRole("checkbox").click();

--- a/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/order-reconciliation.ts
@@ -201,6 +201,7 @@ export class ErrReconciliationOrderFinalized extends Error {
 		}
 	}
 }
+
 /**
   * Deletes a reconciliation order and all its associated order lines from the
  database.

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -32,8 +32,9 @@
 		const disposer1 = rx.onRange(["book"], () => invalidate("books:data"));
 		const disposer2 = rx.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
 		const disposer3 = rx.onRange(["customer_order_lines"], () => invalidate("customers:order_lines"));
+		const disposer4 = rx.onRange(["reconciliation_order"], () => invalidate("reconciliation:orders"));
 
-		disposer = () => (disposer1(), disposer2(), disposer3());
+		disposer = () => (disposer1(), disposer2(), disposer3(), disposer4());
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
@@ -8,6 +8,7 @@ export const load: PageLoad = async ({ depends, parent }) => {
 	depends("books:data");
 	depends("suppliers:data");
 	depends("customers:order_lines");
+	depends("reconciliation:orders");
 
 	const { dbCtx } = await parent();
 


### PR DESCRIPTION
This is a soft refactor of reconciliation e2e tests:
- makes sure we always click on same supplier order(s) when reconciling (independent of the order in which those are listed)
- asserts the lines (when scanning/comparing) in an order-agnostic way (similar to previous point)
- removes `firstOrder`, `secondOrder` and such...(using the particular matcher)

NOTE: As stated: this is a really soft refactor. It doesn't change the testing logic, unless absolutely necessary in order to make the tests not fail. I'm working on a continuation of this: refactoring the tests altogether - kinda like what we did for unit tests - make the tests make more sense, cover potential edge cases and so...
