### PR TITLE
sync server url defaults to 'ws://<hostname>:<port>/sync'

### DIFF
--- a/apps/web-client/src/lib/db/index.ts
+++ b/apps/web-client/src/lib/db/index.ts
@@ -1,11 +1,13 @@
+import { derived, get as get, type Writable } from "svelte/store";
+import { persisted } from "svelte-local-storage-store";
+import { browser } from "$app/environment";
+
 import type { SyncConfig } from "./sync";
 export * from "./sync";
 
-import { derived, get as get, type Writable } from "svelte/store";
-import { persisted } from "svelte-local-storage-store";
-
 export const dbid = persisted("librocco-current-db", "dev");
-const url = persisted("librocco-sync-url", "");
+
+const url = persisted("librocco-sync-url", browser ? `ws://${window.location.host}/sync` : "");
 
 export const syncActive = persisted("librocco-sync-active", false);
 

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -197,6 +197,8 @@
 							onUpdated: ({ form: { data, valid } }) => {
 								if (valid) {
 									syncConfig.set(data);
+									// Invalidating all in order to refresh the form data (done within the load function)
+									invalidateAll();
 								}
 							}
 						}}
@@ -327,6 +329,8 @@
 							onUpdated: ({ form: { data, valid } }) => {
 								if (valid) {
 									deviceSettingsStore.set(data);
+									// Invalidating all in order to refresh the form data (done within the load function)
+									invalidateAll();
 								}
 							}
 						}}


### PR DESCRIPTION
Fixes #894 
Falls back to `ws://<hostname>:<port>/sync` though (not `https://`)
