### PR TITLE
Feat/import export json

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -37,7 +37,7 @@ export async function loadData(db: DB, data: DatabaseDump): Promise<void> {
 		const stmt = [
 			`INSERT INTO ${table} (${keys.join(", ")}) VALUES`,
 			Array(rows.length).fill(placeholderLine).join(",\n"),
-			`ON CONFLICT SET ${keys.map((key) => `${key} = EXCLUDED.${key}`).join(", ")}`
+			`ON CONFLICT DO UPDATE SET ${keys.map((key) => `${key} = EXCLUDED.${key}`).join(", ")}`
 		].join("\n");
 
 		await db.exec(

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -1,0 +1,25 @@
+import { wrapIter } from "@librocco/shared";
+import type { DB, DatabaseDump } from "./types";
+
+export async function dumpData(db: DB): Promise<DatabaseDump> {
+	const tableNames = wrapIter([
+		"customer",
+		"customer_order_lines",
+		"book",
+		"supplier",
+		"supplier_publisher",
+		"supplier_order",
+		"supplier_order_line",
+		"reconciliation_order",
+		"reconciliation_order_lines",
+		"customer_order_line_supplier_order",
+		"warehouse",
+		"note",
+		"book_transaction",
+		"custom_item"
+	]);
+
+	const tableDumps = await Promise.all(tableNames.map((table) => db.execO(`SELECT * FROM ${table}`)));
+
+	return Object.fromEntries(tableNames.zip(tableDumps)) as DatabaseDump;
+}

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -333,3 +333,131 @@ export type Change = readonly [
 
 /* Utils */
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+// #region table entries
+export type CustomerTableEntry = {
+	id: number;
+	display_id: string | null;
+	fullname: string | null;
+	email: string | null;
+	deposit: number | null;
+	updated_at: number;
+};
+
+export type CustomerOrderLinesTableEntry = {
+	id: number;
+	customer_id: number | null;
+	isbn: string | null;
+	created: number;
+	placed: number | null;
+	received: number | null;
+	collected: number | null;
+};
+
+export type BookTableEntry = {
+	isbn: string;
+	title: string | null;
+	authors: string | null;
+	price: number | null;
+	year: string | null;
+	publisher: string | null;
+	edited_by: string | null;
+	out_of_print: number | null;
+	category: string | null;
+	updated_at: number | null;
+};
+
+export type SupplierTableEntry = {
+	id: number;
+	name: string | null;
+	email: string | null;
+	address: string | null;
+};
+
+export type SupplierPublisherTableEntry = {
+	supplier_id: number;
+	publisher: string;
+};
+
+export type SupplierOrderTableEntry = {
+	id: number;
+	supplier_id: number;
+	created: number;
+};
+
+export type SupplierOrderLineTableEntry = {
+	supplier_order_id: number;
+	isbn: string;
+	quantity: number;
+};
+
+export type ReconciliationOrderTableEntry = {
+	id: number;
+	supplier_order_ids: string;
+	created: number;
+	updatedAt: number;
+	finalized: number;
+};
+
+export type ReconciliationOrderLineTableEntry = {
+	reconciliation_order_id: number;
+	isbn: string;
+	quantity: number;
+};
+
+export type CustomerOrderLineSupplierOrderTableEntry = {
+	supplier_order_id: number;
+	customer_order_line_id: number;
+	placed: number;
+};
+
+export type WarehouseTableEntry = {
+	id: number;
+	display_name: string | null;
+	discount: number | null;
+};
+
+export type NoteTableEntry = {
+	id: number;
+	display_name: string | null;
+	warehouse_id: number | null;
+	is_reconciliation_note: number | null;
+	default_warehouse: number | null;
+	updated_at: number;
+	committed: number;
+	committed_at: number | null;
+};
+
+export type BookTransactionTableEntry = {
+	isbn: string;
+	quantity: number;
+	note_id: number;
+	warehouse_id: number;
+	updated_at: number;
+	committed_at: number | null;
+};
+
+export type CustomItemTableEntry = {
+	id: number;
+	title: string | null;
+	price: number | null;
+	note_id: number;
+	updated_at: number | null;
+};
+
+export type DatabaseDump = {
+	customer: CustomerTableEntry[];
+	customer_order_lines: CustomerOrderLinesTableEntry[];
+	book: BookTableEntry[];
+	supplier: SupplierTableEntry[];
+	supplier_publisher: SupplierPublisherTableEntry[];
+	supplier_order: SupplierOrderTableEntry[];
+	supplier_order_line: SupplierOrderLineTableEntry[];
+	reconciliation_order: ReconciliationOrderTableEntry[];
+	reconciliation_order_line: ReconciliationOrderLineTableEntry[];
+	customer_order_line_supplier_order: CustomerOrderLineSupplierOrderTableEntry[];
+	warehouse: WarehouseTableEntry[];
+	note: NoteTableEntry[];
+	book_transaction: BookTransactionTableEntry[];
+	custom_item: CustomItemTableEntry[];
+};

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { onMount } from "svelte";
-	import { fade } from "svelte/transition";
-	import { get } from "svelte/store";
-	import { Search, Download, Trash } from "lucide-svelte";
-	import { createDialog, melt } from "@melt-ui/svelte";
+	import { Search } from "lucide-svelte";
 	import { zod } from "sveltekit-superforms/adapters";
+	import { Download } from "lucide-svelte";
 
-	import { testId, addSQLite3Suffix } from "@librocco/shared";
+	import { testId } from "@librocco/shared";
 
 	import type { PageData } from "./$types";
 
@@ -14,17 +11,17 @@
 
 	import { dbid, syncConfig, syncActive } from "$lib/db";
 
-	import { DeviceSettingsForm, SyncSettingsForm, DatabaseDeleteForm, databaseCreateSchema, DatabaseCreateForm } from "$lib/forms";
+	import { DeviceSettingsForm, SyncSettingsForm } from "$lib/forms";
 	import { deviceSettingsSchema, syncSettingsSchema } from "$lib/forms/schemas";
 	import { Page, ExtensionAvailabilityToast } from "$lib/components";
 
-	import { dialogDescription, dialogTitle, type DialogContent } from "$lib/dialogs";
-
 	import { VERSION } from "$lib/constants";
 	import { goto } from "$lib/utils/navigation";
-	import { invalidateAll } from "$app/navigation";
+
 	import { deviceSettingsStore } from "$lib/stores/app";
+
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { dumpData, loadData } from "$lib/db/cr-sqlite/import_export";
 
 	export let data: PageData;
 
@@ -32,30 +29,16 @@
 
 	$: plugins = data.plugins;
 
-	// #region files list
-	let files: string[] = [];
+	// NOTE: This is TEMP until we implement DB selection functionality
+	$: files = [$dbid];
 
-	const getFiles = async () => {
-		return window.navigator.storage.getDirectory().then(async (dir) => {
-			const files = [] as string[];
-			for await (const [name] of (dir as any).entries() as AsyncIterableIterator<[string, FileSystemHandle]>) {
-				// We're interested only in .sqlite3 files
-				if (name.endsWith(".sqlite3")) {
-					files.push(name);
-				}
-			}
-			return files;
-		});
-	};
-
-	onMount(async () => {
-		files = await getFiles();
-	});
-
-	// #region import control
+	// #region import/export
 	let importOn = false;
-
 	const toggleImport = () => (importOn = !importOn);
+
+	const handleDragOver = (event: DragEvent) => {
+		event.preventDefault();
+	};
 
 	const handleDrop = async (event: DragEvent) => {
 		event.preventDefault();
@@ -64,56 +47,32 @@
 				const item = event.dataTransfer.items[i];
 				if (item.kind === "file") {
 					const file = item.getAsFile();
-					if (file && file.name.endsWith(".sqlite3")) {
-						await importDatabase(file);
+					if (file && file.name.endsWith(".json")) {
+						await handleImportData(file);
 					}
 				}
 			}
 		} else if (event.dataTransfer?.files) {
 			for (let i = 0; i < event.dataTransfer.files.length; i++) {
 				const file = event.dataTransfer.files[i];
-				if (file && file.name.endsWith(".sqlite3")) {
-					await importDatabase(file);
+				if (file && file.name.endsWith(".json")) {
+					await handleImportData(file);
 				}
 			}
 		}
-		files = await getFiles();
 		importOn = false;
 	};
 
-	const handleDragOver = (event: DragEvent) => {
-		event.preventDefault();
+	const handleImportData = async (file: File) => {
+		const data = JSON.parse(await file.text());
+		await loadData(db, data);
 	};
 
-	const importDatabase = async (file: File) => {
-		const dir = await window.navigator.storage.getDirectory();
-		const fileHandle = await dir.getFileHandle(file.name, { create: true });
-		const writable = await fileHandle.createWritable();
-		await writable.write(await file.arrayBuffer());
-		await writable.close();
-		await handleSelect(file.name)();
-	};
-
-	// #region select db control
-	let selectionOn = false;
-	const toggleSelection = () => (selectionOn = !selectionOn);
-	// TODO: This used the old functionality and currently doesn't work, revisit
-	const handleSelect = (name: string) => async () => {
-		// Persist the selection
-		dbid.set(name);
-		// Reset the db (allowing the root load function to reinstantiate the db)
-		// resetDB();
-		// Recalculate the data from root load down
-		await invalidateAll();
-		// Close the modal
-		selectionOn = false;
-	};
-
-	// #region db operations
 	const handleExportDatabase = (name: string) => async () => {
-		const dir = await window.navigator.storage.getDirectory();
-		const file = await dir.getFileHandle(name);
-		const blob = await file.getFile();
+		// Create a blob of JSON data
+		const data = await dumpData(db);
+		const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
+
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement("a");
 		a.href = url;
@@ -122,36 +81,7 @@
 		URL.revokeObjectURL(url);
 		document.removeChild(a);
 	};
-
-	const handleCreateDatabase = async (name: string) => {
-		await handleSelect(name)();
-		open.set(false);
-		files = await getFiles();
-	};
-
-	const handleDeleteDatabase = (name: string) => async () => {
-		const dir = await window.navigator.storage.getDirectory();
-		await dir.removeEntry(name);
-		files = await getFiles();
-
-		// If we've just deleted the current database, select the first one in the list
-		if (!files.includes(addSQLite3Suffix(get(dbid)))) {
-			await handleSelect(files[0] || "dev")(); // If this was the last file, create a new (default) db
-		}
-
-		open.set(false);
-		deleteDatabase = null;
-	};
-
-	// #region dialog
-	const dialog = createDialog({ forceVisible: true });
-	const {
-		elements: { portalled, overlay, trigger, title, description, content },
-		states: { open }
-	} = dialog;
-	let deleteDatabase = { name: "" };
-
-	let dialogContent: (DialogContent & { type: "create" | "delete" }) | null = null;
+	// #endregion import/export
 
 	/**
 	 * Handle create note is an `on:click` handler used to create a new outbound note
@@ -214,59 +144,22 @@
 					<ul data-testid={testId("database-management-list")} class="h-[240px] w-full overflow-y-auto overflow-x-hidden border">
 						{#if !importOn}
 							{#each files as file (file)}
-								{@const active = addSQLite3Suffix(file) === addSQLite3Suffix($dbid)}
-								{#if selectionOn}
-									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<li
-										on:click={handleSelect(file)}
-										data-active={active}
-										class="group flex h-16 cursor-pointer items-center justify-between px-4 py-3 {active
-											? 'bg-green-300'
-											: 'hover:bg-gray-50'}"
-									>
-										<span>{file}</span>
-									</li>
-								{:else}
-									<li
-										data-file={file}
-										data-active={active}
-										class="group flex h-16 items-center justify-between px-4 py-3 {active ? 'bg-gray-100' : ''}"
-									>
-										<span>{file}</span>
-										<div class="hidden gap-x-2 group-hover:flex">
-											<button
-												data-testid={testId("db-action-export")}
-												on:click={handleExportDatabase(file)}
-												type="button"
-												class="button cursor-pointer"><Download /></button
-											>
-											<button
-												data-testid={testId("db-action-delete")}
-												use:melt={$trigger}
-												on:m-click={() => {
-													deleteDatabase = { name: file };
-													dialogContent = {
-														onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-														title: dialogTitle.delete(file),
-														description: dialogDescription.deleteDatabase(),
-														type: "delete"
-													};
-												}}
-												on:m-keydown={() => {
-													deleteDatabase = { name: file };
-													dialogContent = {
-														onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-														title: dialogTitle.delete(file),
-														description: dialogDescription.deleteDatabase(),
-														type: "delete"
-													};
-												}}
-												type="button"
-												class="button cursor-pointer"><Trash /></button
-											>
-										</div>
-									</li>
-								{/if}
+								{@const active = true}
+								<li
+									data-file={file}
+									data-active={active}
+									class="group flex h-16 items-center justify-between px-4 py-3 {active ? 'bg-gray-100' : ''}"
+								>
+									<span>{file}</span>
+									<div class="hidden gap-x-2 group-hover:flex">
+										<button
+											data-testid={testId("db-action-export")}
+											on:click={handleExportDatabase(file)}
+											type="button"
+											class="button cursor-pointer"><Download /></button
+										>
+									</div>
+								</li>
 							{/each}
 						{:else}
 							<div
@@ -285,28 +178,6 @@
 						<button on:click={toggleImport} type="button" class="button button-white">
 							{importOn ? "Cancel" : "Import"}
 						</button>
-						<button on:click={toggleSelection} type="button" class="button {!selectionOn ? 'button-white' : 'button-green'}">Select</button>
-						<button
-							use:melt={$trigger}
-							on:m-click={() => {
-								dialogContent = {
-									onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-									title: dialogTitle.createDatabase(),
-									description: dialogDescription.createDatabase(),
-									type: "create"
-								};
-							}}
-							on:m-keydown={() => {
-								dialogContent = {
-									onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-									title: dialogTitle.createDatabase(),
-									description: dialogDescription.createDatabase(),
-									type: "create"
-								};
-							}}
-							type="button"
-							class="button button-green">New</button
-						>
 					</div>
 				</div>
 			</div>
@@ -340,52 +211,3 @@
 		<ExtensionAvailabilityToast {plugins} />
 	</svelte:fragment>
 </Page>
-
-{#if $open}
-	{@const { type, title: dialogTitle, description: dialogDescription } = dialogContent};
-
-	<div use:melt={$portalled}>
-		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }}></div>
-
-		{#if type === "create"}
-			<div
-				class="fixed left-[50%] top-[50%] z-50 flex max-w-2xl translate-x-[-50%] translate-y-[-50%] flex-col gap-y-8 rounded-md bg-white px-4 py-6"
-				use:melt={$content}
-			>
-				<h2 class="sr-only" use:melt={$title}>
-					{dialogTitle}
-				</h2>
-				<p class="sr-only" use:melt={$description}>
-					{dialogDescription}
-				</p>
-				<DatabaseCreateForm
-					options={{
-						SPA: true,
-						dataType: "json",
-						validators: zod(databaseCreateSchema),
-						validationMethod: "submit-only",
-						onUpdated: ({ form }) => handleCreateDatabase(form?.data?.name)
-					}}
-					onCancel={() => open.set(false)}
-				/>
-			</div>
-		{:else if type === "delete"}
-			<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-				<DatabaseDeleteForm
-					{dialog}
-					{dialogTitle}
-					{dialogDescription}
-					name={deleteDatabase.name}
-					options={{
-						SPA: true,
-						dataType: "json",
-						validationMethod: "submit-only",
-						onSubmit: handleDeleteDatabase(deleteDatabase.name)
-					}}
-				/>
-			</div>
-		{:else}
-			<!---->
-		{/if}
-	</div>
-{/if}


### PR DESCRIPTION
Fixes #880 

The settings page UI is under construction somewhat:
- the old DB management section is used, with the subset of functionality
- the list of DBs shows only the current DB (with selection disabled) - this is a TODO for a later date
- there's no DB delete functionality - this is a TODO for a later date
- to "import" the DB, click 'Import' and drag the `json` file to the drop area
- to "export" the DB, hover over the (only) DB line item (in DB selection area) and click the download button

NOTE: as #880 specifies, the DB is dumped in `json` format
NOTE: the "import"/"export" aren't full DB import/export, but rather data dumps:
- no schema is dumped
- no crsqlite data is dumped
- only the inserted data is dumped
- loading of the data doesn't create a new DB, but rather populates the existing one
- in case of conflict, the imported data takes precedence (`ON CONFLICT DO UPDATE SET '<column>' = excluded.<column>`)
