### PR TITLE
Feat/import export

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -37,7 +37,9 @@
 		"just-compare": "~2.3.0",
 		"nanoid": "^5.0.5",
 		"svelte-local-storage-store": "~0.6.4",
-		"typesafe-i18n": "~5.26.2"
+		"typesafe-i18n": "~5.26.2",
+		"json-bigint": "~1.0.0",
+		"@types/json-bigint": "~1.0.4"
 	},
 	"devDependencies": {
 		"@librocco/book-data-extension": "workspace:*",

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -1,5 +1,5 @@
 import { wrapIter } from "@librocco/shared";
-import type { DB, DatabaseDump } from "./types";
+import type { DB } from "./types";
 
 type SQLiteTableData = {
 	name: string;

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -37,7 +37,7 @@ export async function loadData(db: DB, data: DatabaseDump): Promise<void> {
 		const stmt = [
 			`INSERT INTO ${table} (${keys.join(", ")}) VALUES`,
 			Array(rows.length).fill(placeholderLine).join(",\n"),
-			`ON CONFLICT SET ${keys.map((key) => `${key} = EXCLUDED.${key}`).join(", ")}`
+			`ON CONFLICT DO UPDATE SET ${keys.map((key) => `${key} = EXCLUDED.${key}`).join(", ")}`
 		].join("\n");
 
 		await db.exec(

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -1,50 +1,76 @@
 import { wrapIter } from "@librocco/shared";
 import type { DB, DatabaseDump } from "./types";
 
+type SQLiteTableData = {
+	name: string;
+	rootpage: number;
+	sql: string;
+	tbl_name: string;
+	type: "table";
+};
+
+async function getTables(db: DB, as?: "full"): Promise<SQLiteTableData[]>;
+async function getTables(db: DB, as: "name_only"): Promise<string[]>;
+async function getTables(db: DB, as: "name_only" | "full" = "full"): Promise<SQLiteTableData[] | string[]> {
+	const cols = {
+		full: "*",
+		name_only: "name"
+	}[as];
+
+	const query = `
+		SELECT ${cols} FROM sqlite_master WHERE type = 'table' AND name NOT LIKE '%crsql%'
+	`;
+
+	const res = await db.execO<SQLiteTableData>(query);
+
+	if (as === "name_only") {
+		return res.map(({ name }) => name);
+	}
+
+	return res;
+}
+
+async function getTableData(db: DB, tableName: string): Promise<any[]> {
+	const query = `SELECT * FROM ${tableName}`;
+	const data = await db.execO(query);
+	return data;
+}
+
+async function getTablesData<T extends Record<string, Record<string, any>[]>>(db: DB, tableNames: string[]): Promise<T> {
+	const tables = wrapIter(tableNames);
+	const data = await Promise.all(tables.map((table) => getTableData(db, table)));
+	return Object.fromEntries(tables.zip(data)) as T;
+}
+
+async function sqlFromJSON(data: DatabaseDump): Promise<string> {
+	const tables = Object.entries(data);
+	const sql = tables.map(([table, rows]) => {
+		const keys = Object.keys(rows[0]);
+		const placeholderLine = `(${multiplyString("?", keys.length)})`;
+
+		return [
+			`INSERT INTO ${table} (${keys.join(", ")}) VALUES`,
+			Array(rows.length).fill(placeholderLine).join(",\n"),
+			`ON CONFLICT DO UPDATE SET ${keys.map((key) => `${key} = excluded.${key}`).join(", ")}`
+		].join("\n");
+	});
+
+	return sql.join("\n");
+}
+
 export async function dumpJSONData(db: DB): Promise<DatabaseDump> {
-	const tableNames = wrapIter([
-		"customer",
-		"customer_order_lines",
-		"book",
-		"supplier",
-		"supplier_publisher",
-		"supplier_order",
-		"supplier_order_line",
-		"reconciliation_order",
-		"reconciliation_order_lines",
-		"customer_order_line_supplier_order",
-		"warehouse",
-		"note",
-		"book_transaction",
-		"custom_item"
-	]);
+	const tableNames = await getTables(db, "name_only");
+	return getTablesData(db, tableNames);
+}
 
-	const tableDumps = await Promise.all(tableNames.map((table) => db.execO(`SELECT * FROM ${table}`)));
-
-	return Object.fromEntries(tableNames.zip(tableDumps)) as DatabaseDump;
+export async function dumpSQLData(db: DB): Promise<string> {
+	const data = await dumpJSONData(db);
+	return sqlFromJSON(data);
 }
 
 export async function loadJSONData(db: DB, data: DatabaseDump): Promise<void> {
-	for (const [table, rows] of Object.entries(data)) {
-		// Skip if empty
-		if (!rows.length) continue;
-
-		// Get column values
-		const keys = Object.keys(rows[0]);
-
-		const placeholderLine = `(${multiplyString("?", keys.length)})`;
-
-		const stmt = [
-			`INSERT INTO ${table} (${keys.join(", ")}) VALUES`,
-			Array(rows.length).fill(placeholderLine).join(",\n"),
-			`ON CONFLICT DO UPDATE SET ${keys.map((key) => `${key} = EXCLUDED.${key}`).join(", ")}`
-		].join("\n");
-
-		await db.exec(
-			stmt,
-			rows.flatMap((row: any) => Object.values(row) as any[])
-		);
-	}
+	const sql = await sqlFromJSON(data);
+	await db.exec(sql);
 }
 
 export const multiplyString = (str: string, n: number) => Array(n).fill(str).join(", ");

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -1,7 +1,7 @@
 import { wrapIter } from "@librocco/shared";
 import type { DB, DatabaseDump } from "./types";
 
-export async function dumpData(db: DB): Promise<DatabaseDump> {
+export async function dumpJSONData(db: DB): Promise<DatabaseDump> {
 	const tableNames = wrapIter([
 		"customer",
 		"customer_order_lines",
@@ -24,7 +24,7 @@ export async function dumpData(db: DB): Promise<DatabaseDump> {
 	return Object.fromEntries(tableNames.zip(tableDumps)) as DatabaseDump;
 }
 
-export async function loadData(db: DB, data: DatabaseDump): Promise<void> {
+export async function loadJSONData(db: DB, data: DatabaseDump): Promise<void> {
 	for (const [table, rows] of Object.entries(data)) {
 		// Skip if empty
 		if (!rows.length) continue;

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -24,7 +24,7 @@ async function getTables(db: DB, which: "user_only" | "full" = "full"): Promise<
 
 	const query = `
 		SELECT * FROM sqlite_master
-		WHERE type = 'table' ${filter && `AND ${filter}`}
+		WHERE type = 'table' ${filter ? `AND ${filter}` : ""}
 	`;
 
 	const res = await db.execO<SQLiteTableData>(query);

--- a/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/import_export.ts
@@ -1,0 +1,25 @@
+import { wrapIter } from "@librocco/shared";
+import type { DB, DatabaseDump } from "./types";
+
+export async function dumpData(db: DB): Promise<DatabaseDump> {
+	const tableNames = wrapIter([
+		"customer",
+		"customer_order_lines",
+		"book",
+		"supplier",
+		"supplier_publisher",
+		"supplier_order",
+		"supplier_order_line",
+		"reconciliation_order",
+		"reconciliation_order_lines",
+		"customer_order_line_supplier_order",
+		"warehouse",
+		"note",
+		"book_transaction",
+		"custom_item"
+	]);
+
+	const tableDumps = await Promise.all(tableNames.map((table) => db.execO(`SELECT * FROM ${table}`)));
+
+	return Object.fromEntries(tableNames.zip(tableDumps)) as DatabaseDump;
+}

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -333,3 +333,131 @@ export type Change = readonly [
 
 /* Utils */
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+// #region table entries
+export type CustomerTableEntry = {
+	id: number;
+	display_id: string | null;
+	fullname: string | null;
+	email: string | null;
+	deposit: number | null;
+	updated_at: number;
+};
+
+export type CustomerOrderLinesTableEntry = {
+	id: number;
+	customer_id: number | null;
+	isbn: string | null;
+	created: number;
+	placed: number | null;
+	received: number | null;
+	collected: number | null;
+};
+
+export type BookTableEntry = {
+	isbn: string;
+	title: string | null;
+	authors: string | null;
+	price: number | null;
+	year: string | null;
+	publisher: string | null;
+	edited_by: string | null;
+	out_of_print: number | null;
+	category: string | null;
+	updated_at: number | null;
+};
+
+export type SupplierTableEntry = {
+	id: number;
+	name: string | null;
+	email: string | null;
+	address: string | null;
+};
+
+export type SupplierPublisherTableEntry = {
+	supplier_id: number;
+	publisher: string;
+};
+
+export type SupplierOrderTableEntry = {
+	id: number;
+	supplier_id: number;
+	created: number;
+};
+
+export type SupplierOrderLineTableEntry = {
+	supplier_order_id: number;
+	isbn: string;
+	quantity: number;
+};
+
+export type ReconciliationOrderTableEntry = {
+	id: number;
+	supplier_order_ids: string;
+	created: number;
+	updatedAt: number;
+	finalized: number;
+};
+
+export type ReconciliationOrderLineTableEntry = {
+	reconciliation_order_id: number;
+	isbn: string;
+	quantity: number;
+};
+
+export type CustomerOrderLineSupplierOrderTableEntry = {
+	supplier_order_id: number;
+	customer_order_line_id: number;
+	placed: number;
+};
+
+export type WarehouseTableEntry = {
+	id: number;
+	display_name: string | null;
+	discount: number | null;
+};
+
+export type NoteTableEntry = {
+	id: number;
+	display_name: string | null;
+	warehouse_id: number | null;
+	is_reconciliation_note: number | null;
+	default_warehouse: number | null;
+	updated_at: number;
+	committed: number;
+	committed_at: number | null;
+};
+
+export type BookTransactionTableEntry = {
+	isbn: string;
+	quantity: number;
+	note_id: number;
+	warehouse_id: number;
+	updated_at: number;
+	committed_at: number | null;
+};
+
+export type CustomItemTableEntry = {
+	id: number;
+	title: string | null;
+	price: number | null;
+	note_id: number;
+	updated_at: number | null;
+};
+
+export type DatabaseDump = {
+	customer: CustomerTableEntry[];
+	customer_order_lines: CustomerOrderLinesTableEntry[];
+	book: BookTableEntry[];
+	supplier: SupplierTableEntry[];
+	supplier_publisher: SupplierPublisherTableEntry[];
+	supplier_order: SupplierOrderTableEntry[];
+	supplier_order_line: SupplierOrderLineTableEntry[];
+	reconciliation_order: ReconciliationOrderTableEntry[];
+	reconciliation_order_line: ReconciliationOrderLineTableEntry[];
+	customer_order_line_supplier_order: CustomerOrderLineSupplierOrderTableEntry[];
+	warehouse: WarehouseTableEntry[];
+	note: NoteTableEntry[];
+	book_transaction: BookTransactionTableEntry[];
+	custom_item: CustomItemTableEntry[];
+};

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -21,7 +21,7 @@
 	import { deviceSettingsStore } from "$lib/stores/app";
 
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
-	import { dumpData, loadData } from "$lib/db/cr-sqlite/import_export";
+	import { dumpJSONData, loadJSONData } from "$lib/db/cr-sqlite/import_export";
 
 	export let data: PageData;
 
@@ -65,12 +65,12 @@
 
 	const handleImportData = async (file: File) => {
 		const data = JSON.parse(await file.text());
-		await loadData(db, data);
+		await loadJSONData(db, data);
 	};
 
 	const handleExportDatabase = (name: string) => async () => {
 		// Create a blob of JSON data
-		const data = await dumpData(db);
+		const data = await dumpJSONData(db);
 		const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
 
 		const url = URL.createObjectURL(blob);

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { onMount } from "svelte";
-	import { fade } from "svelte/transition";
-	import { get } from "svelte/store";
-	import { Search, Download, Trash } from "lucide-svelte";
-	import { createDialog, melt } from "@melt-ui/svelte";
+	import { Search } from "lucide-svelte";
 	import { zod } from "sveltekit-superforms/adapters";
+	import { Download } from "lucide-svelte";
 
-	import { testId, addSQLite3Suffix } from "@librocco/shared";
+	import { testId } from "@librocco/shared";
 
 	import type { PageData } from "./$types";
 
@@ -14,17 +11,17 @@
 
 	import { dbid, syncConfig, syncActive } from "$lib/db";
 
-	import { DeviceSettingsForm, SyncSettingsForm, DatabaseDeleteForm, databaseCreateSchema, DatabaseCreateForm } from "$lib/forms";
+	import { DeviceSettingsForm, SyncSettingsForm } from "$lib/forms";
 	import { deviceSettingsSchema, syncSettingsSchema } from "$lib/forms/schemas";
 	import { Page, ExtensionAvailabilityToast } from "$lib/components";
 
-	import { dialogDescription, dialogTitle, type DialogContent } from "$lib/dialogs";
-
 	import { VERSION } from "$lib/constants";
 	import { goto } from "$lib/utils/navigation";
-	import { invalidateAll } from "$app/navigation";
+
 	import { deviceSettingsStore } from "$lib/stores/app";
+
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { dumpData, loadData } from "$lib/db/cr-sqlite/import_export";
 
 	export let data: PageData;
 
@@ -32,30 +29,16 @@
 
 	$: plugins = data.plugins;
 
-	// #region files list
-	let files: string[] = [];
+	// NOTE: This is TEMP until we implement DB selection functionality
+	$: files = [$dbid];
 
-	const getFiles = async () => {
-		return window.navigator.storage.getDirectory().then(async (dir) => {
-			const files = [] as string[];
-			for await (const [name] of (dir as any).entries() as AsyncIterableIterator<[string, FileSystemHandle]>) {
-				// We're interested only in .sqlite3 files
-				if (name.endsWith(".sqlite3")) {
-					files.push(name);
-				}
-			}
-			return files;
-		});
-	};
-
-	onMount(async () => {
-		files = await getFiles();
-	});
-
-	// #region import control
+	// #region import/export
 	let importOn = false;
-
 	const toggleImport = () => (importOn = !importOn);
+
+	const handleDragOver = (event: DragEvent) => {
+		event.preventDefault();
+	};
 
 	const handleDrop = async (event: DragEvent) => {
 		event.preventDefault();
@@ -64,56 +47,32 @@
 				const item = event.dataTransfer.items[i];
 				if (item.kind === "file") {
 					const file = item.getAsFile();
-					if (file && file.name.endsWith(".sqlite3")) {
-						await importDatabase(file);
+					if (file && file.name.endsWith(".json")) {
+						await handleImportData(file);
 					}
 				}
 			}
 		} else if (event.dataTransfer?.files) {
 			for (let i = 0; i < event.dataTransfer.files.length; i++) {
 				const file = event.dataTransfer.files[i];
-				if (file && file.name.endsWith(".sqlite3")) {
-					await importDatabase(file);
+				if (file && file.name.endsWith(".json")) {
+					await handleImportData(file);
 				}
 			}
 		}
-		files = await getFiles();
 		importOn = false;
 	};
 
-	const handleDragOver = (event: DragEvent) => {
-		event.preventDefault();
+	const handleImportData = async (file: File) => {
+		const data = JSON.parse(await file.text());
+		await loadData(db, data);
 	};
 
-	const importDatabase = async (file: File) => {
-		const dir = await window.navigator.storage.getDirectory();
-		const fileHandle = await dir.getFileHandle(file.name, { create: true });
-		const writable = await fileHandle.createWritable();
-		await writable.write(await file.arrayBuffer());
-		await writable.close();
-		await handleSelect(file.name)();
-	};
-
-	// #region select db control
-	let selectionOn = false;
-	const toggleSelection = () => (selectionOn = !selectionOn);
-	// TODO: This used the old functionality and currently doesn't work, revisit
-	const handleSelect = (name: string) => async () => {
-		// Persist the selection
-		dbid.set(name);
-		// Reset the db (allowing the root load function to reinstantiate the db)
-		// resetDB();
-		// Recalculate the data from root load down
-		await invalidateAll();
-		// Close the modal
-		selectionOn = false;
-	};
-
-	// #region db operations
 	const handleExportDatabase = (name: string) => async () => {
-		const dir = await window.navigator.storage.getDirectory();
-		const file = await dir.getFileHandle(name);
-		const blob = await file.getFile();
+		// Create a blob of JSON data
+		const data = await dumpData(db);
+		const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
+
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement("a");
 		a.href = url;
@@ -122,36 +81,7 @@
 		URL.revokeObjectURL(url);
 		document.removeChild(a);
 	};
-
-	const handleCreateDatabase = async (name: string) => {
-		await handleSelect(name)();
-		open.set(false);
-		files = await getFiles();
-	};
-
-	const handleDeleteDatabase = (name: string) => async () => {
-		const dir = await window.navigator.storage.getDirectory();
-		await dir.removeEntry(name);
-		files = await getFiles();
-
-		// If we've just deleted the current database, select the first one in the list
-		if (!files.includes(addSQLite3Suffix(get(dbid)))) {
-			await handleSelect(files[0] || "dev")(); // If this was the last file, create a new (default) db
-		}
-
-		open.set(false);
-		deleteDatabase = null;
-	};
-
-	// #region dialog
-	const dialog = createDialog({ forceVisible: true });
-	const {
-		elements: { portalled, overlay, trigger, title, description, content },
-		states: { open }
-	} = dialog;
-	let deleteDatabase = { name: "" };
-
-	let dialogContent: (DialogContent & { type: "create" | "delete" }) | null = null;
+	// #endregion import/export
 
 	/**
 	 * Handle create note is an `on:click` handler used to create a new outbound note
@@ -214,59 +144,22 @@
 					<ul data-testid={testId("database-management-list")} class="h-[240px] w-full overflow-y-auto overflow-x-hidden border">
 						{#if !importOn}
 							{#each files as file (file)}
-								{@const active = addSQLite3Suffix(file) === addSQLite3Suffix($dbid)}
-								{#if selectionOn}
-									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<li
-										on:click={handleSelect(file)}
-										data-active={active}
-										class="group flex h-16 cursor-pointer items-center justify-between px-4 py-3 {active
-											? 'bg-green-300'
-											: 'hover:bg-gray-50'}"
-									>
-										<span>{file}</span>
-									</li>
-								{:else}
-									<li
-										data-file={file}
-										data-active={active}
-										class="group flex h-16 items-center justify-between px-4 py-3 {active ? 'bg-gray-100' : ''}"
-									>
-										<span>{file}</span>
-										<div class="hidden gap-x-2 group-hover:flex">
-											<button
-												data-testid={testId("db-action-export")}
-												on:click={handleExportDatabase(file)}
-												type="button"
-												class="button cursor-pointer"><Download /></button
-											>
-											<button
-												data-testid={testId("db-action-delete")}
-												use:melt={$trigger}
-												on:m-click={() => {
-													deleteDatabase = { name: file };
-													dialogContent = {
-														onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-														title: dialogTitle.delete(file),
-														description: dialogDescription.deleteDatabase(),
-														type: "delete"
-													};
-												}}
-												on:m-keydown={() => {
-													deleteDatabase = { name: file };
-													dialogContent = {
-														onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-														title: dialogTitle.delete(file),
-														description: dialogDescription.deleteDatabase(),
-														type: "delete"
-													};
-												}}
-												type="button"
-												class="button cursor-pointer"><Trash /></button
-											>
-										</div>
-									</li>
-								{/if}
+								{@const active = true}
+								<li
+									data-file={file}
+									data-active={active}
+									class="group flex h-16 items-center justify-between px-4 py-3 {active ? 'bg-gray-100' : ''}"
+								>
+									<span>{file}</span>
+									<div class="hidden gap-x-2 group-hover:flex">
+										<button
+											data-testid={testId("db-action-export")}
+											on:click={handleExportDatabase(file)}
+											type="button"
+											class="button cursor-pointer"><Download /></button
+										>
+									</div>
+								</li>
 							{/each}
 						{:else}
 							<div
@@ -285,28 +178,6 @@
 						<button on:click={toggleImport} type="button" class="button button-white">
 							{importOn ? "Cancel" : "Import"}
 						</button>
-						<button on:click={toggleSelection} type="button" class="button {!selectionOn ? 'button-white' : 'button-green'}">Select</button>
-						<button
-							use:melt={$trigger}
-							on:m-click={() => {
-								dialogContent = {
-									onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-									title: dialogTitle.createDatabase(),
-									description: dialogDescription.createDatabase(),
-									type: "create"
-								};
-							}}
-							on:m-keydown={() => {
-								dialogContent = {
-									onConfirm: () => {}, // Note: confirm handler is called directly from the form element
-									title: dialogTitle.createDatabase(),
-									description: dialogDescription.createDatabase(),
-									type: "create"
-								};
-							}}
-							type="button"
-							class="button button-green">New</button
-						>
 					</div>
 				</div>
 			</div>
@@ -340,52 +211,3 @@
 		<ExtensionAvailabilityToast {plugins} />
 	</svelte:fragment>
 </Page>
-
-{#if $open}
-	{@const { type, title: dialogTitle, description: dialogDescription } = dialogContent};
-
-	<div use:melt={$portalled}>
-		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }}></div>
-
-		{#if type === "create"}
-			<div
-				class="fixed left-[50%] top-[50%] z-50 flex max-w-2xl translate-x-[-50%] translate-y-[-50%] flex-col gap-y-8 rounded-md bg-white px-4 py-6"
-				use:melt={$content}
-			>
-				<h2 class="sr-only" use:melt={$title}>
-					{dialogTitle}
-				</h2>
-				<p class="sr-only" use:melt={$description}>
-					{dialogDescription}
-				</p>
-				<DatabaseCreateForm
-					options={{
-						SPA: true,
-						dataType: "json",
-						validators: zod(databaseCreateSchema),
-						validationMethod: "submit-only",
-						onUpdated: ({ form }) => handleCreateDatabase(form?.data?.name)
-					}}
-					onCancel={() => open.set(false)}
-				/>
-			</div>
-		{:else if type === "delete"}
-			<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-				<DatabaseDeleteForm
-					{dialog}
-					{dialogTitle}
-					{dialogDescription}
-					name={deleteDatabase.name}
-					options={{
-						SPA: true,
-						dataType: "json",
-						validationMethod: "submit-only",
-						onSubmit: handleDeleteDatabase(deleteDatabase.name)
-					}}
-				/>
-			</div>
-		{:else}
-			<!---->
-		{/if}
-	</div>
-{/if}

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -65,12 +65,12 @@
 
 	const handleImportData = async (file: File) => {
 		const data = JSON.parse(await file.text());
-		await loadJSONData(db, data);
+		await loadJSONData(db, data, "data_only");
 	};
 
 	const handleExportDatabase = (name: string) => async () => {
 		// Create a blob of JSON data
-		const data = await dumpJSONData(db);
+		const data = await dumpJSONData(db, "user_only");
 		const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
 
 		const url = URL.createObjectURL(blob);

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -180,7 +180,7 @@
 								aria-label="Drop zone"
 								on:dragover={handleDragOver}
 							>
-								<p>Drag and drop your .sqlite3 file here to import</p>
+								<p>Drag and drop your .json or .sql file here to import</p>
 							</div>
 						{/if}
 					</ul>

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
 
   ../../apps/web-client:
     dependencies:
+      '@types/json-bigint':
+        specifier: ~1.0.4
+        version: 1.0.4
       '@vlcn.io/crsqlite-wasm':
         specifier: 0.16.0
         version: 0.16.0
@@ -70,6 +73,9 @@ importers:
       export-to-csv:
         specifier: ~1.3.0
         version: 1.3.0
+      json-bigint:
+        specifier: ~1.0.0
+        version: 1.0.0
       just-compare:
         specifier: ~2.3.0
         version: 2.3.0
@@ -343,7 +349,7 @@ importers:
         version: 5.8.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.11(@types/node@16.18.126)
+        version: 6.0.11(tsx@4.19.3)
 
   ../../pkg/scaffold:
     dependencies:
@@ -434,10 +440,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.11(@types/node@16.18.126)
+        version: 6.0.11(tsx@4.19.3)
       vitest:
         specifier: ~3.0.4
-        version: 3.0.9(@vitest/ui@3.0.9)
+        version: 3.0.9(@vitest/browser@3.0.9)(@vitest/ui@3.0.9)(tsx@4.19.3)
 
   ../../plugins/book-data-extension:
     devDependencies:
@@ -524,7 +530,7 @@ importers:
         version: 5.8.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.11(@types/node@16.18.126)
+        version: 6.0.11(tsx@4.19.3)
 
   ../../plugins/open-library-api:
     devDependencies:
@@ -554,7 +560,7 @@ importers:
         version: 5.8.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.11(@types/node@16.18.126)
+        version: 6.0.11(tsx@4.19.3)
 
 packages:
 
@@ -3854,6 +3860,10 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@types/json-bigint@1.0.4:
+    resolution: {integrity: sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==}
+    dev: false
+
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
@@ -4522,7 +4532,7 @@ packages:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@vitest/browser@3.0.9)(@vitest/ui@3.0.9)(tsx@4.19.3)
+      vitest: 3.0.9(@vitest/ui@3.0.9)
     dev: true
 
   /@vitest/utils@2.0.5:
@@ -5170,6 +5180,10 @@ packages:
       bindings: 1.5.0
       prebuild-install: 7.1.3
     dev: true
+
+  /bignumber.js@9.2.0:
+    resolution: {integrity: sha512-JocpCSOixzy5XFJi2ub6IMmV/G9i8Lrm2lZvwBv9xPdglmZM0ufDVBbjbrfU/zuLvBfD7Bv2eYxz9i+OHTgkew==}
+    dev: false
 
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -8579,6 +8593,12 @@ packages:
     hasBin: true
     dev: true
 
+  /json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+    dependencies:
+      bignumber.js: 9.2.0
+    dev: false
+
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -11723,31 +11743,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite-node@3.0.9:
-    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 2.0.3
-      vite: 6.0.11(@types/node@16.18.126)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-    dev: true
-
   /vite-node@3.0.9(@types/node@16.18.126):
     resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -12081,8 +12076,8 @@ packages:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@16.18.126)
-      vite-node: 3.0.9
+      vite: 6.0.11(tsx@4.19.3)
+      vite-node: 3.0.9(tsx@4.19.3)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "171ccc20949833f7cfc2eeef70c70466868b2a46",
+  "pnpmShrinkwrapHash": "6ce0b1b6f70e3230dc394448221244079398a8b2",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
Includes #883 
Fixes #885 

Both formats are kept (json and sql).
There are two buttons: one for json, one for sql export

The import/export functions accept additional options (for future use):
- dump only user data (tables) or full (including crsql master, etc.)
- when constructing sql (either loading json, or constructing sql dump): it could include schema definitions or data-only

Currently wired in import/export dumps user only data and loads data only (to an existing DB). The rest of the functionality is preparation for full DB imports