### PR TITLE
refactor fixtures for modularity:

### DIFF
--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -136,7 +136,7 @@ testOrders("should delete books from a customer order", async ({ page, books }) 
 	await expect(firstRow.getByRole("cell", { name: books[0].isbn })).not.toBeVisible();
 });
 
-testOrders("should mark order lines as collected", async ({ page, customerOrderLines }) => {
+testOrders("should mark order lines as collected", async ({ page, collectCustomerOrderLine: customerOrderLines }) => {
 	await page.goto(`${baseURL}orders/customers/1/`);
 
 	const table = page.getByRole("table");


### PR DESCRIPTION
* separate out 'suppliersWithPublishers' fixture
* separate out 'customerOrderLines' (depending on customers and providing order lines for further fixtures)
* move (old) 'customerOrderLines' -> 'collectCustomerOrderLine' (fixture used for only one test), TODO: revisit this
* update comments on fixtures to include ONLY the data returned from the fixture and list all dependencies of the fixture (as state we can count on when running)

A step towards more modular fixtures (see commit message above). I needed this for further tests, but this should be revisited/enhanced.

I will merge this in as soon as green as it doesn't introduce breaking changes and some later work depends on it.
