### PR TITLE
enhance: focus isbn field after scanning in orders UI:

### DIFF
--- a/apps/web-client/src/lib/forms/DaisyUIScannerForm.svelte
+++ b/apps/web-client/src/lib/forms/DaisyUIScannerForm.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { defaults } from "sveltekit-superforms";
+	import type { FormOptions } from "sveltekit-superforms";
+	import { superForm } from "sveltekit-superforms/client";
+
+	import { scannerSchema, type ScannerSchema } from "$lib/forms/schemas";
+	import { zod } from "sveltekit-superforms/adapters";
+	import { QrCode } from "lucide-svelte";
+
+	export let onSubmit: (isbn: string) => void | Promise<void>;
+
+	let input: HTMLInputElement | undefined = undefined;
+
+	const form = superForm(defaults(zod(scannerSchema)), {
+		SPA: true,
+		validators: zod(scannerSchema),
+		validationMethod: "submit-only",
+
+		onUpdate: async ({ form: { data, valid } }) => {
+			// scannerSchema defines isbn minLength as 1, so it will be invalid if "" is entered
+			if (valid) {
+				await Promise.resolve(onSubmit(data.isbn));
+			}
+		},
+		onUpdated: () => {
+			// Why the promise with 0 timeout works, and not tick().then(), nor direct (sync) input.focus() is beyond me,
+			// but it was proved to be so (manually testing)...
+			setTimeout(() => input.focus(), 0);
+		}
+	});
+
+	const { form: formStore, enhance } = form;
+</script>
+
+<form use:enhance method="POST" class="flex w-full gap-2">
+	<label class="input-bordered input flex flex-1 items-center gap-2">
+		<QrCode />
+		<input
+			bind:this={input}
+			name="isbn"
+			type="text"
+			class="grow"
+			bind:value={$formStore.isbn}
+			placeholder="Enter ISBN of delivered books"
+			required
+			autocomplete="off"
+		/>
+	</label>
+</form>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -26,7 +26,6 @@
 	import { OrderLineStatus, type Customer } from "$lib/db/cr-sqlite/types";
 	import { PopoverWrapper, Dialog } from "$lib/components";
 
-	import { getCustomerOrderLines } from "$lib/db/cr-sqlite/customers";
 	import type { PageData } from "./$types";
 
 	import { type DialogContent, dialogTitle, dialogDescription } from "$lib/dialogs";
@@ -53,6 +52,7 @@
 	import { scannerSchema } from "$lib/forms/schemas";
 
 	import { mergeBookData } from "$lib/utils/misc";
+	import DaisyUiScannerForm from "$lib/forms/DaisyUIScannerForm.svelte";
 
 	// import { createIntersectionObserver } from "$lib/actions";
 
@@ -169,28 +169,7 @@
 		}
 	};
 
-	let scanInputRef: HTMLInputElement = null;
-
-	// TODO: We reuse the ScannerForm and setup across a few pages => good candidate for a component...
-	// It already exists as one but not with the new skin
-	const { form: formStore, enhance } = superForm(defaults(zod(scannerSchema)), {
-		SPA: true,
-		validators: zod(scannerSchema),
-		validationMethod: "submit-only",
-		onUpdate: async ({ form: { data, valid } }) => {
-			// scannerSchema defines isbn minLength as 1, so it will be invalid if "" is entered
-			if (valid) {
-				const { isbn } = data;
-
-				await addBooksToCustomer(db, customerId, [isbn]);
-			}
-		},
-		onUpdated: ({ form: { valid } }) => {
-			if (valid) {
-				scanInputRef?.focus();
-			}
-		}
-	});
+	const handleScanIsbn = (isbn: string) => addBooksToCustomer(db, customerId, [isbn]);
 
 	const dialog = createDialog({
 		forceVisible: true
@@ -290,19 +269,8 @@
 		<div class="mb-20 flex h-full w-full flex-col gap-y-6 md:overflow-y-auto">
 			<div class="prose flex w-full max-w-full flex-col gap-y-3 md:px-4">
 				<h3 class="max-md:divider-start max-md:divider">Books</h3>
-				<form class="flex w-full gap-2" use:enhance method="POST">
-					<label class="input-bordered input flex flex-1 items-center gap-2">
-						<QrCode />
-						<input
-							type="text"
-							class="grow"
-							bind:value={$formStore.isbn}
-							placeholder="Enter ISBN of delivered books"
-							required
-							bind:this={scanInputRef}
-						/>
-					</label>
-				</form>
+
+				<DaisyUiScannerForm onSubmit={handleScanIsbn} />
 			</div>
 
 			<div class="h-full overflow-x-auto">


### PR DESCRIPTION
* create DaisyUIScannerForm component - to house all styles and internal functionality of the scanner form
* make the component autofocus after submission
* use DAisyUIScannerForm in customers/:id view + simplify scanning data flows and submission handling
* use DAisyUIScannerForm in reconcile/:id view + simplify scanning data flows and submission handling

Fixes #855 
