### PR TITLE
Fix/note history null price crash

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/history.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/history.test.ts
@@ -69,6 +69,34 @@ describe("getPastNotes", () => {
 			})
 		]);
 	});
+
+	it("falls back to 0 for price calculation if no book data available", async () => {
+		const db = await getRandomDb();
+
+		// Set up warehouses
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+
+		// Create and commit notes
+		await createInboundNote(db, 1, 1);
+		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 5, warehouseId: 1 });
+		await commitNote(db, 1);
+
+		// NOTE: explicit SQL update -- I know, dirty, but making it easier to make assertions
+		await db.exec("UPDATE note SET committed_at = strftime('%s', '2024-01-02T10:00:00') * 1000 WHERE id = 1");
+
+		const [note] = await getPastNotes(db, "2024-01-02");
+
+		expect(note).toEqual(
+			expect.objectContaining({
+				id: 1,
+				noteType: "inbound",
+				totalBooks: 5,
+				warehouseName: "Warehouse 1",
+				totalCoverPrice: 0,
+				totalDiscountedPrice: 0
+			})
+		);
+	});
 });
 
 describe("getPastTransactions", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/history.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/history.test.ts
@@ -97,6 +97,41 @@ describe("getPastNotes", () => {
 			})
 		);
 	});
+
+	// Regression test -- missing LEFT JOIN (just JOIN) on book table would ommit txns with no book data from the
+	// total books count
+	it("falls back to 0 for price calculation and shows correct book count if no book data", async () => {
+		const db = await getRandomDb();
+
+		// Set up books
+		await upsertBook(db, { isbn: "1111111111", price: 10 });
+		// NOTE: not setting 2222222222
+
+		// Set up warehouses
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1", discount: 20 });
+
+		// Create and commit notes
+		await createInboundNote(db, 1, 1);
+		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 5, warehouseId: 1 });
+		await addVolumesToNote(db, 1, { isbn: "2222222222", quantity: 5, warehouseId: 1 });
+		await commitNote(db, 1);
+
+		// NOTE: explicit SQL update -- I know, dirty, but making it easier to make assertions
+		await db.exec("UPDATE note SET committed_at = strftime('%s', '2024-01-02T10:00:00') * 1000 WHERE id = 1");
+
+		const [note] = await getPastNotes(db, "2024-01-02");
+
+		expect(note).toEqual(
+			expect.objectContaining({
+				id: 1,
+				noteType: "inbound",
+				totalBooks: 10,
+				warehouseName: "Warehouse 1",
+				totalCoverPrice: 50,
+				totalDiscountedPrice: 40
+			})
+		);
+	});
 });
 
 describe("getPastTransactions", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/history.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/history.ts
@@ -40,8 +40,8 @@ export async function getPastNotes(db: DB, date: string): Promise<PastNoteItem[]
                     WHEN n.warehouse_id IS NOT NULL OR n.is_reconciliation_note = 1 THEN w.display_name
                     ELSE 'Outbound'
 				END AS warehouseName,
-                SUM(bt.quantity * b.price) AS totalCoverPrice,
-                SUM(bt.quantity * b.price * (1 - COALESCE(w.discount, 0) / 100.0)) AS totalDiscountedPrice,
+                SUM(bt.quantity * COALESCE(b.price,0)) AS totalCoverPrice,
+                SUM(bt.quantity * COALESCE(b.price,0) * (1 - COALESCE(w.discount, 0) / 100.0)) AS totalDiscountedPrice,
 				n.committed_at
             FROM note n
             JOIN book_transaction bt ON n.id = bt.note_id

--- a/apps/web-client/src/lib/db/cr-sqlite/history.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/history.ts
@@ -44,8 +44,8 @@ export async function getPastNotes(db: DB, date: string): Promise<PastNoteItem[]
                 SUM(bt.quantity * COALESCE(b.price,0) * (1 - COALESCE(w.discount, 0) / 100.0)) AS totalDiscountedPrice,
 				n.committed_at
             FROM note n
-            JOIN book_transaction bt ON n.id = bt.note_id
-            JOIN book b ON bt.isbn = b.isbn
+            LEFT JOIN book_transaction bt ON n.id = bt.note_id
+            LEFT JOIN book b ON bt.isbn = b.isbn
             LEFT JOIN warehouse w ON bt.warehouse_id = w.id
             WHERE DATE(n.committed_at / 1000, 'unixepoch') = ?
             GROUP BY n.id

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -26,7 +26,6 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	}
 
 	const notes = await getPastNotes(dbCtx.db, date);
-	console.log("got notes", JSON.stringify(notes));
 	return { date, dateValue, notes };
 };
 


### PR DESCRIPTION
Replaces #845
Fixes #803

Adds a unit test for #845 fix

Additionally, I realised that `getPastNotes` doesn't take lines containing ISBNs with no `book` table entry into account when counting `totalBookCount` so I've added a test + fix for that
