### PR TITLE
optimise: sluggish outbound scanning:

### DIFF
--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -51,6 +51,7 @@ CREATE TABLE book (
     PRIMARY KEY (isbn)
 );
 SELECT crsql_as_crr('book');
+CREATE INDEX idx_book_publisher ON book(publisher);
 
 CREATE TABLE supplier (
 	id INTEGER NOT NULL,

--- a/apps/web-client/src/routes/outbound/[id]/+page.ts
+++ b/apps/web-client/src/routes/outbound/[id]/+page.ts
@@ -42,7 +42,7 @@ const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 		redirect(307, appPath("outbound"));
 	}
 
-	const warehouses = await getAllWarehouses(dbCtx.db);
+	const warehouses = await getAllWarehouses(dbCtx.db, { skipTotals: true });
 	const _entries = await getNoteEntries(dbCtx.db, id);
 	const entriesAvailability = await getAvailabilityByISBN(
 		dbCtx.db,


### PR DESCRIPTION
* don't calculate 'totalBooks' for warehouses loaded in outbound view (not used and speeds up queries by orders of magnitute)
* create publisher index on 'book' table - much faster 'getPublishers' query

Works on my machine. Please try on yours.

The benchmarks before after (on outbound note page):
- `getAllWarehouses` - ~400ms -> ~5ms
- `getPublisherList` - ~75ms -> 14ms
- total load: ~500ms -> ~30ms 