### PR TITLE
Feat/fn timer

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/customers.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/customers.ts
@@ -39,6 +39,8 @@ import {
 	type CustomerOrderLineHistory
 } from "./types";
 
+import { timed } from "$lib/utils/timer";
+
 /**
  * Creates a new customer or updates an existing one.
  * Uses customer ID as the unique identifier for upsert operations.
@@ -49,7 +51,7 @@ import {
  * @param {Customer} customer - Customer data
  * @throws {Error} If customer ID is not provided
  */
-export async function upsertCustomer(db: DB, customer: Omit<Customer, "updatedAt">) {
+async function _upsertCustomer(db: DB, customer: Omit<Customer, "updatedAt">) {
 	if (!customer.id) {
 		throw new Error("Customer must have an id");
 	}
@@ -145,7 +147,7 @@ const unmarshallCustomerOrder = ({ updated_at, ...customer }: DBCustomer): Custo
  * @param {DB} db - Database connection
  * @returns {Promise<CustomerOrderListItem[]>} Array of customers
  */
-export async function getCustomerOrderList(db: DB): Promise<CustomerOrderListItem[]> {
+async function _getCustomerOrderList(db: DB): Promise<CustomerOrderListItem[]> {
 	const orderLineStatusQuery = `
 		SELECT
 			customer_id,
@@ -302,7 +304,7 @@ export const unmarshalCustomerOrderLine = (line: DBCustomerOrderLine): CustomerO
  * Retrieves a history entries for each time a particular customer order line had been placed with a supplier.
  * TODO: history is the best I cound come up with in terms of nomenclature, maybe revisit
  */
-export async function getCustomerOrderLineHistory(db: DB, lineId: number): Promise<CustomerOrderLineHistory[]> {
+async function _getCustomerOrderLineHistory(db: DB, lineId: number): Promise<CustomerOrderLineHistory[]> {
 	const query = `
 		SELECT
 			supplier_order_id AS supplierOrderId,
@@ -356,3 +358,6 @@ export const markCustomerOrderLinesAsCollected = async (db: DB, ids: number[]): 
 		[timestamp, ...ids]
 	);
 };
+export const upsertCustomer = timed(_upsertCustomer);
+export const getCustomerOrderList = timed(_getCustomerOrderList);
+export const getCustomerOrderLineHistory = timed(_getCustomerOrderLineHistory);

--- a/apps/web-client/src/lib/db/cr-sqlite/history.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/history.ts
@@ -17,6 +17,8 @@
 
 import type { DB, PastNoteItem, PastTransactionItem, NoteType } from "./types";
 
+import { timed } from "$lib/utils/timer";
+
 /**
  * Retrieves all committed notes for a specific date.
  * Includes summary information like total books and pricing.
@@ -26,7 +28,7 @@ import type { DB, PastNoteItem, PastTransactionItem, NoteType } from "./types";
  * @param {string} date - Date to query in YYYY-MM-DD format
  * @returns {Promise<PastNoteItem[]>} Committed notes
  */
-export async function getPastNotes(db: DB, date: string): Promise<PastNoteItem[]> {
+async function _getPastNotes(db: DB, date: string): Promise<PastNoteItem[]> {
 	const query = `
             SELECT
                 n.id,
@@ -87,7 +89,7 @@ type Params = {
  * @param {Params} params - Query filters
  * @returns {Promise<PastTransactionItem[]>} Historical transactions
  */
-export async function getPastTransactions(db: DB, params: Params): Promise<PastTransactionItem[]> {
+async function _getPastTransactions(db: DB, params: Params): Promise<PastTransactionItem[]> {
 	const { isbn, warehouseId, startDate, endDate, noteType } = params;
 	const conditions = [];
 	const values = [];
@@ -149,3 +151,5 @@ export async function getPastTransactions(db: DB, params: Params): Promise<PastT
 
 	return res.map(({ committed_at, ...txn }) => ({ ...txn, committedAt: new Date(committed_at) }));
 }
+export const getPastNotes = timed(_getPastNotes);
+export const getPastTransactions = timed(_getPastTransactions);

--- a/apps/web-client/src/lib/db/cr-sqlite/stock.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock.ts
@@ -20,6 +20,8 @@
 
 import type { DB, GetStockResponseItem } from "./types";
 
+import { timed } from "$lib/utils/timer";
+
 /**
  * Parameters for filtering stock queries
  */
@@ -49,7 +51,7 @@ type GetStockParams = {
  *   - warehouseName: Human readable warehouse name
  *   - Book metadata: title, price, year, authors, etc
  */
-export async function getStock(
+async function _getStock(
 	db: DB,
 	{ searchString = "", entries = [], isbns = [], warehouseId }: GetStockParams = {}
 ): Promise<GetStockResponseItem[]> {
@@ -106,3 +108,4 @@ export async function getStock(
 	const res = await db.execO<Omit<GetStockResponseItem, "outOfPrint"> & { out_of_print: number }>(query, filterValues);
 	return res.map(({ out_of_print, ...rest }) => ({ outOfPrint: !!out_of_print, ...rest }));
 }
+export const getStock = timed(_getStock);

--- a/apps/web-client/src/lib/db/cr-sqlite/suppliers.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/suppliers.ts
@@ -9,6 +9,8 @@ import type {
 	DBPlacedSupplierOrderLine
 } from "./types";
 
+import { timed } from "$lib/utils/timer";
+
 /**
  * @fileoverview Supplier order management system
  *
@@ -35,7 +37,7 @@ import type {
  * @param db - The database instance to query
  * @returns Promise resolving to an array of suppliers with their basic info
  */
-export async function getAllSuppliers(db: DB): Promise<SupplierExtended[]> {
+async function _getAllSuppliers(db: DB): Promise<SupplierExtended[]> {
 	const query = `
 		SELECT
 			supplier.id,
@@ -61,7 +63,7 @@ export async function getAllSuppliers(db: DB): Promise<SupplierExtended[]> {
  * @param db - The database instance to query
  * @param id - supplier id
  */
-export async function getSupplierDetails(db: DB, id: number): Promise<SupplierExtended | undefined> {
+async function _getSupplierDetails(db: DB, id: number): Promise<SupplierExtended | undefined> {
 	const conditions = [];
 	const params = [];
 
@@ -96,7 +98,7 @@ export async function getSupplierDetails(db: DB, id: number): Promise<SupplierEx
  * @param supplier - The supplier data to upsert
  * @throws {Error} If supplier.id is not provided
  */
-export async function upsertSupplier(db: DB, supplier: Supplier) {
+async function _upsertSupplier(db: DB, supplier: Supplier) {
 	if (!supplier.id) {
 		throw new Error("Supplier must have an id");
 	}
@@ -127,7 +129,7 @@ export async function upsertSupplier(db: DB, supplier: Supplier) {
  * @param supplierId - The id of the supplier
  * @returns Promise resolving to an array of publisher ids
  */
-export async function getPublishersFor(db: DB, supplierId: number): Promise<string[]> {
+async function _getPublishersFor(db: DB, supplierId: number): Promise<string[]> {
 	const stmt = await db.prepare(
 		`SELECT publisher
 		FROM supplier_publisher
@@ -149,7 +151,7 @@ export async function getPublishersFor(db: DB, supplierId: number): Promise<stri
  * @param supplierId - The id of the supplier to associate to
  * @param publisher - The id of the publisher to associate
  */
-export async function associatePublisher(db: DB, supplierId: number, publisher: string) {
+async function _associatePublisher(db: DB, supplierId: number, publisher: string) {
 	/* Makes sure the given publisher is associated with the given supplier id.
      If necessary it disassociates a different supplier */
 	await db.exec(
@@ -164,7 +166,7 @@ export async function associatePublisher(db: DB, supplierId: number, publisher: 
 }
 
 /** Removes a publisher from the list of publishers for a supplier */
-export async function removePublisherFromSupplier(db: DB, supplierId: number, publisher: string) {
+async function _removePublisherFromSupplier(db: DB, supplierId: number, publisher: string) {
 	await db.exec("DELETE FROM supplier_publisher WHERE supplier_id = ? AND publisher = ?", [supplierId, publisher]);
 }
 
@@ -188,7 +190,7 @@ export const DEFAULT_SUPPLIER_NAME = "General";
  * @param db - The database instance to query
  * @returns Promise resolving to an array of supplier order summaries with supplier information
  */
-export async function getPossibleSupplierOrders(db: DB): Promise<PossibleSupplierOrder[]> {
+async function _getPossibleSupplierOrders(db: DB): Promise<PossibleSupplierOrder[]> {
 	const query = `
 		SELECT
             supplier_id,
@@ -224,7 +226,7 @@ export async function getPossibleSupplierOrders(db: DB): Promise<PossibleSupplie
  * @param supplierId - The ID of the supplier to get order lines for
  * @returns Promise resolving to an array of possible order lines for the specified supplier
  */
-export async function getPossibleSupplierOrderLines(db: DB, supplierId: number | null): Promise<PossibleSupplierOrderLine[]> {
+async function _getPossibleSupplierOrderLines(db: DB, supplierId: number | null): Promise<PossibleSupplierOrderLine[]> {
 	const conditions = [
 		"col.placed is NULL",
 		// sometimes a book can be received before being placed with the supplier due to overdelivery
@@ -285,7 +287,7 @@ export async function getPossibleSupplierOrderLines(db: DB, supplierId: number |
   * @returns Promise resolving to an array of placed supplier orders with
  supplier details and book counts
   */
-export async function getPlacedSupplierOrders(
+async function _getPlacedSupplierOrders(
 	db: DB,
 	filters?: { supplierId?: number; reconciled?: boolean; finalized?: boolean }
 ): Promise<PlacedSupplierOrder[]> {
@@ -356,7 +358,7 @@ export async function getPlacedSupplierOrders(
  * @param supplier_order_id - supplier order to retrieve lines for
  * @returns array of place supplier order lines:
  **/
-export async function getPlacedSupplierOrderLines(db: DB, supplier_order_ids: number[]): Promise<PlacedSupplierOrderLine[]> {
+async function _getPlacedSupplierOrderLines(db: DB, supplier_order_ids: number[]): Promise<PlacedSupplierOrderLine[]> {
 	if (!supplier_order_ids.length) {
 		return [];
 	}
@@ -413,7 +415,7 @@ export async function getPlacedSupplierOrderLines(db: DB, supplier_order_ids: nu
  * @returns Promise<void>
  * @todo Rewrite this function to accommodate for removing quantity in customerOrderLine
  */
-export async function createSupplierOrder(
+async function _createSupplierOrder(
 	db: DB,
 	id: number,
 	supplierId: number | null,
@@ -478,3 +480,14 @@ export async function createSupplierOrder(
 }
 
 export const multiplyString = (str: string, n: number) => Array(n).fill(str).join(", ");
+export const getAllSuppliers = timed(_getAllSuppliers);
+export const getSupplierDetails = timed(_getSupplierDetails);
+export const upsertSupplier = timed(_upsertSupplier);
+export const getPublishersFor = timed(_getPublishersFor);
+export const associatePublisher = timed(_associatePublisher);
+export const removePublisherFromSupplier = timed(_removePublisherFromSupplier);
+export const getPossibleSupplierOrders = timed(_getPossibleSupplierOrders);
+export const getPossibleSupplierOrderLines = timed(_getPossibleSupplierOrderLines);
+export const getPlacedSupplierOrders = timed(_getPlacedSupplierOrders);
+export const getPlacedSupplierOrderLines = timed(_getPlacedSupplierOrderLines);
+export const createSupplierOrder = timed(_createSupplierOrder);

--- a/apps/web-client/src/lib/utils/time.ts
+++ b/apps/web-client/src/lib/utils/time.ts
@@ -12,3 +12,12 @@ export const generateUpdatedAtString = (updatedAt?: Date | string, mode?: "time-
 				hour: "2-digit",
 				minute: "numeric"
 			}));
+
+/** A util used to time a function call */
+export async function timed<P extends any[], R extends any | Promise<any>>(cb: (...params: P) => R, ...params: P): Promise<R> {
+	const name = cb.name || "anonymous";
+	console.time(name);
+	const result = await cb(...params);
+	console.timeEnd(name);
+	return result;
+}

--- a/apps/web-client/src/lib/utils/time.ts
+++ b/apps/web-client/src/lib/utils/time.ts
@@ -12,12 +12,3 @@ export const generateUpdatedAtString = (updatedAt?: Date | string, mode?: "time-
 				hour: "2-digit",
 				minute: "numeric"
 			}));
-
-/** A util used to time a function call */
-export async function timed<P extends any[], R extends any | Promise<any>>(cb: (...params: P) => R, ...params: P): Promise<R> {
-	const name = cb.name || "anonymous";
-	console.time(name);
-	const result = await cb(...params);
-	console.timeEnd(name);
-	return result;
-}

--- a/apps/web-client/src/lib/utils/timer.ts
+++ b/apps/web-client/src/lib/utils/timer.ts
@@ -1,0 +1,119 @@
+import { get } from "svelte/store";
+import { persisted } from "svelte-local-storage-store";
+
+import { page } from "$app/state";
+
+type TimeLogger = {
+	time: (name: string) => void;
+	timeEnd: (name: string) => void;
+};
+
+class TimeRecord {
+	private rec: Record<string, Record<string, number>> = {};
+
+	keys() {
+		return Object.keys(this.rec);
+	}
+
+	route(route: string) {
+		return this.rec[route];
+	}
+
+	set(route: string, name: string, time: number) {
+		if (!this.rec[route]) {
+			this.rec[route] = {};
+		}
+		this.rec[route][name] = time;
+	}
+
+	get(route: string, name: string) {
+		return this.rec[route]?.[name];
+	}
+
+	delete(route: string, name: string) {
+		if (this.rec[route]) {
+			delete this.rec[route][name];
+			if (Object.keys(this.rec[route]).length === 0) {
+				delete this.rec[route];
+			}
+		}
+	}
+}
+
+class TimeRecorder implements TimeLogger {
+	/** Keeps record of recorded times */
+	private rec = new TimeRecord();
+	/**
+	 * Keeps record of latest start times (for timeEnd calculations)
+	 */
+	private startTimesRec = new TimeRecord();
+	private isOn = persisted("librocco-time-logger-on", false);
+
+	time(name: string) {
+		if (get(this.isOn) === false) return;
+
+		const routeId = page.route.id;
+		this.startTimesRec.set(routeId, name, Date.now());
+	}
+
+	timeEnd(name: string) {
+		if (get(this.isOn) === false) return;
+
+		const routeId = page.route.id;
+		const startTime = this.startTimesRec.get(routeId, name);
+		if (!startTime) {
+			console.warn(`No start time found for: ${routeId}:${name}`);
+			return;
+		}
+		const elapsed = Date.now() - startTime;
+		this.rec.set(routeId, name, elapsed);
+		console.log(`${routeId}:${name}`, elapsed);
+	}
+
+	activate() {
+		this.isOn.set(true);
+	}
+
+	disable() {
+		this.isOn.set(false);
+	}
+
+	report() {
+		let report = "";
+
+		for (const route of this.rec.keys()) {
+			report += `Route: ${route}:\n`;
+			for (const name of Object.keys(this.rec.route(route))) {
+				// Total load is added at the bottom
+				if (name === "load") continue;
+
+				const time = this.rec.get(route, name);
+				if (time) {
+					report += `  - ${name}: ${time} ms\n`;
+				}
+			}
+
+			const totalLoad = this.rec.get(route, "load");
+			if (totalLoad) {
+				report += `  - **total load: ${totalLoad} ms**\n`;
+			}
+
+			report += "\n";
+		}
+
+		return report;
+	}
+}
+
+export const timeLogger = new TimeRecorder();
+
+/** A util used to time a function call */
+export function timed<P extends any[], R>(cb: (...params: P) => Promise<R>): (...params: P) => Promise<R> {
+	return async (...params: P) => {
+		const name = (cb.name || "anonymous").replace(/^_+/, ""); // Remove the prefix
+		timeLogger.time(name);
+		const result = await cb(...params);
+		timeLogger.timeEnd(name);
+		return result;
+	};
+}

--- a/apps/web-client/src/lib/utils/timer.ts
+++ b/apps/web-client/src/lib/utils/timer.ts
@@ -1,8 +1,6 @@
 import { get } from "svelte/store";
 import { persisted } from "svelte-local-storage-store";
 
-import { page } from "$app/state";
-
 type TimeLogger = {
 	time: (name: string) => void;
 	timeEnd: (name: string) => void;
@@ -49,17 +47,19 @@ class TimeRecorder implements TimeLogger {
 	private startTimesRec = new TimeRecord();
 	private isOn = persisted("librocco-time-logger-on", false);
 
+	private routeId: string | null = null;
+
 	time(name: string) {
 		if (get(this.isOn) === false) return;
 
-		const routeId = page.route.id;
+		const routeId = this.routeId;
 		this.startTimesRec.set(routeId, name, Date.now());
 	}
 
 	timeEnd(name: string) {
 		if (get(this.isOn) === false) return;
 
-		const routeId = page.route.id;
+		const routeId = this.routeId;
 		const startTime = this.startTimesRec.get(routeId, name);
 		if (!startTime) {
 			console.warn(`No start time found for: ${routeId}:${name}`);
@@ -102,6 +102,10 @@ class TimeRecorder implements TimeLogger {
 		}
 
 		return report;
+	}
+
+	setCurrentRoute(routeId: string) {
+		this.routeId = routeId;
 	}
 }
 

--- a/apps/web-client/src/lib/utils/timer.ts
+++ b/apps/web-client/src/lib/utils/timer.ts
@@ -108,8 +108,8 @@ class TimeRecorder implements TimeLogger {
 export const timeLogger = new TimeRecorder();
 
 /** A util used to time a function call */
-export function timed<P extends any[], R>(cb: (...params: P) => Promise<R>): (...params: P) => Promise<R> {
-	return async (...params: P) => {
+export function timed<P extends any[], R>(cb: (...params: P) => Promise<R> | R): (...params: P) => Promise<Awaited<R>> {
+	return async (...params: P): Promise<Awaited<R>> => {
 		const name = (cb.name || "anonymous").replace(/^_+/, ""); // Remove the prefix
 		timeLogger.time(name);
 		const result = await cb(...params);

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -21,6 +21,7 @@
 	import * as reconciliation from "$lib/db/cr-sqlite/order-reconciliation";
 	import * as suppliers from "$lib/db/cr-sqlite/suppliers";
 	import * as warehouse from "$lib/db/cr-sqlite/warehouse";
+	import { timeLogger } from "$lib/utils/timer";
 
 	export let data: LayoutData & { status: boolean };
 
@@ -92,6 +93,11 @@
 		// if (!status) {
 		// 	await goto(appPath("settings"));
 		// }
+	});
+
+	// Register time logger
+	onMount(() => {
+		window["timeLogger"] = timeLogger;
 	});
 
 	onDestroy(() => {

--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -17,11 +17,12 @@ import { detectLocale } from "@librocco/shared/i18n-util";
 
 import { DEFAULT_LOCALE, IS_E2E } from "$lib/constants";
 import { newPluginsInterface } from "$lib/plugins";
+import { timeLogger } from "$lib/utils/timer";
 
 // Paths which are valid (shouldn't return 404, but don't have any content and should get redirected to the default route "/inventory/stock/all")
 const redirectPaths = ["", "/"].map((path) => `${base}${path}`);
 
-export const load: LayoutLoad = async ({ url }) => {
+export const load: LayoutLoad = async ({ url, route }) => {
 	const { pathname } = url;
 
 	if (redirectPaths.includes(pathname)) {
@@ -61,6 +62,8 @@ export const load: LayoutLoad = async ({ url }) => {
 			plugins.get("book-fetcher").register(createOpenLibraryApiPlugin());
 			plugins.get("book-fetcher").register(createGoogleBooksApiPlugin());
 		}
+
+		timeLogger.setCurrentRoute(route.id);
 
 		return { dbCtx, status: true, plugins };
 	}

--- a/apps/web-client/src/routes/history/date/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/date/[date]/+page.ts
@@ -9,7 +9,7 @@ import { getPastTransactions } from "$lib/db/cr-sqlite/history";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
+const _load = async ({ params: { date }, parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("history:transactions");
 
 	const { dbCtx } = await parent();
@@ -58,4 +58,4 @@ const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface DailySummaryStore {}
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/history/date/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/date/[date]/+page.ts
@@ -6,6 +6,7 @@ import type { PastTransactionItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
 import { getPastTransactions } from "$lib/db/cr-sqlite/history";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:transactions");
@@ -36,7 +37,7 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 
 	const startDate = new Date(date);
 	const endDate = startDate;
-	const bookList: PastTransactionItem[] = await getPastTransactions(dbCtx.db, { startDate, endDate });
+	const bookList: PastTransactionItem[] = await timed(getPastTransactions, dbCtx.db, { startDate, endDate });
 
 	for (const { noteType, discount = 0, price, quantity } of bookList) {
 		if (noteType === "inbound") {

--- a/apps/web-client/src/routes/history/date/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/date/[date]/+page.ts
@@ -7,7 +7,9 @@ import type { PastTransactionItem } from "$lib/db/cr-sqlite/types";
 import { appPath } from "$lib/paths";
 import { getPastTransactions } from "$lib/db/cr-sqlite/history";
 
-export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:transactions");
 
 	const { dbCtx } = await parent();
@@ -55,3 +57,5 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface DailySummaryStore {}
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/date/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/date/[date]/+page.ts
@@ -6,7 +6,6 @@ import type { PastTransactionItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
 import { getPastTransactions } from "$lib/db/cr-sqlite/history";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:transactions");
@@ -37,7 +36,7 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 
 	const startDate = new Date(date);
 	const endDate = startDate;
-	const bookList: PastTransactionItem[] = await timed(getPastTransactions, dbCtx.db, { startDate, endDate });
+	const bookList: PastTransactionItem[] = await getPastTransactions(dbCtx.db, { startDate, endDate });
 
 	for (const { noteType, discount = 0, price, quantity } of bookList) {
 		if (noteType === "inbound") {

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
@@ -4,6 +4,7 @@ import type { GetStockResponseItem, PastTransactionItem } from "$lib/db/cr-sqlit
 import { getPastTransactions } from "$lib/db/cr-sqlite/history";
 import { getStock } from "$lib/db/cr-sqlite/stock";
 import { getBookData } from "$lib/db/cr-sqlite/books";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 	depends("history:transactions");
@@ -15,9 +16,9 @@ export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 		return { transactions: [] as PastTransactionItem[], stock: [] as GetStockResponseItem[] };
 	}
 
-	const transactions = await getPastTransactions(dbCtx.db, { isbn });
-	const bookData = await getBookData(dbCtx.db, isbn);
-	const stock = await getStock(dbCtx.db, { isbns: [isbn] });
+	const transactions = await timed(getPastTransactions, dbCtx.db, { isbn });
+	const bookData = await timed(getBookData, dbCtx.db, isbn);
+	const stock = await timed(getStock, dbCtx.db, { isbns: [isbn] });
 
 	return { dbCtx, transactions, bookData, stock };
 };

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
@@ -5,7 +5,9 @@ import { getPastTransactions } from "$lib/db/cr-sqlite/history";
 import { getStock } from "$lib/db/cr-sqlite/stock";
 import { getBookData } from "$lib/db/cr-sqlite/books";
 
-export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 	depends("history:transactions");
 
 	const { dbCtx } = await parent();
@@ -21,3 +23,5 @@ export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 
 	return { dbCtx, transactions, bookData, stock };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
@@ -7,7 +7,7 @@ import { getBookData } from "$lib/db/cr-sqlite/books";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
+const _load = async ({ params: { isbn }, parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("history:transactions");
 
 	const { dbCtx } = await parent();
@@ -24,4 +24,4 @@ const _load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 	return { dbCtx, transactions, bookData, stock };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.ts
@@ -4,7 +4,6 @@ import type { GetStockResponseItem, PastTransactionItem } from "$lib/db/cr-sqlit
 import { getPastTransactions } from "$lib/db/cr-sqlite/history";
 import { getStock } from "$lib/db/cr-sqlite/stock";
 import { getBookData } from "$lib/db/cr-sqlite/books";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 	depends("history:transactions");
@@ -16,9 +15,9 @@ export const load: PageLoad = async ({ params: { isbn }, parent, depends }) => {
 		return { transactions: [] as PastTransactionItem[], stock: [] as GetStockResponseItem[] };
 	}
 
-	const transactions = await timed(getPastTransactions, dbCtx.db, { isbn });
-	const bookData = await timed(getBookData, dbCtx.db, isbn);
-	const stock = await timed(getStock, dbCtx.db, { isbns: [isbn] });
+	const transactions = await getPastTransactions(dbCtx.db, { isbn });
+	const bookData = await getBookData(dbCtx.db, isbn);
+	const stock = await getStock(dbCtx.db, { isbns: [isbn] });
 
 	return { dbCtx, transactions, bookData, stock };
 };

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -6,6 +6,7 @@ import type { PastNoteItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
 import { getPastNotes } from "$lib/db/cr-sqlite/history";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:notes");
@@ -25,7 +26,7 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 		return { date, dateValue, notes: [] as PastNoteItem[] };
 	}
 
-	const notes = await getPastNotes(dbCtx.db, date);
+	const notes = await timed(getPastNotes, dbCtx.db, date);
 	return { date, dateValue, notes };
 };
 

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -9,7 +9,7 @@ import { getPastNotes } from "$lib/db/cr-sqlite/history";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
+const _load = async ({ params: { date }, parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("history:notes");
 
 	const { dbCtx } = await parent();
@@ -34,4 +34,4 @@ const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface DailySummaryStore {}
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -6,7 +6,6 @@ import type { PastNoteItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
 import { getPastNotes } from "$lib/db/cr-sqlite/history";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:notes");
@@ -26,7 +25,7 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 		return { date, dateValue, notes: [] as PastNoteItem[] };
 	}
 
-	const notes = await timed(getPastNotes, dbCtx.db, date);
+	const notes = await getPastNotes(dbCtx.db, date);
 	return { date, dateValue, notes };
 };
 

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -7,7 +7,9 @@ import type { PastNoteItem } from "$lib/db/cr-sqlite/types";
 import { appPath } from "$lib/paths";
 import { getPastNotes } from "$lib/db/cr-sqlite/history";
 
-export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ params: { date }, parent, depends }) => {
 	depends("history:notes");
 
 	const { dbCtx } = await parent();
@@ -31,3 +33,5 @@ export const load: PageLoad = async ({ params: { date }, parent, depends }) => {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface DailySummaryStore {}
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
@@ -6,6 +6,7 @@ import { getNoteById, getNoteCustomItems, getNoteEntries } from "$lib/db/cr-sqli
 import type { NoteCustomItem, NoteEntriesItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -25,14 +26,14 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		};
 	}
 
-	const note = await getNoteById(dbCtx.db, id);
+	const note = await timed(getNoteById, dbCtx.db, id);
 	if (!note) {
 		redirect(307, appPath("outbound"));
 	}
 
-	const entries = await getNoteEntries(dbCtx.db, id);
+	const entries = await timed(getNoteEntries, dbCtx.db, id);
 
-	const customItems = await getNoteCustomItems(dbCtx.db, id);
+	const customItems = await timed(getNoteCustomItems, dbCtx.db, id);
 
 	return { dbCtx, ...note, entries, customItems };
 };

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
@@ -7,7 +7,9 @@ import type { NoteCustomItem, NoteEntriesItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
 
 	depends("note:books");
@@ -36,3 +38,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { dbCtx, ...note, entries, customItems };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
@@ -9,7 +9,7 @@ import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	const id = Number(params.id);
 
 	depends("note:books");
@@ -39,4 +39,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { dbCtx, ...note, entries, customItems };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.ts
@@ -6,7 +6,6 @@ import { getNoteById, getNoteCustomItems, getNoteEntries } from "$lib/db/cr-sqli
 import type { NoteCustomItem, NoteEntriesItem } from "$lib/db/cr-sqlite/types";
 
 import { appPath } from "$lib/paths";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -26,14 +25,14 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		};
 	}
 
-	const note = await timed(getNoteById, dbCtx.db, id);
+	const note = await getNoteById(dbCtx.db, id);
 	if (!note) {
 		redirect(307, appPath("outbound"));
 	}
 
-	const entries = await timed(getNoteEntries, dbCtx.db, id);
+	const entries = await getNoteEntries(dbCtx.db, id);
 
-	const customItems = await timed(getNoteCustomItems, dbCtx.db, id);
+	const customItems = await getNoteCustomItems(dbCtx.db, id);
 
 	return { dbCtx, ...note, entries, customItems };
 };

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -2,7 +2,9 @@ import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, depends }) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
@@ -12,3 +14,5 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	return { dbCtx, warehouses };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -1,5 +1,4 @@
 import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
-import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -9,7 +8,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const warehouses = dbCtx ? await timed(getAllWarehouses, dbCtx.db) : [];
+	const warehouses = dbCtx ? await getAllWarehouses(dbCtx.db) : [];
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -4,7 +4,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, depends }) => {
+const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
@@ -15,4 +15,4 @@ const _load: PageLoad = async ({ parent, depends }) => {
 	return { dbCtx, warehouses };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -1,4 +1,5 @@
 import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
+import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -8,7 +9,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const warehouses = dbCtx ? await getAllWarehouses(dbCtx.db) : [];
+	const warehouses = dbCtx ? await timed(getAllWarehouses, dbCtx.db) : [];
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
@@ -3,6 +3,7 @@ import { getWarehouseById } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
 import type { NoteType } from "$lib/db/cr-sqlite/types";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	depends("history:transactions");
@@ -21,8 +22,8 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 	const startDate = new Date(from);
 	const endDate = new Date(to);
 
-	const { displayName } = await getWarehouseById(dbCtx.db, warehouseId);
-	const transactions = await getPastTransactions(dbCtx.db, { warehouseId, startDate, endDate, noteType });
+	const { displayName } = await timed(getWarehouseById, dbCtx.db, warehouseId);
+	const transactions = await timed(getPastTransactions, dbCtx.db, { warehouseId, startDate, endDate, noteType });
 
 	return { displayName, transactions, noteType };
 };

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
@@ -3,7 +3,6 @@ import { getWarehouseById } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
 import type { NoteType } from "$lib/db/cr-sqlite/types";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	depends("history:transactions");
@@ -22,8 +21,8 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 	const startDate = new Date(from);
 	const endDate = new Date(to);
 
-	const { displayName } = await timed(getWarehouseById, dbCtx.db, warehouseId);
-	const transactions = await timed(getPastTransactions, dbCtx.db, { warehouseId, startDate, endDate, noteType });
+	const { displayName } = await getWarehouseById(dbCtx.db, warehouseId);
+	const transactions = await getPastTransactions(dbCtx.db, { warehouseId, startDate, endDate, noteType });
 
 	return { displayName, transactions, noteType };
 };

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
@@ -4,7 +4,9 @@ import { getWarehouseById } from "$lib/db/cr-sqlite/warehouse";
 import type { PageLoad } from "./$types";
 import type { NoteType } from "$lib/db/cr-sqlite/types";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	depends("history:transactions");
 
 	const { to, from } = params;
@@ -26,3 +28,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { displayName, transactions, noteType };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.ts
@@ -6,7 +6,7 @@ import type { NoteType } from "$lib/db/cr-sqlite/types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	depends("history:transactions");
 
 	const { to, from } = params;
@@ -29,4 +29,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { displayName, transactions, noteType };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/+page.ts
+++ b/apps/web-client/src/routes/inventory/+page.ts
@@ -1,4 +1,6 @@
-import { redirect, type Load } from "@sveltejs/kit";
+import { redirect } from "@sveltejs/kit";
+
+import type { PageLoad } from "./$types";
 
 import { base } from "$app/paths";
 
@@ -6,10 +8,10 @@ import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: Load = async ({ url }) => {
+const _load = async ({ url }: Parameters<PageLoad>[0]) => {
 	if ([`${base}/inventory`, `${base}/inventory/`].includes(url.pathname)) {
 		redirect(307, appPath("warehouses"));
 	}
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/+page.ts
+++ b/apps/web-client/src/routes/inventory/+page.ts
@@ -4,8 +4,12 @@ import { base } from "$app/paths";
 
 import { appPath } from "$lib/paths";
 
-export const load: Load = async ({ url }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: Load = async ({ url }) => {
 	if ([`${base}/inventory`, `${base}/inventory/`].includes(url.pathname)) {
 		redirect(307, appPath("warehouses"));
 	}
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -1,5 +1,4 @@
 import { getActiveInboundNotes } from "$lib/db/cr-sqlite/note";
-import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -8,7 +7,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const notes = dbCtx?.db ? await timed(getActiveInboundNotes, dbCtx?.db) : [];
+	const notes = dbCtx?.db ? await getActiveInboundNotes(dbCtx?.db) : [];
 
 	return { dbCtx, notes };
 };

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -2,7 +2,9 @@ import { getActiveInboundNotes } from "$lib/db/cr-sqlite/note";
 
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, depends }) => {
 	depends("inbound:list");
 
 	const { dbCtx } = await parent();
@@ -11,3 +13,5 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	return { dbCtx, notes };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -4,7 +4,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, depends }) => {
+const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("inbound:list");
 
 	const { dbCtx } = await parent();
@@ -14,4 +14,4 @@ const _load: PageLoad = async ({ parent, depends }) => {
 	return { dbCtx, notes };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -1,4 +1,5 @@
 import { getActiveInboundNotes } from "$lib/db/cr-sqlite/note";
+import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -7,7 +8,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const notes = dbCtx?.db ? await getActiveInboundNotes(dbCtx?.db) : [];
+	const notes = dbCtx?.db ? await timed(getActiveInboundNotes, dbCtx?.db) : [];
 
 	return { dbCtx, notes };
 };

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
@@ -7,7 +7,9 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
 
 	depends("note:data");
@@ -34,3 +36,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { dbCtx, ...note, entries, publisherList };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
@@ -6,6 +6,7 @@ import { getNoteById, getNoteEntries } from "$lib/db/cr-sqlite/note";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -20,7 +21,7 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		return { dbCtx, id, displayName: "N/A", entries: [], publisherList: [] as string[] };
 	}
 
-	const note = await getNoteById(dbCtx.db, id);
+	const note = await timed(getNoteById, dbCtx.db, id);
 
 	// If note not found, we shouldn't be here
 	// If note committed, we shouldn't be here either (it can be viewed in the note archive)
@@ -29,8 +30,8 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		redirect(307, appPath("inbound"));
 	}
 
-	const entries = await getNoteEntries(dbCtx.db, id);
-	const publisherList = await getPublisherList(dbCtx.db);
+	const entries = await timed(getNoteEntries, dbCtx.db, id);
+	const publisherList = await timed(getPublisherList, dbCtx.db);
 
 	return { dbCtx, ...note, entries, publisherList };
 };

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
@@ -9,7 +9,7 @@ import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	const id = Number(params.id);
 
 	depends("note:data");
@@ -37,4 +37,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { dbCtx, ...note, entries, publisherList };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.ts
@@ -6,7 +6,6 @@ import { getNoteById, getNoteEntries } from "$lib/db/cr-sqlite/note";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -21,7 +20,7 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		return { dbCtx, id, displayName: "N/A", entries: [], publisherList: [] as string[] };
 	}
 
-	const note = await timed(getNoteById, dbCtx.db, id);
+	const note = await getNoteById(dbCtx.db, id);
 
 	// If note not found, we shouldn't be here
 	// If note committed, we shouldn't be here either (it can be viewed in the note archive)
@@ -30,8 +29,8 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		redirect(307, appPath("inbound"));
 	}
 
-	const entries = await timed(getNoteEntries, dbCtx.db, id);
-	const publisherList = await timed(getPublisherList, dbCtx.db);
+	const entries = await getNoteEntries(dbCtx.db, id);
+	const publisherList = await getPublisherList(dbCtx.db);
 
 	return { dbCtx, ...note, entries, publisherList };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -2,7 +2,9 @@ import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, depends }) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
@@ -12,3 +14,5 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	return { dbCtx, warehouses };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -1,5 +1,4 @@
 import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
-import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -9,7 +8,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const warehouses = dbCtx ? await timed(getAllWarehouses, dbCtx.db) : [];
+	const warehouses = dbCtx ? await getAllWarehouses(dbCtx.db) : [];
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -4,7 +4,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, depends }) => {
+const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
@@ -15,4 +15,4 @@ const _load: PageLoad = async ({ parent, depends }) => {
 	return { dbCtx, warehouses };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -1,4 +1,5 @@
 import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
+import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -8,7 +9,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const warehouses = dbCtx ? await getAllWarehouses(dbCtx.db) : [];
+	const warehouses = dbCtx ? await timed(getAllWarehouses, dbCtx.db) : [];
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -7,7 +7,6 @@ import type { PageLoad } from "./$types";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -22,13 +21,13 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		return { dbCtx, id, displayName: "N/A", discount: 0, entries: [], publisherList: [] as string[] };
 	}
 
-	const warehouse = await timed(getWarehouseById, dbCtx.db, id);
+	const warehouse = await getWarehouseById(dbCtx.db, id);
 	if (!warehouse) {
 		redirect(307, appPath("inventory"));
 	}
 
-	const entries = await timed(getStock, dbCtx.db, { warehouseId: id });
-	const publisherList = await timed(getPublisherList, dbCtx.db);
+	const entries = await getStock(dbCtx.db, { warehouseId: id });
+	const publisherList = await getPublisherList(dbCtx.db);
 
 	return { dbCtx, ...warehouse, entries, publisherList };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -8,7 +8,9 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
 
 	depends("warehouse:data");
@@ -31,3 +33,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { dbCtx, ...warehouse, entries, publisherList };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -7,6 +7,7 @@ import type { PageLoad } from "./$types";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
+import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -21,13 +22,13 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		return { dbCtx, id, displayName: "N/A", discount: 0, entries: [], publisherList: [] as string[] };
 	}
 
-	const warehouse = await getWarehouseById(dbCtx.db, id);
+	const warehouse = await timed(getWarehouseById, dbCtx.db, id);
 	if (!warehouse) {
 		redirect(307, appPath("inventory"));
 	}
 
-	const entries = await getStock(dbCtx.db, { warehouseId: id });
-	const publisherList = await getPublisherList(dbCtx.db);
+	const entries = await timed(getStock, dbCtx.db, { warehouseId: id });
+	const publisherList = await timed(getPublisherList, dbCtx.db);
 
 	return { dbCtx, ...warehouse, entries, publisherList };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -10,7 +10,7 @@ import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	const id = Number(params.id);
 
 	depends("warehouse:data");
@@ -34,4 +34,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { dbCtx, ...warehouse, entries, publisherList };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/customers/+page.ts
+++ b/apps/web-client/src/routes/orders/customers/+page.ts
@@ -5,7 +5,7 @@ import { getCustomerOrderList } from "$lib/db/cr-sqlite/customers";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ depends, parent }) => {
+const _load = async ({ depends, parent }: Parameters<PageLoad>[0]) => {
 	depends("customer:list");
 
 	const { dbCtx } = await parent();
@@ -22,4 +22,4 @@ const _load: PageLoad = async ({ depends, parent }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/customers/+page.ts
+++ b/apps/web-client/src/routes/orders/customers/+page.ts
@@ -3,7 +3,9 @@ import type { CustomerOrderListItem } from "$lib/db/cr-sqlite/types";
 
 import { getCustomerOrderList } from "$lib/db/cr-sqlite/customers";
 
-export const load: PageLoad = async ({ depends, parent }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ depends, parent }) => {
 	depends("customer:list");
 
 	const { dbCtx } = await parent();
@@ -19,3 +21,5 @@ export const load: PageLoad = async ({ depends, parent }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.ts
@@ -5,7 +5,9 @@ import type { Customer, CustomerOrderLine } from "$lib/db/cr-sqlite/types";
 import { getCustomerOrderLines, getCustomerDetails } from "$lib/db/cr-sqlite/customers";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	depends("customer:data");
 	depends("customer:books");
 
@@ -23,3 +25,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { customer, customerOrderLines, publisherList };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.ts
@@ -7,7 +7,7 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	depends("customer:data");
 	depends("customer:books");
 
@@ -26,4 +26,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { customer, customerOrderLines, publisherList };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/+page.ts
@@ -4,7 +4,9 @@ import { getAllSuppliers } from "$lib/db/cr-sqlite/suppliers";
 
 import type { SupplierExtended } from "$lib/db/cr-sqlite/types";
 
-export const load: PageLoad = async ({ depends, parent }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ depends, parent }) => {
 	depends("suppliers:list");
 
 	const { dbCtx } = await parent();
@@ -20,3 +22,5 @@ export const load: PageLoad = async ({ depends, parent }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/+page.ts
@@ -6,7 +6,7 @@ import type { SupplierExtended } from "$lib/db/cr-sqlite/types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ depends, parent }) => {
+const _load = async ({ depends, parent }: Parameters<PageLoad>[0]) => {
 	depends("suppliers:list");
 
 	const { dbCtx } = await parent();
@@ -23,4 +23,4 @@ const _load: PageLoad = async ({ depends, parent }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
@@ -10,7 +10,7 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	depends("supplier:data");
 	depends("supplier:orders");
 
@@ -51,4 +51,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 	return { supplier, assignedPublishers, unassignedPublishers, orders: [...unreconciledOrders, ...reconciledOrders] };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.ts
@@ -8,7 +8,9 @@ import { getPlacedSupplierOrders, getPublishersFor, getSupplierDetails } from "$
 import { appPath } from "$lib/paths";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	depends("supplier:data");
 	depends("supplier:orders");
 
@@ -48,3 +50,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 
 	return { supplier, assignedPublishers, unassignedPublishers, orders: [...unreconciledOrders, ...reconciledOrders] };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.ts
@@ -7,7 +7,9 @@ import { base } from "$app/paths";
 import type { PossibleSupplierOrderLine } from "$lib/db/cr-sqlite/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	depends("books:data");
 	depends("suppliers:data");
 	depends("customers:order_lines");
@@ -31,3 +33,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.ts
@@ -9,7 +9,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	depends("books:data");
 	depends("suppliers:data");
 	depends("customers:order_lines");
@@ -34,4 +34,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ depends, parent }) => {
+const _load = async ({ depends, parent }: Parameters<PageLoad>[0]) => {
 	depends("books:data");
 	depends("suppliers:data");
 	depends("customers:order_lines");
@@ -36,4 +36,4 @@ const _load: PageLoad = async ({ depends, parent }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.ts
@@ -4,7 +4,9 @@ import { getPlacedSupplierOrders, getPossibleSupplierOrders } from "$lib/db/cr-s
 import type { PlacedSupplierOrder, PossibleSupplierOrder, ReconciliationOrder } from "$lib/db/cr-sqlite/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ depends, parent }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ depends, parent }) => {
 	depends("books:data");
 	depends("suppliers:data");
 	depends("customers:order_lines");
@@ -33,3 +35,5 @@ export const load: PageLoad = async ({ depends, parent }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.ts
@@ -3,7 +3,9 @@ import { getPlacedSupplierOrderLines, getPlacedSupplierOrders } from "$lib/db/cr
 import type { PlacedSupplierOrderLine } from "$lib/db/cr-sqlite/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	// Reactive on book data displayed in the table
 	depends("book:data");
 	// Reactive on reconciled state -- calculated from existing reconciliation orders
@@ -29,3 +31,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	// Reactive on book data displayed in the table
 	depends("book:data");
 	// Reactive on reconciled state -- calculated from existing reconciliation orders
@@ -32,4 +32,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.ts
@@ -4,7 +4,9 @@ import type { PlacedSupplierOrderLine, ReconciliationOrder, ReconciliationOrderL
 import { getPlacedSupplierOrderLines } from "$lib/db/cr-sqlite/suppliers";
 import { getReconciliationOrder, getReconciliationOrderLines } from "$lib/db/cr-sqlite/order-reconciliation";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	depends("reconciliationOrder:data");
 
 	const { dbCtx } = await parent();
@@ -27,3 +29,5 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 };
 
 export const ssr = false;
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.ts
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.ts
@@ -6,7 +6,7 @@ import { getReconciliationOrder, getReconciliationOrderLines } from "$lib/db/cr-
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	depends("reconciliationOrder:data");
 
 	const { dbCtx } = await parent();
@@ -30,4 +30,4 @@ const _load: PageLoad = async ({ parent, params, depends }) => {
 
 export const ssr = false;
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/outbound/+page.ts
+++ b/apps/web-client/src/routes/outbound/+page.ts
@@ -1,5 +1,4 @@
 import { getActiveOutboundNotes } from "$lib/db/cr-sqlite/note";
-import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -8,7 +7,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const notes = dbCtx?.db ? await timed(getActiveOutboundNotes, dbCtx?.db) : [];
+	const notes = dbCtx?.db ? await getActiveOutboundNotes(dbCtx?.db) : [];
 
 	return { dbCtx, notes };
 };

--- a/apps/web-client/src/routes/outbound/+page.ts
+++ b/apps/web-client/src/routes/outbound/+page.ts
@@ -4,7 +4,7 @@ import type { PageLoad } from "./$types";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, depends }) => {
+const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("outbound:list");
 
 	const { dbCtx } = await parent();
@@ -14,4 +14,4 @@ const _load: PageLoad = async ({ parent, depends }) => {
 	return { dbCtx, notes };
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/outbound/+page.ts
+++ b/apps/web-client/src/routes/outbound/+page.ts
@@ -2,7 +2,9 @@ import { getActiveOutboundNotes } from "$lib/db/cr-sqlite/note";
 
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, depends }) => {
 	depends("outbound:list");
 
 	const { dbCtx } = await parent();
@@ -11,3 +13,5 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	return { dbCtx, notes };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/outbound/+page.ts
+++ b/apps/web-client/src/routes/outbound/+page.ts
@@ -1,4 +1,5 @@
 import { getActiveOutboundNotes } from "$lib/db/cr-sqlite/note";
+import { timed } from "$lib/utils/time";
 
 import type { PageLoad } from "./$types";
 
@@ -7,7 +8,7 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	const { dbCtx } = await parent();
 
-	const notes = dbCtx?.db ? await getActiveOutboundNotes(dbCtx?.db) : [];
+	const notes = dbCtx?.db ? await timed(getActiveOutboundNotes, dbCtx?.db) : [];
 
 	return { dbCtx, notes };
 };

--- a/apps/web-client/src/routes/outbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/outbound/[id]/+page.ts
@@ -12,7 +12,7 @@ import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
 
-const _load: PageLoad = async ({ parent, params, depends }) => {
+const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	const id = Number(params.id);
 
 	depends("note:data");
@@ -68,4 +68,4 @@ const getAvailabilityByISBN = async (db: DB, isbns: string[]): Promise<Map<numbe
 	return [...resMap.values()];
 };
 
-export const load = timed(_load as any) as PageLoad;
+export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/outbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/outbound/[id]/+page.ts
@@ -10,7 +10,9 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
 
-export const load: PageLoad = async ({ parent, params, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
 
 	depends("note:data");
@@ -65,3 +67,5 @@ const getAvailabilityByISBN = async (db: DB, isbns: string[]): Promise<Map<numbe
 
 	return [...resMap.values()];
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/outbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/outbound/[id]/+page.ts
@@ -9,7 +9,6 @@ import { getStock } from "$lib/db/cr-sqlite/stock";
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
 import { appPath } from "$lib/paths";
-import { timed } from "$lib/utils/time";
 
 export const load: PageLoad = async ({ parent, params, depends }) => {
 	const id = Number(params.id);
@@ -33,7 +32,7 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		};
 	}
 
-	const note = await timed(getNoteById, dbCtx.db, id);
+	const note = await getNoteById(dbCtx.db, id);
 	// If note not found, we shouldn't be here
 	// If note committed, we shouldn't be here either (it can be viewed in the note archive)
 	// This also triggers redirect to inbound (reactively) upon committing of the note
@@ -41,17 +40,16 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 		redirect(307, appPath("outbound"));
 	}
 
-	const warehouses = await timed(getAllWarehouses, dbCtx.db);
-	const _entries = await timed(getNoteEntries, dbCtx.db, id);
-	const entriesAvailability = await timed(
-		getAvailabilityByISBN,
+	const warehouses = await getAllWarehouses(dbCtx.db);
+	const _entries = await getNoteEntries(dbCtx.db, id);
+	const entriesAvailability = await getAvailabilityByISBN(
 		dbCtx.db,
 		_entries.map(({ isbn }) => isbn)
 	);
 	const entries = _entries.map((e, i) => ({ ...e, availableWarehouses: entriesAvailability[i] }));
-	const customItems = await timed(getNoteCustomItems, dbCtx.db, id);
+	const customItems = await getNoteCustomItems(dbCtx.db, id);
 
-	const publisherList = await timed(getPublisherList, dbCtx.db);
+	const publisherList = await getPublisherList(dbCtx.db);
 
 	return { dbCtx, ...note, warehouses, entries, customItems, publisherList };
 };
@@ -60,7 +58,7 @@ export const load: PageLoad = async ({ parent, params, depends }) => {
 const getAvailabilityByISBN = async (db: DB, isbns: string[]): Promise<Map<number, { displayName: string; quantity: number }>[]> => {
 	const resMap = new Map(isbns.map((isbn) => [isbn, new Map<number, { displayName: string; quantity: number }>()]));
 
-	const stock = await timed(getStock, db, { isbns });
+	const stock = await getStock(db, { isbns });
 	for (const { isbn, warehouseId, warehouseName, quantity } of stock) {
 		resMap.get(isbn)?.set(warehouseId, { displayName: warehouseName, quantity });
 	}

--- a/apps/web-client/src/routes/settings/+page.ts
+++ b/apps/web-client/src/routes/settings/+page.ts
@@ -9,7 +9,9 @@ import { deviceSettingsSchema, syncSettingsSchema } from "$lib/forms/schemas";
 
 import { syncConfig } from "$lib/db";
 
-export const load: PageLoad = async () => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async () => {
 	const deviceSettingsData = get(deviceSettingsStore);
 	const deviceSettingsForm = await superValidate(deviceSettingsData, zod(deviceSettingsSchema));
 
@@ -18,3 +20,5 @@ export const load: PageLoad = async () => {
 
 	return { deviceSettingsForm, syncSettingsForm };
 };
+
+export const load = timed(_load as any) as PageLoad;

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -34,6 +34,7 @@
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import { appPath } from "$lib/paths";
 	import { racefreeGoto } from "$lib/utils/navigation";
+	import { timed } from "$lib/utils/time";
 
 	export let data: PageData;
 	$: db = data?.dbCtx?.db;
@@ -76,7 +77,9 @@
 	// - further below, we're checking that +1 entry exists, if so, we let the intersection observer know it can requery when reached (infinite scroll)
 	//
 	// TODO: 'db' should always be defined, as we want this to run ONLY in browser context, but, as of yet, I wasn't able to get this to work
-	$: currentQuery = Promise.resolve(db && $search.length > 2 ? getStock(db, { searchString: $search }) : ([] as GetStockResponseItem[]));
+	$: currentQuery = Promise.resolve(
+		db && $search.length > 2 ? timed(getStock, db, { searchString: $search }) : ([] as GetStockResponseItem[])
+	);
 	$: currentQuery.then((e) => (entries = e));
 
 	const tableOptions = writable({ data: entries.slice(0, maxResults) });

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -34,7 +34,6 @@
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import { appPath } from "$lib/paths";
 	import { racefreeGoto } from "$lib/utils/navigation";
-	import { timed } from "$lib/utils/time";
 
 	export let data: PageData;
 	$: db = data?.dbCtx?.db;
@@ -77,9 +76,7 @@
 	// - further below, we're checking that +1 entry exists, if so, we let the intersection observer know it can requery when reached (infinite scroll)
 	//
 	// TODO: 'db' should always be defined, as we want this to run ONLY in browser context, but, as of yet, I wasn't able to get this to work
-	$: currentQuery = Promise.resolve(
-		db && $search.length > 2 ? timed(getStock, db, { searchString: $search }) : ([] as GetStockResponseItem[])
-	);
+	$: currentQuery = Promise.resolve(db && $search.length > 2 ? getStock(db, { searchString: $search }) : ([] as GetStockResponseItem[]));
 	$: currentQuery.then((e) => (entries = e));
 
 	const tableOptions = writable({ data: entries.slice(0, maxResults) });

--- a/apps/web-client/src/routes/stock/+page.ts
+++ b/apps/web-client/src/routes/stock/+page.ts
@@ -2,7 +2,9 @@ import type { PageLoad } from "./$types";
 
 import { getPublisherList } from "$lib/db/cr-sqlite/books";
 
-export const load: PageLoad = async ({ parent, depends }) => {
+import { timed } from "$lib/utils/timer";
+
+const _load: PageLoad = async ({ parent, depends }) => {
 	depends("book:data");
 
 	const { dbCtx } = await parent();
@@ -16,3 +18,5 @@ export const load: PageLoad = async ({ parent, depends }) => {
 
 	return { dbCtx, publisherList };
 };
+
+export const load = timed(_load as any) as PageLoad;


### PR DESCRIPTION
Creates a `timed` wrapper for functions:
- db interactions are wrapped so that they do what they normally would, but (optionally) log the execution time
- `timeLogger` is attached to the window, allowing for:
  - turning on/off (controlled from the console -- persisted between renders)
  - exporting the report (if turned on) of recorded interactions
- load functions are wrapped as well
- the final report looks something like this:
```
  Route: <route-id>:
    - <function-foo>: <execution-time>ms
    - <function-bar>: <execution-time>ms
    - total load: <total-load-function-exec-time>ms
```
This shouldn't affect the functionality in any way, so I suggest we merge as soon as green

