### PR TITLE
Optimise/cache invalidation txn.committed at

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/books.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/books.ts
@@ -76,6 +76,11 @@ async function _upsertBook(db: DB, book: BookData) {
 }
 
 async function _getMultipleBookData(db: DB, ...isbns: string[]): Promise<Array<Required<BookData> & { updatedAt: Date | null }>> {
+	// Supporting this case as there might be a request for empty entries list (as this depends on warehouse/note entries)
+	if (!isbns.length) {
+		return [];
+	}
+
 	const placeholders = isbns.map((_, i) => `(?, ${i})`).join(",\n");
 	const query = `
 		WITH input_list(isbn, ord) AS (
@@ -101,10 +106,6 @@ async function _getMultipleBookData(db: DB, ...isbns: string[]): Promise<Array<R
 	`;
 
 	const res = await db.execO<RawBookRes>(query, isbns);
-	if (!res) {
-		return undefined;
-	}
-
 	return res.map(processRawBookRes);
 }
 

--- a/apps/web-client/src/lib/db/cr-sqlite/books.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/books.ts
@@ -75,6 +75,39 @@ async function _upsertBook(db: DB, book: BookData) {
 	);
 }
 
+async function _getMultipleBookData(db: DB, ...isbns: string[]): Promise<Array<Required<BookData> & { updatedAt: Date | null }>> {
+	const placeholders = isbns.map((_, i) => `(?, ${i})`).join(",\n");
+	const query = `
+		WITH input_list(isbn, ord) AS (
+			VALUES
+				${placeholders}
+		)
+		SELECT
+			input_list.isbn,
+			COALESCE(title, '') as title,
+			COALESCE(authors, '') as authors,
+			COALESCE(publisher, '') as publisher,
+			COALESCE(price, 0) as price,
+			COALESCE(year, '') as year,
+			COALESCE(edited_by, '') as editedBy,
+			COALESCE(out_of_print, 0) as outOfPrint,
+			COALESCE(category, '') as category,
+			updated_at as updatedAt
+		FROM input_list
+		LEFT JOIN book AS b
+			ON b.isbn = input_list.isbn
+		ORDER BY
+			input_list.ord;
+	`;
+
+	const res = await db.execO<RawBookRes>(query, isbns);
+	if (!res) {
+		return undefined;
+	}
+
+	return res.map(processRawBookRes);
+}
+
 async function _getBookData(db: DB, isbn: string): Promise<Required<BookData> & { updatedAt: Date | null }> {
 	const [res] = await db.execO<RawBookRes>(
 		`SELECT
@@ -175,5 +208,6 @@ const processRawBookRes = (res: RawBookRes): Required<BookData> & { updatedAt: D
 
 export const upsertBook = timed(_upsertBook);
 export const getBookData = timed(_getBookData);
+export const getMultipleBookData = timed(_getMultipleBookData);
 export const getPublisherList = timed(_getPublisherList);
 export const searchBooks = timed(_searchBooks);

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -403,13 +403,13 @@ async function _commitNote(db: DB, id: number, { force = false }: { force?: bool
 	}
 
 	const timestamp = Date.now();
-	const query = `
-		UPDATE note
-		SET committed = 1, committed_at = ?
-		WHERE id = ?
-	`;
 
-	await db.exec(query, [timestamp, id]);
+	await db.tx(async (db) => {
+		// Update note's committed_at
+		await db.exec("UPDATE note SET committed = 1, committed_at = ? WHERE id = ?", [timestamp, id]);
+		// Update all related book transactions' committed_at
+		await db.exec("UPDATE book_transaction SET committed_at = ? WHERE note_id = ?", [timestamp, id]);
+	});
 }
 
 /**
@@ -481,6 +481,7 @@ async function _getNoteEntries(db: DB, id: number): Promise<NoteEntriesItem[]> {
 			bt.quantity,
 			bt.warehouse_id AS warehouseId,
 			bt.updated_at,
+			bt.committed_at, -- NOTE: committed at is not used in production, but this is useful for testing
 			COALESCE(w.display_name, 'not-found') AS warehouseName,
 			COALESCE(w.discount, 0) AS warehouseDiscount,
 			COALESCE(b.title, 'N/A') AS title,
@@ -503,6 +504,7 @@ async function _getNoteEntries(db: DB, id: number): Promise<NoteEntriesItem[]> {
 		quantity: number;
 		warehouseId?: number;
 		updated_at: number;
+		committed_at: number;
 
 		warehouseName?: string;
 		warehouseDiscount: number;
@@ -517,9 +519,10 @@ async function _getNoteEntries(db: DB, id: number): Promise<NoteEntriesItem[]> {
 		category: string;
 	}>(query, [id]);
 
-	return result.map(({ warehouseId, out_of_print, updated_at, ...res }) => ({
+	return result.map(({ warehouseId, out_of_print, updated_at, committed_at, ...res }) => ({
 		...res,
-		updatedAt: new Date(updated_at),
+		updatedAt: updated_at ? new Date(updated_at) : undefined,
+		committedAt: committed_at ? new Date(committed_at) : undefined,
 		warehouseId: warehouseId ?? undefined,
 		outOfPrint: Boolean(out_of_print)
 	}));

--- a/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
@@ -1,4 +1,4 @@
-import { writable, get, derived, type Readable } from "svelte/store";
+import { writable, get, derived } from "svelte/store";
 
 import type { DB, GetStockResponseItem } from "$lib/db/cr-sqlite/types";
 
@@ -77,7 +77,7 @@ export const invalidate = () => {
 	}
 };
 
-let onInvalidatedSubscribers = new Set<() => void>();
+const onInvalidatedSubscribers = new Set<() => void>();
 
 // Every time a query changes (it had been invalidated), we notify all of the 'onInvalidated' subscribers
 // NOTE: We're doint this way, instead of directly subscribing every 'onInvalidated' callback to the query,

--- a/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
@@ -17,7 +17,14 @@ const execQuery = async (db: DB) => {
 	return stock;
 };
 
-/** An internal store keeping the full stock query as a promise */
+/**
+ * An internal store keeping the full stock query as a promise
+ * NOTE: This is somewhat lazy - the initial promise never resolves, but it doesn't
+ * choke up the DB either. Only when the cached stock is activated (needed by a consumer), does it
+ * run the query.
+ *
+ * This is a tradeoff between prefetching the results and not blocking other DB interactions until the stock is needed.
+ */
 const query = writable<Promise<GetStockResponseItem[]>>(new Promise(() => {}));
 
 /**

--- a/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
@@ -1,0 +1,70 @@
+import { writable, get, derived } from "svelte/store";
+
+import type { DB, GetStockResponseItem } from "$lib/db/cr-sqlite/types";
+
+import { getStock } from "$lib/db/cr-sqlite/stock";
+import { reduce, wrapIter } from "@librocco/shared";
+
+const dbStore = writable<DB | null>(null);
+const valid = writable(false);
+
+/**
+ * Executes the stock query and sets the cache as valid (upon resolution)
+ */
+const execQuery = async (db: DB) => {
+	const stock = await getStock(db);
+	valid.set(true);
+	return stock;
+};
+
+/** An internal store keeping the full stock query as a promise */
+const query = writable<Promise<GetStockResponseItem[]>>(new Promise(() => {}));
+
+/**
+ * A store derived from cached stock query:
+ * - it contains a promise which resolves to a Map { warehouseId => Iterable<GetStockResponseItem> }
+ * - having a promise allows us to use Svelte's async await block
+ * - being a store, it automatically updates when the cache is invalidated
+ */
+export const stockByWarehouse = derived(query, ($query) =>
+	$query.then((stock) => wrapIter(stock)._groupIntoMap((item) => [item.warehouseId, item]))
+);
+
+/**
+ * A store derived from cached stock query:
+ * - it contains a promise which resolves to a Map { warehouseId => number }
+ * - having a promise allows us to use Svelte's async await block
+ * - being a store, it automatically updates when the cache is invalidated
+ */
+export const warehouseTotals = derived(stockByWarehouse, ($stockByWarehouse) =>
+	// Wait for the stock by warehouse (effectively stock query)
+	$stockByWarehouse.then(
+		(stock) =>
+			// Reduce the quantities of items for each warehouse and create a Map { warehouseId => totalQuantiy }
+			new Map(wrapIter(stock).map(([warehouseId, items]) => [warehouseId, reduce(items, (acc, { quantity }) => acc + quantity, 0)]))
+	)
+);
+
+export const enable = (db: DB) => {
+	// Set the DB -- effectively enabling the cache
+	dbStore.set(db);
+
+	// If cache invalidated while not active, rerun the query
+	if (!get(valid)) {
+		query.set(execQuery(db));
+	}
+};
+
+export const disable = () => dbStore.set(null);
+
+export const invalidate = () => {
+	// Invalidate the cache
+	valid.set(false);
+
+	const db = get(dbStore);
+
+	// If currently active, rerun the query
+	if (db) {
+		query.set(execQuery(db));
+	}
+};

--- a/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
@@ -4,16 +4,20 @@ import type { DB, GetStockResponseItem } from "$lib/db/cr-sqlite/types";
 
 import { getStock } from "$lib/db/cr-sqlite/stock";
 import { reduce, wrapIter } from "@librocco/shared";
+import { timed } from "$lib/utils/timer";
 
 const dbStore = writable<DB | null>(null);
 const valid = writable(false);
+const cacheTimestamp = writable(0);
 
 /**
  * Executes the stock query and sets the cache as valid (upon resolution)
  */
 const execQuery = async (db: DB) => {
 	const stock = await getStock(db);
+	const [[timestamp]] = await db.execA<[number]>("SELECT COALESCE(MAX(committed_at), 0) FROM book_transaction");
 	valid.set(true);
+	cacheTimestamp.set(timestamp);
 	return stock;
 };
 
@@ -74,6 +78,26 @@ export const invalidate = () => {
 	// If currently active, rerun the query
 	if (db) {
 		query.set(execQuery(db));
+	}
+};
+
+async function _countRelevantUpdates(db: DB, cacheTimestamp: number) {
+	// Count the number of updates that are relevant to the stock calculation
+	const [[res]] = await db.execA<[number]>("SELECT COUNT(*) FROM book_transaction WHERE committed_at > ?", [cacheTimestamp]);
+	return res;
+}
+const countRelevantUpdates = timed(_countRelevantUpdates);
+
+/**
+ * We run a intermediate (cheap) query to check if the observed updates affect the stock calculation:
+ * - if so, we invalidate the cache (which will then may, or may not, re-execute the, expensive stock query - depending on the cache being active)
+ * - if not, noop
+ *
+ */
+export const maybeInvalidate = async (db: DB) => {
+	const numUpdates = await countRelevantUpdates(db, get(cacheTimestamp));
+	if (numUpdates > 0) {
+		invalidate();
 	}
 };
 

--- a/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock_cache.ts
@@ -53,7 +53,7 @@ export const warehouseTotals = derived(stockByWarehouse, ($stockByWarehouse) =>
 	)
 );
 
-export const enable = (db: DB) => {
+export const enableRefresh = (db: DB) => {
 	// Set the DB -- effectively enabling the cache
 	dbStore.set(db);
 
@@ -63,7 +63,7 @@ export const enable = (db: DB) => {
 	}
 };
 
-export const disable = () => dbStore.set(null);
+export const disableRefresh = () => dbStore.set(null);
 
 export const invalidate = () => {
 	// Invalidate the cache

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -229,9 +229,12 @@ export type VolumeStock = {
 	warehouseId?: number;
 };
 
-export type NoteEntriesItem = VolumeStock & { warehouseName?: string; warehouseDiscount: number; updatedAt?: Date } & Required<
-		Omit<BookData, "updatedAt">
-	>;
+export type NoteEntriesItem = VolumeStock & {
+	warehouseName?: string;
+	warehouseDiscount: number;
+	updatedAt?: Date;
+	committedAt?: Date;
+} & Required<Omit<BookData, "updatedAt">>;
 
 export type NoteCustomItem = { id: number; title: string; price: number; updatedAt?: Date };
 

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -174,6 +174,7 @@ CREATE TABLE book_transaction (
 CREATE INDEX idx_book_transaction_isbn ON book_transaction(isbn);
 CREATE INDEX idx_book_transaction_note_id ON book_transaction(note_id);
 CREATE INDEX idx_book_transaction_warehouse_id ON book_transaction(warehouse_id);
+CREATE INDEX idx_book_transaction_committed_at ON book_transaction(committed_at);
 SELECT crsql_as_crr('book_transaction');
 
 

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -156,6 +156,7 @@ CREATE TABLE note (
 );
 CREATE INDEX idx_note_warehouse_id ON note(warehouse_id);
 CREATE INDEX idx_note_default_warehouse ON note(default_warehouse);
+CREATE INDEX idx_note_committed_at ON note(committed_at);
 SELECT crsql_as_crr('note');
 
 CREATE TABLE book_transaction (

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -112,9 +112,9 @@
 		}
 
 		// Control the invalidation of the stock cache in central spot
-		// Invalidate on every change to note (notes being committed)
-		// TODO: Implement more fine-grained control over this - potentially using a separate table to control committed state
-		disposer = dbCtx.rx.onRange(["note"], () => stockCache.invalidate());
+		// On every 'book_transaction' change, we run 'maybeInvalidate', which, in turn checks for relevant changes
+		// between the last cached value and the current one and invalidates the cache if needed
+		disposer = dbCtx.rx.onRange(["book_transaction"], () => stockCache.maybeInvalidate(dbCtx.db));
 	});
 
 	onDestroy(() => {

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -114,7 +114,7 @@
 		// Control the invalidation of the stock cache in central spot
 		// Invalidate on every change to note (notes being committed)
 		// TODO: Implement more fine-grained control over this - potentially using a separate table to control committed state
-		disposer = dbCtx.rx.onRange(["note", "book"], () => stockCache.invalidate());
+		disposer = dbCtx.rx.onRange(["note"], () => stockCache.invalidate());
 	});
 
 	onDestroy(() => {

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
 		//
 		// NOTE: the cache will still be invalidated in the mean while, there will just be no requerying,
 		// effectively turning the cache back to lazy mode
-		stockCache.disable();
+		stockCache.disableRefresh();
 	});
 
 	$: {

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
 	import * as reconciliation from "$lib/db/cr-sqlite/order-reconciliation";
 	import * as suppliers from "$lib/db/cr-sqlite/suppliers";
 	import * as warehouse from "$lib/db/cr-sqlite/warehouse";
+	import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 	import { timeLogger } from "$lib/utils/timer";
 	import { beforeNavigate } from "$app/navigation";
 
@@ -40,6 +41,15 @@
 		if (IS_DEBUG || IS_E2E) {
 			timeLogger.setCurrentRoute(to?.route?.id);
 		}
+
+		// We're disabling updates to the stock cache whenever we navigate to prevent
+		// invalidations (and requerying) choking up the DB for view that don't require it.
+		//
+		// NOTE: It is up to views that require the stock data to re-enable the cache (on load)
+		//
+		// NOTE: the cache will still be invalidated in the mean while, there will just be no requerying,
+		// effectively turning the cache back to lazy mode
+		stockCache.disable();
 	});
 
 	$: {
@@ -80,6 +90,8 @@
 		sync.stop();
 	}
 
+	let disposer: () => void;
+
 	onMount(() => {
 		// This helps us in e2e to know when the page is interactive, otherwise Playwright will start too early
 		document.body.setAttribute("hydrated", "true");
@@ -98,12 +110,19 @@
 		if (get(syncActive)) {
 			sync.sync(get(syncConfig));
 		}
+
+		// Control the invalidation of the stock cache in central spot
+		// Invalidate on every change to note (notes being committed)
+		// TODO: Implement more fine-grained control over this - potentially using a separate table to control committed state
+		disposer = dbCtx.rx.onRange(["note"], () => stockCache.invalidate());
 	});
 
 	onDestroy(() => {
 		sync.stop(); // Safe and idempotent
 
 		availabilitySubscription?.unsubscribe();
+
+		disposer?.();
 	});
 
 	const {

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -114,7 +114,7 @@
 		// Control the invalidation of the stock cache in central spot
 		// Invalidate on every change to note (notes being committed)
 		// TODO: Implement more fine-grained control over this - potentially using a separate table to control committed state
-		disposer = dbCtx.rx.onRange(["note"], () => stockCache.invalidate());
+		disposer = dbCtx.rx.onRange(["note", "book"], () => stockCache.invalidate());
 	});
 
 	onDestroy(() => {

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { Loader2 as Loader, Library, Percent } from "lucide-svelte";
+	import { Library, Percent } from "lucide-svelte";
 	import { invalidate } from "$app/navigation";
 
 	import { entityListView, testId } from "@librocco/shared";
+	import LL from "@librocco/shared/i18n-svelte";
+
+	import type { PageData } from "./$types";
+
+	import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 
 	import HistoryPage from "$lib/controllers/HistoryPage.svelte";
 
 	import { appPath } from "$lib/paths";
-	import LL from "@librocco/shared/i18n-svelte";
-
-	import type { PageData } from "./$types";
+	import { PlaceholderDots } from "$lib/components";
 
 	export let data: PageData;
 
@@ -22,8 +25,10 @@
 
 		// Reload when warehouse data changes
 		const disposer1 = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
-		// Reload when a note gets committed (affecting stock)
-		const disposer2 = rx.onRange(["note"], () => invalidate("warehouse:books"));
+
+		// Invalidate the stock cache when a note is committed (unfortunately, we don't have a fine-grained control over this, so we invalidate each time a note updates)
+		// TODO: move this to a central location
+		const disposer2 = rx.onRange(["note"], () => stockCache.invalidate());
 		disposer = () => (disposer1(), disposer2());
 	});
 	onDestroy(() => {
@@ -33,6 +38,8 @@
 
 	$: ({ warehouses, plugins } = data);
 	$: db = data.dbCtx?.db;
+
+	$: ({ warehouseTotals } = stockCache);
 
 	$: t = $LL.history_page.warehouse_tab;
 
@@ -56,7 +63,6 @@
 				<!-- Start entity list -->
 				{#each warehouses as warehouse}
 					{@const displayName = warehouse.displayName || warehouse.id}
-					{@const totalBooks = warehouse.totalBooks}
 					{@const href = appPath("history/warehouse", warehouse.id)}
 					{@const warehouseDiscount = warehouse.discount}
 
@@ -67,7 +73,14 @@
 							<div class="flex flex-col gap-2 sm:flex-row">
 								<div class="flex w-32 items-center gap-x-1">
 									<Library class="text-base-content" size={20} />
-									<span class="entity-list-text-sm text-base-content">{t.stats.books({ no_of_books: totalBooks })}</span>
+
+									{#await $warehouseTotals}
+										<PlaceholderDots />
+									{:then warehouseTotals}
+										<span class="entity-list-text-sm text-base-content">
+											{t.stats.books({ no_of_books: warehouseTotals.get(warehouse.id) })}
+										</span>
+									{/await}
 								</div>
 
 								{#if warehouseDiscount}

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -24,12 +24,7 @@
 		const { rx } = data.dbCtx;
 
 		// Reload when warehouse data changes
-		const disposer1 = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
-
-		// Invalidate the stock cache when a note is committed (unfortunately, we don't have a fine-grained control over this, so we invalidate each time a note updates)
-		// TODO: move this to a central location
-		const disposer2 = rx.onRange(["note"], () => stockCache.invalidate());
-		disposer = () => (disposer1(), disposer2());
+		disposer = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -1,16 +1,26 @@
 import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
+import type { Warehouse } from "$lib/db/cr-sqlite/types";
 
 import { timed } from "$lib/utils/timer";
+import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 
 const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
-	const { dbCtx } = await parent();
+	// Disable the stock cache to prevent the expensive stock query from blocking the
+	// DB for other (cheaper) queries necessary for the page load.
+	stockCache.disable();
 
-	const warehouses = dbCtx ? await getAllWarehouses(dbCtx.db) : [];
+	const { dbCtx } = await parent();
+	if (!dbCtx) return { dbCtx, warehouses: [] as Warehouse[] };
+
+	const warehouses = await getAllWarehouses(dbCtx.db, { skipTotals: true });
+
+	// Enable the stock cache again to execute in the background
+	stockCache.enable(dbCtx.db);
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/history/warehouse/+page.ts
+++ b/apps/web-client/src/routes/history/warehouse/+page.ts
@@ -10,17 +10,17 @@ const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
-	// Disable the stock cache to prevent the expensive stock query from blocking the
+	// Disable the stock cache refreshing to prevent the expensive stock query from blocking the
 	// DB for other (cheaper) queries necessary for the page load.
-	stockCache.disable();
+	stockCache.disableRefresh();
 
 	const { dbCtx } = await parent();
 	if (!dbCtx) return { dbCtx, warehouses: [] as Warehouse[] };
 
 	const warehouses = await getAllWarehouses(dbCtx.db, { skipTotals: true });
 
-	// Enable the stock cache again to execute in the background
-	stockCache.enable(dbCtx.db);
+	// Re-enable the stock cache refreshing to execute in the background
+	stockCache.enableRefresh(dbCtx.db);
 
 	return { dbCtx, warehouses };
 };

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -134,7 +134,9 @@
 
 					<div class="group entity-list-row">
 						<div class="flex flex-col gap-y-2 self-start">
-							<a {href} class="entity-list-text-lg text-base-content hover:underline focus:underline">{displayName}</a>
+							<a data-sveltekit-preload-data="hover" {href} class="entity-list-text-lg text-base-content hover:underline focus:underline"
+								>{displayName}</a
+							>
 
 							<div class="flex flex-row gap-x-8 gap-y-2 max-xs:flex-col">
 								<div class="entity-list-text-sm flex items-center gap-x-2 text-sm text-base-content">

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -45,12 +45,7 @@
 		const { rx } = data.dbCtx;
 
 		// Reload when warehouse data changes
-		const disposer1 = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
-
-		// Invalidate the stock cache when a note is committed (unfortunately, we don't have a fine-grained control over this, so we invalidate each time a note updates)
-		// TODO: move this to a central location
-		const disposer2 = rx.onRange(["note"], () => stockCache.invalidate());
-		disposer = () => (disposer1(), disposer2());
+		disposer = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -11,15 +11,18 @@ const _load = async ({ parent, depends }: Parameters<PageLoad>[0]) => {
 	depends("warehouse:list");
 	depends("warehouse:books");
 
-	// Disable the stock cache to prevent the expensive stock query from blocking the
+	// Disable the stock cache refreshing to prevent the expensive stock query from blocking the
 	// DB for other (cheaper) queries necessary for the page load.
-	stockCache.disable();
+	stockCache.disableRefresh();
+
 	const { dbCtx } = await parent();
 	if (!dbCtx) return { dbCtx, warehouses: [] as Warehouse[] };
 
 	const warehouses = await getAllWarehouses(dbCtx.db, { skipTotals: true });
 
-	stockCache.enable(dbCtx.db);
+	// Re-enable the stock cache refreshing to execute in the background
+	stockCache.enableRefresh(dbCtx.db);
+
 	return { dbCtx, warehouses };
 };
 

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -32,12 +32,18 @@
 	import { appPath } from "$lib/paths";
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import { upsertBook } from "$lib/db/cr-sqlite/books";
+	import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 	import LL from "@librocco/shared/i18n-svelte";
+	import type { GetStockResponseItem } from "$lib/db/cr-sqlite/types";
 
 	export let data: PageData;
 
-	$: ({ plugins, displayName, entries, publisherList, id } = data);
+	$: ({ plugins, displayName, publisherList, id } = data);
 	$: db = data.dbCtx?.db;
+
+	let entries: GetStockResponseItem[] = [];
+	$: ({ stockByWarehouse } = stockCache);
+	$: $stockByWarehouse.then((s) => (entries = [...s.get(id)]));
 
 	$: tColumnHeaders = $LL.warehouse_page.table;
 	$: tLabels = $LL.warehouse_page.labels;
@@ -59,10 +65,6 @@
 		disposer?.();
 	});
 	$: goto = racefreeGoto(disposer);
-
-	// We display loading state before navigation (in case of creating new note/warehouse)
-	// and reset the loading state when the data changes (should always be truthy -> thus, loading false).
-	$: loading = !db;
 
 	// #region csv
 	const handleExportCsv = () => {
@@ -172,90 +174,93 @@
 				{/if}
 			</div>
 		</div>
-		{#if loading}
+
+		{#await $stockByWarehouse}
 			<div class="flex grow justify-center">
 				<div class="mx-auto translate-y-1/2">
 					<span class="loading loading-spinner loading-lg text-primary"></span>
 				</div>
 			</div>
-		{:else if !entries?.length}
-			<div class="flex grow justify-center">
-				<div class="mx-auto max-w-xl translate-y-1/2">
-					<!-- Start entity list placeholder -->
-					<PlaceholderBox title="Add new inbound note" description="Get started by adding a new note">
-						<FilePlus slot="icon" />
-						<button slot="actions" on:click={handleCreateInboundNote} class="btn-primary btn w-full">
-							{tLabels.new_note()}
-						</button>
-					</PlaceholderBox>
-					<!-- End entity list placeholder -->
+		{:then}
+			{#if !entries?.length}
+				<div class="flex grow justify-center">
+					<div class="mx-auto max-w-xl translate-y-1/2">
+						<!-- Start entity list placeholder -->
+						<PlaceholderBox title="Add new inbound note" description="Get started by adding a new note">
+							<FilePlus slot="icon" />
+							<button slot="actions" on:click={handleCreateInboundNote} class="btn-primary btn w-full">
+								{tLabels.new_note()}
+							</button>
+						</PlaceholderBox>
+						<!-- End entity list placeholder -->
+					</div>
 				</div>
-			</div>
-		{:else}
-			<div use:scroll.container={{ rootMargin: "400px" }} class="h-full overflow-y-auto" style="scrollbar-width: thin">
-				<!-- This div allows us to scroll (and use intersecion observer), but prevents table rows from stretching to fill the entire height of the container -->
-				<div>
-					<StockTable {table}>
-						<tr slot="row" let:row let:rowIx>
-							<StockBookRow {row} {rowIx}>
-								<div slot="row-actions">
-									<PopoverWrapper
-										options={{
-											forceVisible: true,
-											positioning: {
-												placement: "left"
-											}
-										}}
-										let:trigger
-									>
-										<button
-											data-testid={testId("popover-control")}
-											{...trigger}
-											use:trigger.action
-											class="btn-neutral btn-outline btn-sm btn px-0.5"
+			{:else}
+				<div use:scroll.container={{ rootMargin: "400px" }} class="h-full overflow-y-auto" style="scrollbar-width: thin">
+					<!-- This div allows us to scroll (and use intersecion observer), but prevents table rows from stretching to fill the entire height of the container -->
+					<div>
+						<StockTable {table}>
+							<tr slot="row" let:row let:rowIx>
+								<StockBookRow {row} {rowIx}>
+									<div slot="row-actions">
+										<PopoverWrapper
+											options={{
+												forceVisible: true,
+												positioning: {
+													placement: "left"
+												}
+											}}
+											let:trigger
 										>
-											<span class="sr-only">{tLabels.edit_row()} {rowIx}</span>
-											<span class="aria-hidden">
-												<MoreVertical />
-											</span>
-										</button>
-
-										<div slot="popover-content" data-testid={testId("popover-container")} class="bg-secondary">
 											<button
-												use:melt={$trigger}
-												data-testid={testId("edit-row")}
-												on:m-click={() => {
-													const { __kind, warehouseId, warehouseName, warehouseDiscount, quantity, ...bookData } = row;
-													bookFormData = bookData;
-												}}
-												class="btn-secondary btn-sm btn"
+												data-testid={testId("popover-control")}
+												{...trigger}
+												use:trigger.action
+												class="btn-neutral btn-outline btn-sm btn px-0.5"
 											>
 												<span class="sr-only">{tLabels.edit_row()} {rowIx}</span>
 												<span class="aria-hidden">
-													<FileEdit />
+													<MoreVertical />
 												</span>
 											</button>
 
-											<button class="btn-secondary btn-sm btn" data-testid={testId("print-book-label")} on:click={handlePrintLabel(row)}>
-												<span class="sr-only">{tLabels.print_book_label()} {rowIx}</span>
-												<span class="aria-hidden">
-													<Printer />
-												</span>
-											</button>
-										</div>
-									</PopoverWrapper>
-								</div>
-							</StockBookRow>
-						</tr>
-					</StockTable>
+											<div slot="popover-content" data-testid={testId("popover-container")} class="bg-secondary">
+												<button
+													use:melt={$trigger}
+													data-testid={testId("edit-row")}
+													on:m-click={() => {
+														const { __kind, warehouseId, warehouseName, warehouseDiscount, quantity, ...bookData } = row;
+														bookFormData = bookData;
+													}}
+													class="btn-secondary btn-sm btn"
+												>
+													<span class="sr-only">{tLabels.edit_row()} {rowIx}</span>
+													<span class="aria-hidden">
+														<FileEdit />
+													</span>
+												</button>
+
+												<button class="btn-secondary btn-sm btn" data-testid={testId("print-book-label")} on:click={handlePrintLabel(row)}>
+													<span class="sr-only">{tLabels.print_book_label()} {rowIx}</span>
+													<span class="aria-hidden">
+														<Printer />
+													</span>
+												</button>
+											</div>
+										</PopoverWrapper>
+									</div>
+								</StockBookRow>
+							</tr>
+						</StockTable>
+					</div>
+
+					<!-- Trigger for the infinite scroll intersection observer -->
+					{#if entries?.length > maxResults}
+						<div use:scroll.trigger></div>
+					{/if}
 				</div>
-
-				<!-- Trigger for the infinite scroll intersection observer -->
-				{#if entries?.length > maxResults}
-					<div use:scroll.trigger></div>
-				{/if}
-			</div>
-		{/if}
+			{/if}
+		{/await}
 	</div>
 </Page>
 

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -35,9 +35,9 @@ const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 		};
 	}
 
-	// Disable the stock cache to prevent the expensive stock query from blocking the
+	// Disable the stock cache refreshing to prevent the expensive stock query from blocking the
 	// DB for other (cheaper) queries necessary for the page load.
-	stockCache.disable();
+	stockCache.disableRefresh();
 
 	const warehouse = await getWarehouseById(dbCtx.db, id);
 	if (!warehouse) {
@@ -46,8 +46,8 @@ const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 
 	const publisherList = await getPublisherList(dbCtx.db);
 
-	// Enable the stock cache again to execute in the background
-	stockCache.enable(dbCtx.db);
+	// Re-enable the stock cache refreshing to execute in the background
+	stockCache.enableRefresh(dbCtx.db);
 
 	const entries = get(stockByWarehouse)
 		.then((s) => s.get(id))

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -9,6 +9,7 @@ import { getPublisherList } from "$lib/db/cr-sqlite/books";
 import { appPath } from "$lib/paths";
 
 import { timed } from "$lib/utils/timer";
+import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 
 const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	const id = Number(params.id);
@@ -20,18 +21,24 @@ const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 
 	// We're not in the browser, no need for further loading
 	if (!dbCtx) {
-		return { dbCtx, id, displayName: "N/A", discount: 0, entries: [], publisherList: [] as string[] };
+		return { dbCtx, id, displayName: "N/A", discount: 0, publisherList: [] as string[] };
 	}
+
+	// Disable the stock cache to prevent the expensive stock query from blocking the
+	// DB for other (cheaper) queries necessary for the page load.
+	stockCache.disable();
 
 	const warehouse = await getWarehouseById(dbCtx.db, id);
 	if (!warehouse) {
 		redirect(307, appPath("inventory"));
 	}
 
-	const entries = await getStock(dbCtx.db, { warehouseId: id });
 	const publisherList = await getPublisherList(dbCtx.db);
 
-	return { dbCtx, ...warehouse, entries, publisherList };
+	// Enable the stock cache again to execute in the background
+	stockCache.enable(dbCtx.db);
+
+	return { dbCtx, ...warehouse, publisherList };
 };
 
 export const load: PageLoad = timed(_load);

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -50,8 +50,11 @@ const _load = async ({ parent, params, depends }: Parameters<PageLoad>[0]) => {
 	stockCache.enableRefresh(dbCtx.db);
 
 	const entries = get(stockByWarehouse)
-		.then((s) => s.get(id))
+		.then((s) => [...(s.get(id) || [])])
 		.then(async (entries) => {
+			// Return early if stock empty
+			if (!entries.length) return [];
+
 			const isbns = map(entries, ({ isbn }) => isbn);
 			const bookData = await getMultipleBookData(dbCtx.db, ...isbns);
 			const iter = wrapIter(entries)


### PR DESCRIPTION
Goes after #951 

Adds some optimisations to reduce number of unnecessary queries and make sure the state validation is correct:
- makes sure `book_transaction.committed_at` is updated on every commit (the column was there only, it was seldom used)
- listens to changes to `book_transaction` table, rather than note table (with updated `committed_at` we can invalidate stock cache with respect to committed transactions, regardless of notes per se)
- the cache invalidation logic is updates so that:
  - every cached value is timestamped
  - when an update to `book_transaction` table happens, we run the `maybeInvalidate` function
  - `maybeInvalidate` runs a cheap query - checking if there are any `book_transaction` entries with `committed_at` after the last cache timestamp
  - invalidates cache only if there are relevant changes to the DB (num book transactions where `committed_at` > cache timestamp)
  
This is also sync-safe as it runs only on transactions (notes are irrelevant in this case), so sync order doesn't matter

Fixes #952 
^ in a simpler way than specified in the ticket
