### PR TITLE
Fix/playwright config

### DIFF
--- a/apps/e2e/constants.ts
+++ b/apps/e2e/constants.ts
@@ -1,6 +1,6 @@
 import * as net from "net";
 
-export const IS_CI = process.env.CI === "true";
+export const IS_CI = /^(?:1|true|on)$/i.test(process.env.CI?.trim() ?? "");
 
 export function getPort(): Promise<number> {
 	const testSocket = new net.Socket();

--- a/apps/e2e/constants.ts
+++ b/apps/e2e/constants.ts
@@ -21,8 +21,7 @@ export function getPort(): Promise<number> {
 }
 
 const port = await getPort();
-export const baseURL = `http://localhost:${port}`;
-
+export const baseURL = `http://localhost:${port}/preview/`;
 
 /** Max timeout for DOM assertions (waitFor, etc. - longer in CI, default in non-CI) */
 export const assertionTimeout = IS_CI ? 15000 : undefined;

--- a/apps/e2e/constants.ts
+++ b/apps/e2e/constants.ts
@@ -1,5 +1,7 @@
 import * as net from "net";
 
+export const IS_CI = process.env.CI === "true";
+
 export function getPort(): Promise<number> {
 	const testSocket = new net.Socket();
 
@@ -21,5 +23,6 @@ export function getPort(): Promise<number> {
 const port = await getPort();
 export const baseURL = `http://localhost:${port}`;
 
+
 /** Max timeout for DOM assertions (waitFor, etc. - longer in CI, default in non-CI) */
-export const assertionTimeout = process.env.CI ? 15000 : undefined;
+export const assertionTimeout = IS_CI ? 15000 : undefined;

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -2,12 +2,12 @@ import { DB } from "@vlcn.io/crsqlite-wasm";
 import test, { JSHandle } from "@playwright/test";
 
 import { BookData, wrapIter, TranslationFunctions, Locales } from "@librocco/shared";
-
-import { Customer, Supplier } from "./types";
-
-import { baseURL } from "@/integration/constants";
 import { loadLocale } from "@librocco/shared/i18n-util.sync";
 import { i18nObject } from "@librocco/shared/i18n-util";
+
+import { baseURL } from "@/constants";
+
+import { Customer, Supplier } from "./types";
 
 import {
 	addBooksToCustomer,

--- a/apps/e2e/integration/constants.ts
+++ b/apps/e2e/integration/constants.ts
@@ -1,1 +1,0 @@
-export const baseURL = process.env.CI ? "http://localhost:4173/preview/" : "http://localhost:4173/preview/";

--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { testOrders } from "@/helpers/fixtures";
 import { getDbHandle } from "@/helpers";

--- a/apps/e2e/integration/customer_order_form.spec.ts
+++ b/apps/e2e/integration/customer_order_form.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { testOrders } from "@/helpers/fixtures";
 

--- a/apps/e2e/integration/db_management_ui.spec.ts
+++ b/apps/e2e/integration/db_management_ui.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { getDashboard } from "@/helpers";
 import { selector, testIdSelector } from "@/helpers/utils";

--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 import { assertionTimeout } from "@/constants";
 
 import { getDashboard, getDbHandle } from "@/helpers";

--- a/apps/e2e/integration/navigation_temp.spec.ts
+++ b/apps/e2e/integration/navigation_temp.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { getDashboard } from "@/helpers";
 

--- a/apps/e2e/integration/outbound_flow.spec.ts
+++ b/apps/e2e/integration/outbound_flow.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import { testBase as test } from "@/helpers/fixtures";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 import { assertionTimeout } from "@/constants";
 
 import { getDashboard, getDbHandle } from "@/helpers";

--- a/apps/e2e/integration/reactivity/customers.spec.ts
+++ b/apps/e2e/integration/reactivity/customers.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { baseURL } from "../constants";
+import { baseURL } from "@/constants";
 
 import { getDbHandle, upsertCustomer } from "@/helpers/cr-sqlite";
 import { depends, testOrders } from "@/helpers/fixtures";

--- a/apps/e2e/integration/reactivity/supplier_orders.spec.ts
+++ b/apps/e2e/integration/reactivity/supplier_orders.spec.ts
@@ -1,4 +1,4 @@
-import { baseURL } from "../constants";
+import { baseURL } from "@/constants";
 
 import { addBooksToCustomer, associatePublisher, getDbHandle, upsertBook, upsertSupplier } from "@/helpers/cr-sqlite";
 import { testOrders } from "@/helpers/fixtures";

--- a/apps/e2e/integration/reconciliation_order.spec.ts
+++ b/apps/e2e/integration/reconciliation_order.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 import { depends, testOrders } from "@/helpers/fixtures";
 
 testOrders("create: single order: on row button click", async ({ page, supplierOrders }) => {

--- a/apps/e2e/integration/search_flow.spec.ts
+++ b/apps/e2e/integration/search_flow.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { getDashboard, getDbHandle } from "@/helpers";
 import { addVolumesToNote, commitNote, createInboundNote, upsertWarehouse } from "@/helpers/cr-sqlite";

--- a/apps/e2e/integration/supplier_form.spec.ts
+++ b/apps/e2e/integration/supplier_form.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { testOrders } from "@/helpers/fixtures";
 

--- a/apps/e2e/integration/supplier_order.spec.ts
+++ b/apps/e2e/integration/supplier_order.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 import { getDbHandle } from "@/helpers";
 import {
 	addBooksToCustomer,

--- a/apps/e2e/integration/supplier_publisher.spec.ts
+++ b/apps/e2e/integration/supplier_publisher.spec.ts
@@ -1,4 +1,4 @@
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 import { test, expect } from "@playwright/test";
 import { associatePublisher, removePublisherFromSupplier, upsertBook } from "@/helpers/cr-sqlite";
 import { depends, testOrders } from "@/helpers/fixtures";

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 
-import { baseURL } from "./constants";
+import { baseURL } from "@/constants";
 
 import { getDashboard, getDbHandle } from "@/helpers";
 import { book1 } from "@/integration/data";

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig, devices, ReporterDescription } from "@playwright/test";
 
+import { IS_CI } from "./constants";
+
 const reporter: ReporterDescription[] = [["list"]];
 // Produce a merge‑able blob report when running in CI
-if (process.env.CI) {
+if (IS_CI) {
 	reporter.push(["blob"]);
 }
 
@@ -12,15 +14,15 @@ if (process.env.CI) {
 export default defineConfig({
 	testDir: "./integration",
 	/* Run tests in files in parallel */
-	fullyParallel: false,
+	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
-	forbidOnly: !!process.env.CI,
+	forbidOnly: IS_CI,
 	/* Retry for local test run (normally, the tests ran using the UI will not be flaky, but headless tests might take a toll on the CPU, resulting in flaky tests) */
-	retries: 3,
+	retries: 1,
 	timeout: 15000,
 	globalTimeout: 55 * 60 * 1000, // 55 minutes of global timeout - the github job has a 60 minutes limit
 	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : 4,
+	workers: IS_CI ? 1 : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: reporter,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
For the most part, this PR serves to revert some changes to `playwright.config.ts` which I deem unnecessary, as well, as limiting for local env.

Furthermore, there was some ambiguity (which I couldn't put my finger on) around the port the app is served from:
- @silviot had made the determining of the base url (port `4173` or `5173`) easier and more automated
- the problem: it didn't seem to work (😂)
- the actual problem: we had two sources of truth for `baseURL`
- the solution: removed `e2e/integration/constants.ts` and made all tests use `e2e/constants.ts` (where the port check is made)
- works like a charm

Oh, and yeah: fix ambiguity with `CI` env variable:
- if `export CI=false`,  `process.env.CI == "false" == true`
- however if `export CI=false` and `IS_CI = process.env.CI === "true"`, `IS_CI == false`
