### PR TITLE
Split e2e tests into 6 jobs

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -21,6 +21,11 @@ jobs:
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,39 +39,17 @@ jobs:
         run: cd apps/web-client && rushx build:e2e
       - name: Download playwright browsers
         run: cd apps/e2e && npx playwright install
-      - name: Run Playwright tests
+      - name: Run Playwright tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: cd apps/e2e && rushx test:ci
-      - name: Install lftp
-        if: always()
-        run: |
-          [ -d apps/e2e/playwright-report ] || exit 0
-          sudo apt-get update
-          sudo apt-get install lftp
-      - name: Copy playwright test result to bunny storage zone
-        if: always()
-        run: |
-          [ -d apps/e2e/playwright-report ] || exit 0
-          lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-          set ftp:ssl-allow no
-          set mirror:parallel-transfer-count 10
-          mirror -R apps/e2e/playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
-          EOF
-          echo Uploaded to https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests
         env:
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
-      - name: Purge bunny cache
-        if: always()
-        run: |
-          [ -d apps/e2e/playwright-report ] || exit 0
-          curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+          PLAYWRIGHT_OPTIONS: "--shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+      #! upload each shard’s blob so we can merge later
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-test-results
-          path: apps/e2e/test-results
-          retention-days: 30
+          name: e2e-blob-report-${{ matrix.shardIndex }}
+          path: apps/e2e/blob-report
+          retention-days: 2
 
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -167,3 +150,55 @@ jobs:
           BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
       - name: Output link to deployed app
         run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
+  e2e-merge-report:
+    if: ${{ !cancelled() }}
+    needs: [e2e-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: e2e-blob-report-*
+          merge-multiple: true
+
+      - name: Merge to HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Install lftp
+        run: |
+          sudo apt-get update
+          sudo apt-get install lftp
+
+      - name: Upload merged report to Bunny storage
+        run: |
+          lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
+          set ftp:ssl-allow no
+          set mirror:parallel-transfer-count 10
+          mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
+          EOF
+        env:
+          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+
+      - name: Purge Bunny cache
+        run: |
+          curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
+               --header "content-type: application/json" \
+               --header "AccessKey: $BUNNY_API_KEY"
+        env:
+          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-merged-html-report
+          path: playwright-report
+          retention-days: 30
+
+      - name: Output link to report
+        run: echo "Merged e2e report https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests/index.html" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -104,6 +104,18 @@ jobs:
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        shardTotal:
+        - 6
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -128,39 +140,16 @@ jobs:
       run: cd apps/web-client && rushx build:e2e
     - name: Download playwright browsers
       run: cd apps/e2e && npx playwright install
-    - name: Run Playwright tests
+    - name: Run Playwright tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
       run: cd apps/e2e && rushx test:ci
-    - name: Install lftp
-      if: always()
-      run: |
-        [ -d apps/e2e/playwright-report ] || exit 0
-        sudo apt-get update
-        sudo apt-get install lftp
-    - name: Copy playwright test result to bunny storage zone
-      if: always()
-      run: |
-        [ -d apps/e2e/playwright-report ] || exit 0
-        lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-        set ftp:ssl-allow no
-        set mirror:parallel-transfer-count 10
-        mirror -R apps/e2e/playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
-        EOF
-        echo Uploaded to https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests
       env:
-        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
-    - name: Purge bunny cache
-      if: always()
-      run: |
-        [ -d apps/e2e/playwright-report ] || exit 0
-        curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"
-      env:
-        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        PLAYWRIGHT_OPTIONS: --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-test-results
-        path: apps/e2e/test-results
-        retention-days: 30
+        name: e2e-blob-report-${{ matrix.shardIndex }}
+        path: apps/e2e/blob-report
+        retention-days: 2
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -300,3 +289,49 @@ jobs:
         BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
     - name: Output link to deployed app
       run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
+  e2e-merge-report:
+    if: ${{ !cancelled() }}
+    needs:
+    - e2e-test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+    - name: Download blob reports
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: e2e-blob-report-*
+        merge-multiple: true
+    - name: Merge to HTML report
+      run: npx playwright merge-reports --reporter html ./all-blob-reports
+    - name: Install lftp
+      run: |
+        sudo apt-get update
+        sudo apt-get install lftp
+    - name: Upload merged report to Bunny storage
+      run: |
+        lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
+        set ftp:ssl-allow no
+        set mirror:parallel-transfer-count 10
+        mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
+        EOF
+      env:
+        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+    - name: Purge Bunny cache
+      run: |
+        curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
+             --header "content-type: application/json" \
+             --header "AccessKey: $BUNNY_API_KEY"
+      env:
+        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: e2e-merged-html-report
+        path: playwright-report
+        retention-days: 30
+    - name: Output link to report
+      run: echo "Merged e2e report https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests/index.html" | tee -a $GITHUB_STEP_SUMMARY

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -7,7 +7,7 @@
 		"test:debug": "PLAYWRIGHT_HTML_OPEN=never playwright test $1 --debug",
 		"test:run": "PLAYWRIGHT_HTML_OPEN=never playwright test",
 		"test:codegen": "playwright codegen",
-		"test:ci": "(cd ../web-client && rushx preview) & PREVIEW_PID=$!; CI=true playwright test; RESULT=$?; kill $PREVIEW_PID; exit $RESULT",
+		"test:ci": "(cd ../web-client && rushx preview) & PREVIEW_PID=$!; CI=true playwright test ${PLAYWRIGHT_OPTIONS:-} \"$@\"; RESULT=$?; kill $PREVIEW_PID; exit $RESULT",
 		"typecheck": "tsc",
 		"lint": "prettier --check . && eslint .",
 		"lint:strict": "prettier --check . && eslint . --max-warnings=0",

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices, ReporterDescription } from "@playwright/test";
 
 const reporter: ReporterDescription[] = [["list"]];
+// Produce a merge‑able blob report when running in CI
 if (process.env.CI) {
-	reporter.push(["html"]);
+	reporter.push(["blob"]);
 }
 
 /**
@@ -11,7 +12,7 @@ if (process.env.CI) {
 export default defineConfig({
 	testDir: "./integration",
 	/* Run tests in files in parallel */
-	fullyParallel: true,
+	fullyParallel: false,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	/* Retry for local test run (normally, the tests ran using the UI will not be flaky, but headless tests might take a toll on the CPU, resulting in flaky tests) */


### PR DESCRIPTION
This PR changes the way e2e tests are run in CI: instead of running them all in a single job, six jobs are spawn to run them in parallel. A seventh job takes care of merging the test results and publishing them.

The overall waiting time for CI to finish is brought down to 8 minutes from 18.