### PR TITLE
Playwright matrix/fix e2e tests

### DIFF
--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -246,12 +246,12 @@ export const testBase = test.extend({
 	page: async ({ page }, use) => {
 		// Make sure the DB schema is initialised before running any tests
 		// This is here to prevent partial initialisation (and subsequent conflicts when reinitialising the, partially initialised, schema)
-		await page.goto(baseURL)
+		await page.goto(baseURL);
 		await getDbHandle(page);
 
 		const goto = page.goto;
 
-		page.goto = async function(url, opts) {
+		page.goto = async function (url, opts) {
 			// Wait for 100ms, for ongoing IndexedDB transactions to finish
 			// This is as dirty as it gets, but is a quick fix to ensure that ongoing txns (such as fixture setups)
 			// don't get interrupted on navigation - causing flaky-as-hell tests

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -244,9 +244,14 @@ type OrderTestFixture = {
 
 export const testBase = test.extend({
 	page: async ({ page }, use) => {
+		// Make sure the DB schema is initialised before running any tests
+		// This is here to prevent partial initialisation (and subsequent conflicts when reinitialising the, partially initialised, schema)
+		await page.goto(baseURL)
+		await getDbHandle(page);
+
 		const goto = page.goto;
 
-		page.goto = async function (url, opts) {
+		page.goto = async function(url, opts) {
 			// Wait for 100ms, for ongoing IndexedDB transactions to finish
 			// This is as dirty as it gets, but is a quick fix to ensure that ongoing txns (such as fixture setups)
 			// don't get interrupted on navigation - causing flaky-as-hell tests

--- a/apps/e2e/integration/book_form.spec.ts
+++ b/apps/e2e/integration/book_form.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-
 import { baseURL } from "../constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import { upsertWarehouse, createInboundNote, createOutboundNote, addVolumesToNote, commitNote } from "@/helpers/cr-sqlite";
 

--- a/apps/e2e/integration/book_form.spec.ts
+++ b/apps/e2e/integration/book_form.spec.ts
@@ -33,7 +33,7 @@ test("update is reflected in table view - stock", async ({ page }) => {
 
 	// Navigate to the warehouse page
 	await content.entityList("warehouse-list").item(0).dropdown().viewStock();
-	await page.getByRole("main").getByRole("heading", { name: "Warehouse 1" });
+	await page.getByRole("heading", { name: "Warehouse 1" }).waitFor();
 	await content.table("warehouse").assertRows([{ isbn: "1234567890", quantity: 1 }], { strict: true });
 
 	// Edit the book data for the first (and only) row
@@ -68,7 +68,7 @@ test("update is reflected in table view - inbound", async ({ page }) => {
 
 	// Navigate to the note page
 	await content.entityList("inbound-list").item(0).edit();
-	await page.getByRole("main").getByRole("heading", { name: "Note 1" });
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 	await content.table("inbound-note").assertRows([{ isbn: "1234567890", quantity: 1 }], { strict: true });
 
 	// Edit the book data for the first (and only) row
@@ -101,7 +101,7 @@ test("update is reflected in table view - outbound", async ({ page }) => {
 
 	// Navigate to the note page
 	await content.entityList("outbound-list").item(0).edit();
-	await page.getByRole("main").getByRole("heading", { name: "Note 1" });
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 	await content.table("outbound-note").assertRows([{ isbn: "1234567890", quantity: 1 }], { strict: true });
 
 	// Edit the book data for the first (and only) row
@@ -134,7 +134,7 @@ test("book form can be submitted using keyboard", async ({ page }) => {
 
 	// Navigate to the note page
 	await content.entityList("outbound-list").item(0).edit();
-	await page.getByRole("main").getByRole("heading", { name: "Note 1" });
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 	await content.table("outbound-note").assertRows([{ isbn: "1234567890", quantity: 1 }], { strict: true });
 
 	// Edit the book data for the first (and only) row

--- a/apps/e2e/integration/customer_order.spec.ts
+++ b/apps/e2e/integration/customer_order.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "@/constants";
 
-import { testOrders } from "@/helpers/fixtures";
+import { testBase as test, testOrders } from "@/helpers/fixtures";
 import { getDbHandle } from "@/helpers";
 import { addBooksToCustomer } from "@/helpers/cr-sqlite";
 

--- a/apps/e2e/integration/db_management_ui.spec.ts
+++ b/apps/e2e/integration/db_management_ui.spec.ts
@@ -1,7 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard } from "@/helpers";
 import { selector, testIdSelector } from "@/helpers/utils";
 import { DashboardNode } from "@/helpers/types";

--- a/apps/e2e/integration/history.spec.ts
+++ b/apps/e2e/integration/history.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import type { BookData } from "@librocco/shared";
 
 import { baseURL } from "@/constants";
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import { upsertWarehouse, createInboundNote, createOutboundNote, addVolumesToNote, commitNote, upsertBook } from "../helpers/cr-sqlite";
 import { getDateStub } from "@/helpers/dateStub";

--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -1,8 +1,9 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "@/constants";
 import { assertionTimeout } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import { addVolumesToNote, createInboundNote, updateNote, upsertBook, upsertWarehouse } from "@/helpers/cr-sqlite";
 import { book1 } from "@/integration/data";

--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -24,8 +24,6 @@ test.beforeEach(async ({ page }) => {
 	// Wait for the view to load (warehouse list is the default sub-view)
 	const warehouseList = dashboard.content().entityList("warehouse-list");
 	await warehouseList.waitFor();
-
-	await page.getByRole("heading", { name: "Note" }).first();
 });
 
 test('should create a new inbound note, under the particular warehouse, on warehouse row -> "New note" click and redirect to it', async ({
@@ -40,7 +38,7 @@ test('should create a new inbound note, under the particular warehouse, on wareh
 
 	// Check that we've been redirected to the new note's page
 	await dasbboard.view("inbound-note").waitFor();
-	await page.getByRole("main").getByRole("heading", { name: "New Note" });
+	await page.getByRole("main").getByRole("heading", { name: "New Note" }).first().waitFor();
 });
 
 test("should display notes, namespaced to warehouses, in the inbound note list", async ({ page }) => {
@@ -101,7 +99,7 @@ test("note heading should display note name, 'updated at' timestamp", async ({ p
 	await dashboard.content().entityList("warehouse-list").item(0).createNote();
 
 	// Check the title
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	// Check the 'updated at' timestamp
 	const updatedAt = new Date();
@@ -131,7 +129,7 @@ test("note should display breadcrumbs leading back to inbound page, or the paren
 	await header.breadcrumbs().getByText("Warehouse 1").click();
 
 	await dashboard.view("warehouse").waitFor();
-	await page.getByRole("heading", { name: "Warehouse 1" }).first();
+	await page.getByRole("heading", { name: "Warehouse 1" }).first().waitFor();
 });
 
 test("should assign default name to notes in sequential order (regardless of warehouse they belong to)", async ({ page }) => {
@@ -148,21 +146,21 @@ test("should assign default name to notes in sequential order (regardless of war
 
 	// First note (Warehouse 1)
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 	const note1UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
 	// Second note (Warehouse 1)
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Note 2" }).first();
+	await page.getByRole("heading", { name: "New Note (2)" }).first().waitFor();
 	const note2UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
 	// Third note (Warehouse 2)
 	await warehouseList.item(1).createNote();
-	await page.getByRole("heading", { name: "New Note 3" }).first();
+	await page.getByRole("heading", { name: "New Note (3)" }).first().waitFor();
 	const note3UpdatedAt = await header.updatedAt().value();
 
 	// Should display created notes in the inbound list
@@ -194,7 +192,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 
 	// Create a new note, continuning the naming sequence
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Note 3" }).first();
+	await page.getByRole("heading", { name: "New Note (3)" }).first().waitFor();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
@@ -203,7 +201,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await dbHandle.evaluate(updateNote, { id: 2, displayName: "Note 2" });
 
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Note 4" }).first();
+	await page.getByRole("heading", { name: "New Note (4)" }).first().waitFor();
 
 	// Check names
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -226,7 +224,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await page.getByRole("link", { name: "Warehouses" }).click();
 
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	// Check names
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -255,7 +253,7 @@ test("should be able to edit note title", async ({ page }) => {
 	await content.entityList("inbound-list").item(0).edit();
 	// Check title
 	await dashboard.view("inbound-note").waitFor();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	await dashboard.textEditableField().fillData("title");
 	await dashboard.textEditableField().submit();
@@ -263,8 +261,9 @@ test("should be able to edit note title", async ({ page }) => {
 	await page.getByRole("link", { name: "Manage Inventory" }).click();
 	await page.getByRole("link", { name: "Inbound" }).click();
 
-	expect(content.entityList("inbound-list").item(0).getByText("title")).toBeVisible();
+	await expect(content.entityList("inbound-list").item(0).getByText("Warehouse 1 / title")).toBeVisible();
 });
+
 test("should navigate to note page on 'edit' button click", async ({ page }) => {
 	const dashboard = getDashboard(page);
 
@@ -285,7 +284,7 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 
 	// Check title
 	await dashboard.view("inbound-note").waitFor();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 
 	// Navigate back to inbound page and to note 2
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -295,7 +294,7 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 
 	// Check title
 	await dashboard.view("inbound-note").waitFor();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "Note 2" }).first().waitFor();
 });
 
 test("should display book count for each respective note in the list", async ({ page }) => {

--- a/apps/e2e/integration/navigation_temp.spec.ts
+++ b/apps/e2e/integration/navigation_temp.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard } from "@/helpers";
 
 test("should navigate using the side nav", async ({ page }) => {

--- a/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
@@ -21,20 +21,17 @@ test.beforeEach(async ({ page }) => {
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 	await page.getByRole("link", { name: "Inbound" }).click();
+	await dashboard.content().entityList("inbound-list").waitFor();
+
+	// Navigate to the note page
+	await page.getByRole("link", { name: "Edit" }).first().click();
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 });
 
 test("should display correct transaction fields for the inbound-note note view", async ({ page }) => {
 	// Setup: Add the book data to the database
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(upsertBook, book1);
-
-	// Navigate to the note page
-	// * We repeat this at the start of each test, as tests which do a lot of `dbHandle.evaluate`
-	// * calls within the test block can variably end up on `/inventory/inbound` or `/inventory/inbound/1` between firefox and chrome, and this way we can make sure we navigate after
-	// await dashboard.content().entityList("inbound-list").item(0).edit();
-	//* The following is more reliable on chrome than ^^
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
 
 	const content = getDashboard(page).content();
 
@@ -59,11 +56,6 @@ test("should display correct transaction fields for the inbound-note note view",
 });
 
 test("should show empty or \"N/A\" fields and not 'null' or 'undefined' (in case no book data is provided)", async ({ page }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
-
 	const content = getDashboard(page).content();
 
 	// Add a book transaction without book data (only isbn)
@@ -89,11 +81,6 @@ test("should show empty or \"N/A\" fields and not 'null' or 'undefined' (in case
 test("should add a transaction to the note by 'typing the ISBN into the 'Scan' field and pressing \"Enter\" (the same way scenner interaction would be processed)", async ({
 	page
 }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
-
 	const content = getDashboard(page).content();
 
 	// Open the book form with the isbn added to the form using the 'Scan' field
@@ -108,11 +95,6 @@ test("should aggregate the quantity for the same isbn", async ({ page }) => {
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567891", quantity: 1, warehouseId: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
 
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("inbound-note");
@@ -139,11 +121,6 @@ test("should autofill the existing book data when adding a transaction with exis
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(upsertBook, book1);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
-
 	const content = getDashboard(page).content();
 
 	// Add book 1 again (this time using only isbn and 'Add' button)
@@ -157,11 +134,6 @@ test("should allow for changing of transaction quantity using the quantity field
 	// Setup: Add one transaction to the note
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
 
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("inbound-note");
@@ -185,11 +157,6 @@ test("should allow for changing of transaction quantity using the quantity field
 });
 
 test("should sort in reverse order to being added/aggregated", async ({ page }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
-
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("inbound-note");
 
@@ -215,11 +182,6 @@ test("should delete the transaction from the note on delete button click", async
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567891", quantity: 1, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567892", quantity: 1, warehouseId: 1 }] as const);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
-
 	const entries = getDashboard(page).content().table("inbound-note");
 
 	// Wait for all the entries to be displayed before selection/deletion (to reduce flakiness)
@@ -239,11 +201,6 @@ test("should display book count for all book quantities in the commit message", 
 
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 3, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1111111111", quantity: 5, warehouseId: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/inventory/inbound/1/");
 
 	const dashboard = getDashboard(page);
 

--- a/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/inbound_note_transactions.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import { addVolumesToNote, createInboundNote, upsertBook, upsertWarehouse } from "@/helpers/cr-sqlite";
 

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -33,20 +33,16 @@ test.beforeEach(async ({ page }) => {
 
 	await page.getByRole("link", { name: "Outbound" }).click();
 	await dashboard.content().entityList("outbound-list").waitFor();
+
+	// Navigate to the note page
+	await page.getByRole("link", { name: "Edit" }).first().click();
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 });
 
 test("should display correct transaction fields for the outbound note view", async ({ page }) => {
 	// Setup: Add the book data to the database
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(upsertBook, book1);
-
-	// Navigate to the note page
-	// * We repeat this at the start of each test, as tests which do a lot of `dbHandle.evaluate`
-	// * calls within the test block can variably end up on `/inventory/inbound` or `/inventory/inbound/1` between firefox and chrome, and this way we can make sure we navigate after
-	// await dashboard.content().entityList("outbound-list").item(0).edit();
-	//* The following is more reliable on chrome than ^^
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const content = getDashboard(page).content();
 
@@ -70,11 +66,6 @@ test("should display correct transaction fields for the outbound note view", asy
 });
 
 test("should show empty or \"N/A\" fields and not 'null' or 'undefined' (in case no book data is provided)", async ({ page }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const content = getDashboard(page).content();
 
 	// Add a book transaction without book data (only isbn)
@@ -99,11 +90,6 @@ test("should show empty or \"N/A\" fields and not 'null' or 'undefined' (in case
 test("should add a transaction to the note by 'typing the ISBN into the 'Scan' field and pressing \"Enter\" (the same way scenner interaction would be processed)", async ({
 	page
 }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const content = getDashboard(page).content();
 
 	await content.scanField().add("1234567890");
@@ -117,11 +103,6 @@ test("should aggregate the quantity for the same isbn", async ({ page }) => {
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567891", quantity: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("outbound-note");
@@ -148,11 +129,6 @@ test("should autofill the existing book data when adding a transaction with exis
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(upsertBook, book1);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const content = getDashboard(page).content();
 
 	// Add book 1 again (this time using only isbn and 'Add' button)
@@ -166,11 +142,6 @@ test("should allow for changing of transaction quantity using the quantity field
 	// Setup: Add one transaction to the note
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("outbound-note");
@@ -194,11 +165,6 @@ test("should allow for changing of transaction quantity using the quantity field
 });
 
 test("should sort in reverse order to being added/aggregated", async ({ page }) => {
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("inbound-note");
 
@@ -224,11 +190,6 @@ test("should delete the transaction from the note when when selected for deletio
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567891", quantity: 1, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567892", quantity: 1, warehouseId: 1 }] as const);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const entries = getDashboard(page).content().table("outbound-note");
 
 	// Wait for all the entries to be displayed before selection/deletion (to reduce flakiness)
@@ -250,11 +211,6 @@ test.skip("transaction should default to the only warehouse the given book is av
 	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1 });
 	await dbHandle.evaluate(addVolumesToNote, [2, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(commitNote, 2);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const content = getDashboard(page).content();
 
@@ -287,11 +243,6 @@ test("transaction should allow for warehouse selection if there is more than one
 	// Warehouse without book in stock should still be available for selection (out-of-stock is handled at a later step)
 	await dbHandle.evaluate(upsertWarehouse, { id: 3, displayName: "Warehouse 3" });
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const scanField = getDashboard(page).content().scanField();
 	const row = getDashboard(page).content().table("outbound-note").row(0);
 
@@ -321,11 +272,6 @@ test("if there's one transaction for the isbn with specified warehouse, should a
 
 	// Add a transaction to the note, belonging to the first warehouse - specified warehouse
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("outbound-note");
@@ -368,11 +314,6 @@ test("if there are two transactions, one with specified and one with unspecified
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 1 }] as const);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const scanField = getDashboard(page).content().scanField();
 	const entries = getDashboard(page).content().table("outbound-note");
 
@@ -403,11 +344,6 @@ test("updating a transaction to an 'isbn' and 'warehouseId' of an already existi
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 3, warehouseId: 1 }] as const);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1234567890", quantity: 2, warehouseId: 2 }] as const);
 
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
-
 	const entries = getDashboard(page).content().table("outbound-note");
 
 	// Wait for the transactions to be displayed before continuing with assertions
@@ -426,11 +362,6 @@ test("should add custom item on 'Custom Item' button click after filling out the
 	// Setup: add one non-custom transaction
 	const dbHandle = await getDbHandle(page);
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "11111111", quantity: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const content = getDashboard(page).content();
 
@@ -479,11 +410,6 @@ test("should allow for editing of custom items using the custom item form", asyn
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "22222222", quantity: 1 }] as const);
 	await dbHandle.evaluate(upsertNoteCustomItem, [1, { id: 1, title: "Custom item 1", price: 10 }] as const);
 	await dbHandle.evaluate(upsertNoteCustomItem, [1, { id: 2, title: "Custom item 2", price: 10 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const content = getDashboard(page).content();
 
@@ -536,11 +462,6 @@ test("should check validity of the transactions and commit the note on 'commit' 
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "33333333", quantity: 2, warehouseId: 1 }] as const);
 	// No warehouse assigned
 	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "44444444", quantity: 1 }] as const);
-
-	// Navigate to the note page
-	// * See note on first test about why this is repeated
-	await page.getByRole("link", { name: "Edit" }).first().click();
-	await page.waitForURL("**/outbound/1/");
 
 	const dashboard = getDashboard(page);
 

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -1,7 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import {
 	addVolumesToNote,

--- a/apps/e2e/integration/outbound_flow.spec.ts
+++ b/apps/e2e/integration/outbound_flow.spec.ts
@@ -25,7 +25,7 @@ test.beforeEach(async ({ page }) => {
 
 	// Navigate to the outbound note page
 	await page.getByRole("link", { name: "Outbound" }).click();
-	await dashboard.content().entityList("outbound-list").waitFor();
+	await page.getByRole("heading", { name: "Outbound" }).first().waitFor();
 });
 
 test('should create a new outbound note, on "New note" and redirect to it', async ({ page }) => {
@@ -36,7 +36,7 @@ test('should create a new outbound note, on "New note" and redirect to it', asyn
 	await dashboard.content().header().getByRole("button", { name: "New note" }).first().click();
 
 	// Check that we've been redirected to the new note's page
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 });
 
 test("should delete the note on delete button click (after confirming the prompt)", async ({ page }) => {
@@ -70,7 +70,7 @@ test("note heading should display note name, 'updated at' timestamp", async ({ p
 	await dashboard.content().header().getByRole("button", { name: "New note" }).first().click();
 
 	// Check the title
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	// Check the 'updated at' timestamp
 	const updatedAt = new Date();
@@ -104,7 +104,7 @@ test("should assign default name to notes in sequential order", async ({ page })
 	// First note
 	await dashboard.content().header().getByRole("button", { name: "New note" }).first().click();
 
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 	const note1UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -112,7 +112,7 @@ test("should assign default name to notes in sequential order", async ({ page })
 	// Second note
 	await dashboard.content().header().getByRole("button", { name: "New note" }).first().click();
 
-	await page.getByRole("heading", { name: "New Note 2" }).first();
+	await page.getByRole("heading", { name: "New Note (2)" }).first().waitFor();
 	const note2UpdatedAt = await header.updatedAt().value();
 
 	// Should display created notes in the outbound note list
@@ -143,7 +143,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 
 	// Create a new note, continuing the naming sequence
 	await page.getByRole("button", { name: "New Note", exact: true }).click();
-	await page.getByRole("heading", { name: "New Note 3" }).first();
+	await page.getByRole("heading", { name: "New Note (3)" }).first().waitFor();
 
 	// Verify names
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -158,7 +158,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 
 	// Create another note, continuing the sequence
 	await page.getByRole("button", { name: "New Note", exact: true }).click();
-	await page.getByRole("heading", { name: "New Note 4" }).first();
+	await page.getByRole("heading", { name: "New Note (4)" }).first().waitFor();
 
 	// Verify names
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -175,7 +175,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 
 	// Create a final note with reset sequence
 	await page.getByRole("button", { name: "New Note", exact: true }).click();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	// Verify names
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -202,7 +202,7 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 
 	// Check title
 	await dashboard.view("outbound-note").waitFor();
-	await page.getByRole("heading", { name: "Note 1" }).first();
+	await page.getByRole("heading", { name: "Note 1" }).first().waitFor();
 
 	// Navigate back to outbound page and to note 2
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -210,7 +210,7 @@ test("should navigate to note page on 'edit' button click", async ({ page }) => 
 
 	// Check title
 	await dashboard.view("outbound-note").waitFor();
-	await page.getByRole("heading", { name: "Note 2" }).first();
+	await page.getByRole("heading", { name: "Note 2" }).first().waitFor();
 });
 
 test("should display book count for each respective note in the list", async ({ page }) => {
@@ -302,7 +302,7 @@ test("should update default warehouse for outbound note using dropdown", async (
 
 	// Verify we're on the note page
 	await dashboard.view("outbound-note").waitFor();
-	await page.getByRole("heading", { name: "Default Warehouse Test" }).first();
+	await page.getByRole("heading", { name: "Default Warehouse Test" }).first().waitFor();
 
 	const defaultWarehouseDropdown = page.locator("#defaultWarehouse");
 	await defaultWarehouseDropdown.waitFor();
@@ -711,15 +711,15 @@ test("should be able to edit note title", async ({ page }) => {
 	const content = dashboard.content();
 
 	await content.entityList("outbound-list").item(0).edit();
+
 	// Check title
 	await dashboard.view("outbound-note").waitFor();
-	await page.getByRole("heading", { name: "New Note" }).first();
+	await page.getByRole("heading", { name: "New Note" }).first().waitFor();
 
 	await dashboard.textEditableField().fillData("title");
 	await dashboard.textEditableField().submit();
-	// to make sure title is persisted
 
 	await page.getByLabel("Main navigation").getByRole("link", { name: "Outbound" }).click();
 
-	expect(content.entityList("outbound-list").item(0).getByText("title")).toBeVisible();
+	await expect(content.entityList("outbound-list").item(0).getByText("title")).toBeVisible();
 });

--- a/apps/e2e/integration/scan_flow.spec.ts
+++ b/apps/e2e/integration/scan_flow.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-
 import { baseURL } from "../constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard } from "@/helpers";
 
 test.beforeEach(async ({ page }) => {

--- a/apps/e2e/integration/search_flow.spec.ts
+++ b/apps/e2e/integration/search_flow.spec.ts
@@ -1,7 +1,6 @@
-import { test } from "@playwright/test";
-
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 import { addVolumesToNote, commitNote, createInboundNote, upsertWarehouse } from "@/helpers/cr-sqlite";
 

--- a/apps/e2e/integration/stock_changes.spec.ts
+++ b/apps/e2e/integration/stock_changes.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import { baseURL } from "../constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
 
 import { addVolumesToNote, commitNote, createInboundNote, createOutboundNote, upsertWarehouse } from "@/helpers/cr-sqlite";

--- a/apps/e2e/integration/supplier_publisher.spec.ts
+++ b/apps/e2e/integration/supplier_publisher.spec.ts
@@ -1,5 +1,8 @@
+import { expect } from "@playwright/test";
+
 import { baseURL } from "@/constants";
-import { test, expect } from "@playwright/test";
+
+import { testBase as test } from "@/helpers/fixtures";
 import { associatePublisher, removePublisherFromSupplier, upsertBook } from "@/helpers/cr-sqlite";
 import { depends, testOrders } from "@/helpers/fixtures";
 import { getDbHandle } from "@/helpers";

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -1,10 +1,10 @@
-import { test } from "@playwright/test";
-
 import { baseURL } from "@/constants";
 
+import { testBase as test } from "@/helpers/fixtures";
 import { getDashboard, getDbHandle } from "@/helpers";
-import { book1 } from "@/integration/data";
 import { addVolumesToNote, commitNote, createInboundNote, upsertBook, upsertWarehouse } from "@/helpers/cr-sqlite";
+
+import { book1 } from "@/integration/data";
 
 test.beforeEach(async ({ page }) => {
 	await page.waitForTimeout(1000);

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -40,7 +40,7 @@ test('should create a new warehouse, on "New warehouse" and redirect to it', asy
 
 	// Check that we've been redirected to the new warehouse's page
 	await dashboard.view("warehouse").waitFor();
-	await page.getByRole("main").getByRole("heading", { name: "New Warehouse" });
+	await page.getByRole("heading", { name: "New Warehouse" }).waitFor();
 });
 
 test("should delete the warehouse on delete button click (after confirming the prompt)", async ({ page }) => {
@@ -206,7 +206,7 @@ test("should navigate to warehouse page on 'View stock' button click", async ({ 
 
 	// Check title
 	await dashboard.view("warehouse").waitFor();
-	await page.getByRole("main").getByRole("heading", { name: "Warehouse 1" });
+	await page.getByRole("heading", { name: "Warehouse 1" }).waitFor();
 
 	// Navigate back to inventory page and to second warehouse
 	await page.getByRole("link", { name: "Manage inventory" }).click();

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -37,7 +37,9 @@
 	const { dbCtx } = data;
 
 	beforeNavigate(({ to }) => {
-		timeLogger.setCurrentRoute(to.route.id);
+		if (IS_DEBUG || IS_E2E) {
+			timeLogger.setCurrentRoute(to?.route?.id);
+		}
 	});
 
 	$: {
@@ -82,7 +84,9 @@
 		// This helps us in e2e to know when the page is interactive, otherwise Playwright will start too early
 		document.body.setAttribute("hydrated", "true");
 
-		window["timeLogger"] = timeLogger;
+		if (IS_E2E || IS_DEBUG) {
+			window["timeLogger"] = timeLogger;
+		}
 
 		// Start the sync worker
 		//


### PR DESCRIPTION
The test flakiness has really become unbearable, so I took the time to finally fix them (sorry, not sorry). 
This:
- improves the test code so that the assertions are made when they're supposed to
- waits for certain params (like element appearing on screen) before continuing

All in all: it should significantly reduce flakiness and, if the tests need to fail, they should fail for less ambiguous reasons

🤞 this passes on playwright matrix

@delasous sry. I reverted back to waiting for elements (not routes). We can discuss it further and that could be massaged. I rushed through this with what I'm used to (in an effort to clear the path for other updates failing in CI due to flakiness).
