### PR TITLE
uncomment the time logger in root layout

### DIFF
--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -36,9 +36,9 @@
 
 	const { dbCtx } = data;
 
-	// beforeNavigate(({ to }) => {
-	// 	timeLogger.setCurrentRoute(to.route.id);
-	// });
+	beforeNavigate(({ to }) => {
+		timeLogger.setCurrentRoute(to.route.id);
+	});
 
 	$: {
 		// Register (and update on each change) the db and some db handlers to the window object.


### PR DESCRIPTION
I need this, I use it a lot, it doesn't affect performance in any way and is opt-in (in terms of cluttering the console).

Merging as soon as green
