### PR TITLE
add 'getDB' function to the window (at root layout.ts):

### DIFF
--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -18,6 +18,7 @@ import { detectLocale } from "@librocco/shared/i18n-util";
 import { DEFAULT_LOCALE, IS_E2E } from "$lib/constants";
 import { newPluginsInterface } from "$lib/plugins";
 import { timeLogger } from "$lib/utils/timer";
+import { getDB } from "$lib/db/cr-sqlite";
 
 // Paths which are valid (shouldn't return 404, but don't have any content and should get redirected to the default route "/inventory/stock/all")
 const redirectPaths = ["", "/"].map((path) => `${base}${path}`);
@@ -51,6 +52,9 @@ export const load: LayoutLoad = async ({ url, route }) => {
 
 	// If in browser, we init the db, otherwise this is a prerender, for which we're only building basic html skeleton
 	if (browser) {
+		// For debug purposes and manual overrides (e.g. 'schema_version')
+		window["getDB"] = getDB;
+
 		// Init the db
 		const { getInitializedDB } = await import("$lib/db/cr-sqlite");
 		const dbCtx = await getInitializedDB(get(dbid));


### PR DESCRIPTION
in order to be able to use the DB from console even if the app crashes.

This is quite useful when we apply some minor changes to the DB schema and want to manually update the `schema_version` (without the full round trip of torching the DB, initialising and, potentially, adding the data)
