### PR TITLE
Optimise/some query optimisations

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -359,9 +359,14 @@ describe("Inbound note tests", () => {
 		await createInboundNote(db, 1, 1);
 		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 2, warehouseId: 1 });
 		await addVolumesToNote(db, 1, { isbn: "2222222222", quantity: 3, warehouseId: 1 });
+		await addVolumesToNote(db, 1, { isbn: "3333333333", quantity: 3, warehouseId: 1 });
+
+		await removeNoteTxn(db, 1, { isbn: "3333333333", warehouseId: 1 });
+
+		await updateNoteTxn(db, 1, { isbn: "2222222222", warehouseId: 1 }, { quantity: 4, warehouseId: 1 });
 
 		expect(await getActiveInboundNotes(db)).toEqual([
-			{ id: 1, displayName: "New Note", warehouseName: "Warehouse 1", updatedAt: expect.any(Date), totalBooks: 5 }
+			{ id: 1, displayName: "New Note", warehouseName: "Warehouse 1", updatedAt: expect.any(Date), totalBooks: 6 }
 		]);
 	});
 });
@@ -823,8 +828,13 @@ describe("Outbound note tests", () => {
 		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 2, warehouseId: 1 });
 		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 5, warehouseId: 2 });
 		await addVolumesToNote(db, 1, { isbn: "2222222222", quantity: 3, warehouseId: 1 });
+		await addVolumesToNote(db, 1, { isbn: "3333333333", quantity: 3, warehouseId: 1 });
 
-		expect(await getActiveOutboundNotes(db)).toEqual([{ id: 1, displayName: "New Note", updatedAt: expect.any(Date), totalBooks: 10 }]);
+		await removeNoteTxn(db, 1, { isbn: "3333333333", warehouseId: 1 });
+
+		await updateNoteTxn(db, 1, { isbn: "2222222222", warehouseId: 1 }, { quantity: 4, warehouseId: 1 });
+
+		expect(await getActiveOutboundNotes(db)).toEqual([{ id: 1, displayName: "New Note", updatedAt: expect.any(Date), totalBooks: 11 }]);
 	});
 });
 

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -141,12 +141,10 @@ async function _getActiveInboundNotes(db: DB): Promise<InboundNoteListItem[]> {
 			note.display_name AS displayName,
 			warehouse.display_name AS warehouseName,
 			note.updated_at,
-			COALESCE(SUM(book_transaction.quantity), 0) AS totalBooks
+			COALESCE(note.total_books, 0) AS totalBooks
 		FROM note
 		INNER JOIN warehouse ON note.warehouse_id = warehouse.id
-		LEFT JOIN book_transaction ON note.id = book_transaction.note_id
 		WHERE note.committed = 0
-		GROUP BY note.id
 		ORDER BY note.updated_at DESC
 	`;
 
@@ -169,12 +167,10 @@ async function _getActiveOutboundNotes(db: DB): Promise<OutboundNoteListItem[]> 
 			note.id,
 			note.display_name AS displayName,
 			note.updated_at,
-			COALESCE(SUM(book_transaction.quantity), 0) AS totalBooks
+			COALESCE(note.total_books, 0) AS totalBooks
 		FROM note
-		LEFT JOIN book_transaction ON note.id = book_transaction.note_id
 		WHERE note.warehouse_id IS NULL
 		AND note.committed = 0
-		GROUP BY note.id
 		ORDER BY note.updated_at DESC
 	`;
 

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -141,9 +141,10 @@ async function _getActiveInboundNotes(db: DB): Promise<InboundNoteListItem[]> {
 			note.display_name AS displayName,
 			warehouse.display_name AS warehouseName,
 			note.updated_at,
-			COALESCE(note.total_books, 0) AS totalBooks
+			COALESCE(ntb.total_books, 0) AS totalBooks
 		FROM note
 		INNER JOIN warehouse ON note.warehouse_id = warehouse.id
+		LEFT JOIN note_total_books ntb ON note.id = ntb.note_id
 		WHERE note.committed = 0
 		ORDER BY note.updated_at DESC
 	`;
@@ -167,8 +168,9 @@ async function _getActiveOutboundNotes(db: DB): Promise<OutboundNoteListItem[]> 
 			note.id,
 			note.display_name AS displayName,
 			note.updated_at,
-			COALESCE(note.total_books, 0) AS totalBooks
+			COALESCE(ntb.total_books, 0) AS totalBooks
 		FROM note
+		LEFT JOIN note_total_books ntb ON note.id = ntb.note_id
 		WHERE note.warehouse_id IS NULL
 		AND note.committed = 0
 		ORDER BY note.updated_at DESC

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -174,6 +174,59 @@ CREATE INDEX idx_book_transaction_note_id ON book_transaction(note_id);
 CREATE INDEX idx_book_transaction_warehouse_id ON book_transaction(warehouse_id);
 SELECT crsql_as_crr('book_transaction');
 
+CREATE TABLE book_stock (
+	warehouse_id INTEGER NOT NULL,
+	isbn TEXT NOT NULL,
+	quantity INTEGER NOT NULL DEFAULT 0,
+	PRIMARY KEY (warehouse_id, isbn)
+);
+SELECT crsql_as_crr('book_stock');
+
+-- Each time a note is committed, this trigger recalculates the stock for each (warehouse, isbn) entry
+CREATE TRIGGER trg_commit_note_update_stock
+AFTER UPDATE OF committed ON note
+WHEN NEW.committed = 1 AND OLD.committed = 0
+BEGIN
+  -- Inbound
+  INSERT INTO book_stock (warehouse_id, isbn, quantity)
+  SELECT
+    bt.warehouse_id,
+    bt.isbn,
+	CASE
+		WHEN (n.warehouse_id IS NOT NULL OR n.is_reconciliation_note = 1) THEN SUM(bt.quantity)
+		ELSE -SUM(bt.quantity)
+	END AS quantity
+  FROM book_transaction bt
+  JOIN note n ON n.id = bt.note_id
+  WHERE bt.note_id = NEW.id
+  GROUP BY bt.warehouse_id, bt.isbn
+  ON CONFLICT(warehouse_id, isbn) DO UPDATE SET
+    quantity = quantity + excluded.quantity;
+END;
+
+-- This trigger works on insertions of committed notes (in general)
+-- but it will generally be used when creating and committing a reconciliation note
+CREATE TRIGGER trg_insert_committed_note_update_stock
+AFTER INSERT ON note
+WHEN NEW.committed = 1
+BEGIN
+  -- Inbound
+  INSERT INTO book_stock (warehouse_id, isbn, quantity)
+  SELECT
+    bt.warehouse_id,
+    bt.isbn,
+	CASE
+		WHEN (n.warehouse_id IS NOT NULL OR n.is_reconciliation_note = 1) THEN SUM(bt.quantity)
+		ELSE -SUM(bt.quantity)
+	END AS quantity
+  FROM book_transaction bt
+  JOIN note n ON n.id = bt.note_id
+  WHERE bt.note_id = NEW.id
+  GROUP BY bt.warehouse_id, bt.isbn
+  ON CONFLICT(warehouse_id, isbn) DO UPDATE SET
+    quantity = quantity + excluded.quantity;
+END;
+
 
 CREATE TABLE custom_item (
 	id INTEGER NOT NULL,

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -210,7 +210,6 @@ CREATE TABLE book_stock (
 	quantity INTEGER NOT NULL DEFAULT 0,
 	PRIMARY KEY (warehouse_id, isbn)
 );
-SELECT crsql_as_crr('book_stock');
 
 -- Each time a note is committed, this trigger recalculates the stock for each (warehouse, isbn) entry
 CREATE TRIGGER trg_commit_note_update_stock

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -51,6 +51,7 @@ CREATE TABLE book (
     PRIMARY KEY (isbn)
 );
 SELECT crsql_as_crr('book');
+CREATE INDEX idx_book_publisher ON book(publisher);
 
 CREATE TABLE supplier (
 	id INTEGER NOT NULL,

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -149,6 +149,7 @@ CREATE TABLE note (
 	updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000),
 	committed INTEGER NOT NULL DEFAULT 0,
 	committed_at INTEGER,
+	total_books INTEGER DEFAULT 0,
 	PRIMARY KEY (id)
 	-- FOREIGN KEY (warehouse_id) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL,
 	-- FOREIGN KEY (default_warehouse) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL
@@ -173,6 +174,30 @@ CREATE INDEX idx_book_transaction_isbn ON book_transaction(isbn);
 CREATE INDEX idx_book_transaction_note_id ON book_transaction(note_id);
 CREATE INDEX idx_book_transaction_warehouse_id ON book_transaction(warehouse_id);
 SELECT crsql_as_crr('book_transaction');
+
+CREATE TRIGGER trg_insert_txn_update_note_total
+AFTER INSERT ON book_transaction
+BEGIN
+  UPDATE note
+  SET total_books = total_books + NEW.quantity
+  WHERE id = NEW.note_id;
+END;
+
+CREATE TRIGGER trg_update_txn_update_note_total
+AFTER UPDATE OF quantity ON book_transaction
+BEGIN
+  UPDATE note
+  SET total_books = total_books + NEW.quantity - OLD.quantity
+  WHERE id = NEW.note_id;
+END;
+
+CREATE TRIGGER trg_remove_txn_update_note_total
+AFTER DELETE ON book_transaction
+BEGIN
+  UPDATE note
+  SET total_books = total_books - OLD.quantity
+  WHERE id = OLD.note_id;
+END;
 
 CREATE TABLE book_stock (
 	warehouse_id INTEGER NOT NULL,

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -149,7 +149,6 @@ CREATE TABLE note (
 	updated_at INTEGER DEFAULT (strftime('%s', 'now') * 1000),
 	committed INTEGER NOT NULL DEFAULT 0,
 	committed_at INTEGER,
-	total_books INTEGER DEFAULT 0,
 	PRIMARY KEY (id)
 	-- FOREIGN KEY (warehouse_id) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL,
 	-- FOREIGN KEY (default_warehouse) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL
@@ -157,6 +156,13 @@ CREATE TABLE note (
 CREATE INDEX idx_note_warehouse_id ON note(warehouse_id);
 CREATE INDEX idx_note_default_warehouse ON note(default_warehouse);
 SELECT crsql_as_crr('note');
+
+CREATE TABLE note_total_books(
+	note_id INTEGER NOT NULL,
+	total_books INTEGER NOT NULL DEFAULT 0,
+	PRIMARY KEY (note_id)
+);
+-- NOTE: no crsql_as_crr as we don't want to sync this table
 
 CREATE TABLE book_transaction (
 	isbn TEXT NOT NULL,
@@ -178,25 +184,24 @@ SELECT crsql_as_crr('book_transaction');
 CREATE TRIGGER trg_insert_txn_update_note_total
 AFTER INSERT ON book_transaction
 BEGIN
-  UPDATE note
-  SET total_books = total_books + NEW.quantity
-  WHERE id = NEW.note_id;
+  INSERT INTO note_total_books (note_id, total_books) VALUES (NEW.note_id, NEW.quantity)
+  ON CONFLICT (note_id) DO UPDATE SET total_books = note_total_books.total_books + NEW.quantity;
 END;
 
 CREATE TRIGGER trg_update_txn_update_note_total
 AFTER UPDATE OF quantity ON book_transaction
 BEGIN
-  UPDATE note
+  UPDATE note_total_books
   SET total_books = total_books + NEW.quantity - OLD.quantity
-  WHERE id = NEW.note_id;
+  WHERE note_id = NEW.note_id;
 END;
 
 CREATE TRIGGER trg_remove_txn_update_note_total
 AFTER DELETE ON book_transaction
 BEGIN
-  UPDATE note
+  UPDATE note_total_books
   SET total_books = total_books - OLD.quantity
-  WHERE id = OLD.note_id;
+  WHERE note_id = OLD.note_id;
 END;
 
 CREATE TABLE book_stock (


### PR DESCRIPTION
An effort to improve app load times (queries and such). As of now this is still WIP.

It has:
- updates to publisher retrieval - created an index - major speedup
- updates to warehouse list queries (and stock queries in general) - created a materialised calc table `book_stock` - major speedup to retrieval
- updates to note list queries - created a metarialised table `note_total_books` - major speedup
- data is consistent (even under sync) - the materialised tables aren't being synced (to avoid double addition/subtraction) and are updated by data triggers

Some challenges:
- data triggers make the sync teeeediously slow
- the infinite scroll is broken on note list views (starts at infinity 😂) so the load is really slow (due to paing, the load fn takes 250-280ms)
- warehouse total stock doesn't show anything (total stock = 0) after sync (even though a similar scenario passes in tests)

I would, by no means, recommend merging this in as it's a broken work in progress

**edit:** 
- tests are added for data consistency (didn't work at first)
- benchmarks coming soon: this should take care of most of the lag in #910 (provided I get it to work...)
