### PR TITLE
Feat/db automigrate

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
@@ -1,0 +1,386 @@
+import { cryb64 } from "@vlcn.io/ws-common";
+
+import { zip } from "@librocco/shared";
+
+import type { DB, TXAsync } from "../types";
+import { getDB } from "../db";
+
+function firstPick<T>(data: any[]): T | undefined {
+	const d = data[0];
+	if (d == null) {
+		return undefined;
+	}
+
+	return d[Object.keys(d)[0]];
+}
+
+/**
+ * A copy of crsqlite db.automigrateTo function,
+ * @see https://github.com/vlcn-io/js/blob/b1574592f87067c8d6ddc269d9ad26018cfde05b/packages/crsqlite-wasm/src/DB.ts#L74
+ * only this is used to test out autmigration in JS context (for easier error reporting/debugging) and, as such, it uses the
+ * JS code defined below instead of calling the `crsql_automigrate` SQL function.
+ *
+ * The JS code used below is a port of the Rust code integrated into the crsqlite extension.
+ */
+export async function jsAutomigrateTo(db: DB, schemaName: string, schemaContent: string): Promise<"noop" | "apply" | "migrate"> {
+	// less safety checks for local db than server db.
+	const version = cryb64(schemaContent);
+	const storedName = firstPick(await db.execA(`SELECT value FROM crsql_master WHERE key = 'schema_name'`));
+	const storedVersion = firstPick(await db.execA(`SELECT value FROM crsql_master WHERE key = 'schema_version'`)) as
+		| bigint
+		| number
+		| undefined;
+
+	if (storedName === schemaName && BigInt(storedVersion || 0) === version) {
+		return "noop";
+	}
+
+	const ret = storedName === undefined || storedName !== schemaName ? "apply" : "migrate";
+
+	await db.tx(async (tx) => {
+		if (storedVersion == null || storedName !== schemaName) {
+			if (storedName !== schemaName) {
+				// drop all tables since a schema name change is a reformat of the db.
+				const tables = await tx.execA(
+					`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'crsql_%'`
+				);
+				for (const table of tables) {
+					await tx.exec(`DROP TABLE [${table[0]}]`);
+				}
+			}
+			await tx.exec(schemaContent);
+		} else {
+			// The following line is the original (for the original method):
+			//
+			// await tx.exec(`SELECT crsql_automigrate(?, 'SELECT crsql_finalize();')`, [schemaContent]);
+			//
+			// it calls the crsql_automigrate function, the impl for which can be found at:
+			// https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L31
+			//
+			// Here we're using the JS version of the same code in order to have clear and granunlar control on the execution
+			await crsql_automigrate(tx, schemaContent, `SELECT crsql_finalize()`);
+		}
+		await tx.exec(`INSERT OR REPLACE INTO crsql_master (key, value) VALUES (?, ?)`, ["schema_version", version]);
+		await tx.exec(`INSERT OR REPLACE INTO crsql_master (key, value) VALUES (?, ?)`, ["schema_name", schemaName]);
+	});
+	await db.exec(`VACUUM;`);
+
+	return ret;
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L31
+ */
+export async function crsql_automigrate(tx: TXAsync, schema: string, cleanup_stmt: string): Promise<void> {
+	// NOTE: the original Rust code parses the args received as pointers from the C glue and then proceeds to call the
+	// automigrate_impl function with the parsed args. Here we're letting TS take care of that and are calling the impl
+	// right away (rendering this function unnecessary, but defined here to keep consistent with the original code structure.
+	await automigrate_impl(tx, schema, cleanup_stmt);
+	console.log("Automigration completed successfully!");
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L55
+ */
+export async function automigrate_impl(tx: TXAsync, schema: string, cleanup_stmt: string) {
+	const cleanup = (mem_db: DB) => mem_db.exec(cleanup_stmt);
+
+	const local_db = tx;
+	const desired_schema = schema;
+	const stripped_schema = strip_crr_statements(desired_schema);
+
+	const mem_db = await getDB(":memory:");
+	if (!mem_db) {
+		throw new Error("could not open the temporary migration db");
+	}
+
+	try {
+		await mem_db.exec(stripped_schema);
+	} catch (e) {
+		// NOTE: we won't get as good of an error as we would within
+		// the sqlite extension (Rust code), but we get a clearer idea on the point of failure
+		console.error(e);
+		await cleanup(mem_db);
+		throw e;
+	}
+	local_db.exec("SAVEPOINT automigrate_tables;");
+
+	try {
+		await migrate_to(local_db, mem_db);
+		await cleanup(mem_db);
+	} catch (e) {
+		local_db.exec("ROLLBACK");
+		// NOTE: we won't get as good of an error as we would within
+		// the sqlite extension (Rust code), but we get a clearer idea on the point of failure
+		console.error(e);
+		await cleanup(mem_db);
+		throw e;
+	}
+
+	// IDK Why this is needed here (seems as if it would most certainly break -- unique constraint violations and what not...)
+	// EDIT: this is here as no new tables/indices are added within the check -- only the stale/existing ones are removed/updated
+	// and the full schema is applied at the end (here), skipping the existing ones and merely creating the new ones
+	//
+	// IMPORTANT NOTE: This implies that 'CREATE TABLE <table>' statements (or their index counterparts) will fail due to UNIQUE constraint violations
+	// and all such statements shold be replaced with 'CREATE TABLE IF NOT EXISTS <table>' statements (or their index counterparts)
+	if (desired_schema.length) {
+		local_db.exec(desired_schema);
+	}
+
+	local_db.exec("RELEASE automigrate_tables");
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L106
+ */
+export async function migrate_to(local_db: DB, mem_db: DB) {
+	const sql = `SELECT name FROM sqlite_master WHERE type = 'table'
+	    AND name NOT LIKE 'sqlite_%'
+	    AND name NOT LIKE 'crsql_%'
+	    AND name NOT LIKE '__crsql_%'
+	    AND name NOT LIKE '%__crsql_%'`;
+	const mem_tables = await mem_db.execA<[string]>(sql).then((r) => new Set(r.map(([name]) => name)));
+	const local_tables = await local_db.execA<[string]>(sql).then((r) => new Set(r.map(([name]) => name)));
+
+	const removed_tables: Array<string> = [];
+	const maybe_modified_tables: Array<string> = [];
+
+	for (const table of local_tables) {
+		if (mem_tables.has(table)) {
+			maybe_modified_tables.push(table);
+		} else {
+			removed_tables.push(table);
+		}
+	}
+
+	await drop_tables(local_db, removed_tables);
+	for (const table of maybe_modified_tables) {
+		await maybe_modify_table(local_db, table, mem_db);
+	}
+}
+
+/**
+ * stripts `select crsql_as_crr` statements
+ * from the provided schema.
+ * returns which tables were crrs so we can re-apply the statements
+ * once migrations are complete.
+ *
+ * We have to strip the statements given we can't load an extension into an extension
+ * in all environment.
+ *
+ * E.g., if cr-sqlite is running as a runtime loadable ext
+ * then it cannot open an in-memory db within itself that loads this same
+ * extension.
+ *
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L158
+ */
+export function strip_crr_statements(schema: string) {
+	return schema
+		.split("\n")
+		.filter((line) => !line.toLowerCase().includes("crsql_as_crr") && !line.toLowerCase().includes("crsql_fract_as_ordered"))
+		.join("\n");
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L169
+ */
+export async function drop_tables(local_db: DB, tables: string[]) {
+	for (const table of tables) {
+		await local_db.exec(`DROP TABLE ?`, [table]);
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L181
+ */
+export async function maybe_modify_table(local_db: DB, table: string, mem_db: DB) {
+	const sql = "SELECT name FROM pragma_table_info(?)";
+	const mem_columns = await mem_db.execA<[string]>(sql).then(([columns]) => new Set(columns || []));
+	const local_columns = await local_db.execA<[string]>(sql).then(([columns]) => new Set(columns || []));
+
+	const removed_columns: Array<string> = [];
+	const added_columns: Array<string> = [];
+
+	for (const column of local_columns) {
+		if (!mem_columns.has(column)) {
+			removed_columns.push(column);
+		}
+	}
+
+	for (const column of mem_columns) {
+		if (!local_columns.has(column)) {
+			added_columns.push(column);
+		}
+	}
+
+	const is_a_crr = await is_crr(local_db, table);
+	if (is_a_crr) {
+		await local_db.exec("SELECT crsql_begin_alter(?)", [table]);
+	}
+
+	await drop_columns(local_db, table, removed_columns);
+	await add_columns(local_db, table, added_columns, mem_db);
+	await maybe_update_indices(local_db, table, mem_db);
+
+	if (is_a_crr) {
+		await local_db.exec("SELECT crsql_commit_alter(?)", [table]);
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/is_crr.rs#L10
+ */
+export async function is_crr(local_db: DB, table: string) {
+	const sql = "SELECT count(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?";
+	const count = firstPick(await local_db.execA(sql, [table + "__crsql_itrig"]));
+	return Boolean(count);
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L236
+ */
+export async function drop_columns(local_db: DB, table: string, columns: string[]) {
+	await local_db.exec('DROP VIEW IF EXISTS "?"', [`${table}_fractindex`]);
+	for (const col of columns) {
+		await local_db.exec('ALTER TABLE "?" DROP "?"', [table, col]);
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L256
+ */
+export async function add_columns(local_db: DB, table: string, columns: string[], mem_db: DB) {
+	if (!columns.length) {
+		return;
+	}
+
+	const placeholder = `(${columns.map(() => "?").join(", ")})`;
+	const sql = `SELECT name, type, "notnull", dflt_value, pk FROM pragma_table_info(?) WHERE name IN (${placeholder})`;
+
+	const res = await mem_db.execA<[string, string, number, unknown, number]>(sql, [table, ...columns]);
+
+	let processed_cols = 0;
+	for (const col of res) {
+		const [name, col_type, nutnull, dflt_val, pk] = col;
+		if (Boolean(pk)) {
+			throw new Error("Adding primary key columns to existing tables is not supported in auto-migration");
+		}
+		await add_column(local_db, table, name, col_type, nutnull, dflt_val);
+		processed_cols += 1;
+	}
+
+	if (processed_cols !== columns.length) {
+		throw new Error("Not all columns were processed during migration");
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L301
+ */
+export function add_column(local_db: DB, table: string, name: string, col_type: string, notnull: number, dflt_val: unknown) {
+	const dflt_val_str = dflt_val === null ? "" : `DEFAULT ${dflt_val}`;
+	return local_db.exec(`ALTER TABLE "${table}" ADD COLUMN "${name}" ${col_type} ${notnull ? "NOT NULL" : ""} ${dflt_val_str}`);
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L328
+ */
+export async function maybe_update_indices(local_db: DB, table: string, mem_db: DB) {
+	// We do not pull PK indices because we do not support alterations that change
+	// primary key definitions.
+	// User would need to perform a manual migration for that.
+	// This is due to the fact that SQLite itself does not support changing primary key
+	// definitions in alter table statements.
+	const sql = "SELECT name FROM pragma_index_list(?) WHERE origin != 'pk';";
+
+	const local_indices = await local_db.execA(sql, [table]).then((res) => new Set(res.map(([name]) => name)));
+	const mem_indices = await mem_db.execA(sql, [table]).then((res) => new Set(res.map(([name]) => name)));
+
+	const removed: string[] = [];
+	const maybe_modified: string[] = [];
+
+	for (const idx of local_indices) {
+		if (!mem_indices.has(idx)) {
+			removed.push(idx);
+		} else {
+			maybe_modified.push(idx);
+		}
+	}
+
+	await drop_indices(local_db, removed);
+	// no add, schema file application will add
+	for (const idx of maybe_modified) {
+		await maybe_recreate_index(local_db, table, idx, mem_db);
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L374
+ */
+export async function drop_indices(local_db: DB, dropped: string[]) {
+	// drop if exists given column dropping could have destroyed the index
+	// already.
+	for (const idx of dropped) {
+		const sql = `DROP INDEX IF EXISTS "${idx}"`;
+		await local_db.exec(sql);
+	}
+}
+
+/**
+ * SQLite does not support alter index statements.
+ * What we are doing here is looking to see if indices with the same
+ * name have different definitions.
+ *
+ * If so, drop the index and re-create it with the new definiton.
+ *
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L396
+ *
+ */
+export async function maybe_recreate_index(local_db: DB, table: string, idx: string, mem_db: DB) {
+	const IS_UNIQUE_IDX_SQL = `SELECT "unique" FROM pragma_index_list(?) WHERE name = ?`;
+	const IDX_COLS_SQL = `SELECT name FROM pragma_index_info(?) ORDER BY seqno ASC`;
+
+	const is_unique_local = firstPick(await local_db.exec(IS_UNIQUE_IDX_SQL, [table, idx]).then((res) => res[0]?.[0] ?? 0));
+	const is_unique_mem = firstPick(await mem_db.exec(IS_UNIQUE_IDX_SQL, [table, idx]).then((res) => res[0]?.[0] ?? 0));
+
+	if (!is_unique_local && !is_unique_mem) {
+		throw new Error("Cannot alter index that is not unique");
+	}
+
+	// NOTE: Here the Rust code drops the prepared statement in order to free the index (not having open statements against it),
+	// but we're safe here as our queries are done in a (high-level) req-res manner
+
+	const idx_cols_local = await local_db.execA<[string]>(IDX_COLS_SQL, [idx]).then((res) => res.map(([name]) => name));
+	const idx_cols_mem = await local_db.execA<[string]>(IDX_COLS_SQL, [idx]).then((res) => res.map(([name]) => name));
+
+	// NOTE: This differs slightly from the Rust code: The Rust code (running within the SQLite process)
+	// - iterates over (both local and mem) index result rows in lockstep, as long as 'next' for both are defined and checks each step for equality
+	// - finally, it checks the final step for equality (expecting both to be end of result -- implying the same length)
+	// (see the original function for details)
+	//
+	// here we're doing things slightly differently (in opposite order):
+	// - we first check the lengths of both index definitions
+	// - if same, we perform the zip check
+	if (idx_cols_local.length !== idx_cols_mem.length) {
+		return recreate_index(local_db, idx);
+	}
+
+	for (const [[a], [b]] of zip(idx_cols_local, idx_cols_mem)) {
+		if (a !== b) {
+			// NOTE: Here the Rust code drops the prepared statement in order to free the index (not having open statements against it),
+			// but we're safe here as our queries are done in a (high-level) req-res manner
+			return recreate_index(local_db, idx);
+		}
+	}
+}
+
+/**
+ * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L447
+ */
+export function recreate_index(local_db: DB, idx: string) {
+	let indices = [idx];
+	drop_indices(local_db, indices);
+
+	// no need to call add_indices
+	// they'll be added later with schema reapplication
+}

--- a/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
@@ -2,7 +2,7 @@ import { cryb64 } from "@vlcn.io/ws-common";
 
 import { zip } from "@librocco/shared";
 
-import type { DB, TXAsync } from "../types";
+import type { DB } from "../types";
 import { getDB } from "../db";
 
 function firstPick<T>(data: any[]): T | undefined {
@@ -369,7 +369,7 @@ export async function add_columns(local_db: DB, table: string, columns: string[]
 	let processed_cols = 0;
 	for (const col of res) {
 		const [name, col_type, nutnull, dflt_val, pk] = col;
-		if (Boolean(pk)) {
+		if (pk) {
 			throw new Error("Adding primary key columns to existing tables is not supported in auto-migration");
 		}
 		await add_column(local_db, table, name, col_type, nutnull, dflt_val);
@@ -518,7 +518,7 @@ export async function recreate_index(local_db: DB, idx: string) {
 	const l = logger.extend("recreate_index");
 	l.start({ local_db, idx });
 
-	let indices = [idx];
+	const indices = [idx];
 	await drop_indices(local_db, indices);
 
 	// no need to call add_indices

--- a/apps/web-client/src/lib/db/indexeddb.ts
+++ b/apps/web-client/src/lib/db/indexeddb.ts
@@ -1,0 +1,37 @@
+/**
+ * An util used to promisify IDBRequest
+ */
+export function idbPromise<T extends IDBRequest>(req: T): Promise<T["result"]> {
+	return new Promise<T["result"]>((resolve, reject) => {
+		req.onsuccess = () => {
+			resolve(req.result);
+		};
+		req.onerror = () => {
+			reject(req.error);
+		};
+	});
+}
+
+/**
+ * A wrapper arount IDBTransaction:
+ * - accepts a transaction
+ * - runs the (async) setup - equeueing of operations within the transction
+ * - commits the transaction
+ * - resolves or rejects the promise based on the transaction result
+ */
+export function idbTxn(transaction: IDBTransaction, setup: (txn: IDBTransaction) => Promise<void>) {
+	return new Promise<void>((resolve, reject) => {
+		transaction.oncomplete = () => {
+			console.log("txn completed");
+			resolve();
+		};
+		transaction.onerror = () => {
+			console.error("txn error:", transaction.error);
+			reject(transaction.error);
+		};
+		setup(transaction)
+			.then(() => transaction.commit())
+			.then(resolve)
+			.catch(reject);
+	});
+}

--- a/apps/web-client/src/lib/schemas/init
+++ b/apps/web-client/src/lib/schemas/init
@@ -10,7 +10,7 @@
 	NOTE: Each table definition is followed by a call to 'crsql_as_crr' for that particular table - this activates the cr-sqlite extension functionality for that table
 */
 
-CREATE TABLE customer (
+CREATE TABLE IF NOT EXISTS customer (
 	id INTEGER NOT NULL,
 	display_id TEXT,
 	fullname TEXT,
@@ -22,7 +22,7 @@ CREATE TABLE customer (
 );
 SELECT crsql_as_crr('customer');
 
-CREATE TABLE customer_order_lines (
+CREATE TABLE IF NOT EXISTS customer_order_lines (
 	id INTEGER NOT NULL,
 	customer_id INTEGER,
 	isbn TEXT,
@@ -34,11 +34,11 @@ CREATE TABLE customer_order_lines (
 	-- FOREIGN KEY (customer_id) REFERENCES customer(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	-- FOREIGN KEY (isbn) REFERENCES book(isbn) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_customer_order_lines_customer_id ON customer_order_lines(customer_id);
-CREATE INDEX idx_customer_order_lines_isbn ON customer_order_lines(isbn);
+CREATE INDEX IF NOT EXISTS idx_customer_order_lines_customer_id ON customer_order_lines(customer_id);
+CREATE INDEX IF NOT EXISTS idx_customer_order_lines_isbn ON customer_order_lines(isbn);
 SELECT crsql_as_crr('customer_order_lines');
 
-CREATE TABLE book (
+CREATE TABLE IF NOT EXISTS book (
 	isbn TEXT NOT NULL,
 	title TEXT,
     authors TEXT,
@@ -52,9 +52,9 @@ CREATE TABLE book (
     PRIMARY KEY (isbn)
 );
 SELECT crsql_as_crr('book');
-CREATE INDEX idx_book_publisher ON book(publisher);
+CREATE INDEX IF NOT EXISTS idx_book_publisher ON book(publisher);
 
-CREATE TABLE supplier (
+CREATE TABLE IF NOT EXISTS supplier (
 	id INTEGER NOT NULL,
 	name TEXT,
 	email TEXT,
@@ -64,26 +64,26 @@ CREATE TABLE supplier (
 );
 SELECT crsql_as_crr('supplier');
 
-CREATE TABLE supplier_publisher (
+CREATE TABLE IF NOT EXISTS supplier_publisher (
 	supplier_id INTEGER,
 	publisher TEXT NOT NULL,
 	PRIMARY KEY (publisher)
 	-- FOREIGN KEY (supplier_id) REFERENCES supplier(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_supplier_publisher_supplier_id ON supplier_publisher(supplier_id);
+CREATE INDEX IF NOT EXISTS idx_supplier_publisher_supplier_id ON supplier_publisher(supplier_id);
 SELECT crsql_as_crr('supplier_publisher');
 
-CREATE TABLE supplier_order (
+CREATE TABLE IF NOT EXISTS supplier_order (
 	id INTEGER NOT NULL,
 	supplier_id INTEGER,
 	created INTEGER DEFAULT (strftime('%s', 'now') * 1000),
 	PRIMARY KEY (id)
 	-- FOREIGN KEY (supplier_id) REFERENCES supplier(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_supplier_order_supplier_id ON supplier_order(supplier_id);
+CREATE INDEX IF NOT EXISTS idx_supplier_order_supplier_id ON supplier_order(supplier_id);
 SELECT crsql_as_crr('supplier_order');
 
-CREATE TABLE supplier_order_line (
+CREATE TABLE IF NOT EXISTS supplier_order_line (
 	supplier_order_id INTEGER NOT NULL,
 	isbn TEXT NOT NULL,
 	quantity INTEGER NOT NULL DEFAULT 1,
@@ -91,11 +91,11 @@ CREATE TABLE supplier_order_line (
 	-- FOREIGN KEY (supplier_order_id) REFERENCES supplier_order(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	-- FOREIGN KEY (isbn) REFERENCES book(isbn) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_supplier_order_line_supplier_order_id ON supplier_order_line(supplier_order_id);
-CREATE INDEX idx_supplier_order_line_isbn ON supplier_order_line(isbn);
+CREATE INDEX IF NOT EXISTS idx_supplier_order_line_supplier_order_id ON supplier_order_line(supplier_order_id);
+CREATE INDEX IF NOT EXISTS idx_supplier_order_line_isbn ON supplier_order_line(isbn);
 SELECT crsql_as_crr('supplier_order_line');
 
-CREATE TABLE reconciliation_order (
+CREATE TABLE IF NOT EXISTS reconciliation_order (
 	id INTEGER NOT NULL,
 	supplier_order_ids TEXT CHECK (json_valid(supplier_order_ids) AND json_array_length(supplier_order_ids) >= 1),
 	created INTEGER DEFAULT (strftime('%s', 'now') * 1000),
@@ -105,7 +105,7 @@ CREATE TABLE reconciliation_order (
 );
 SELECT crsql_as_crr('reconciliation_order');
 
-CREATE TABLE reconciliation_order_lines (
+CREATE TABLE IF NOT EXISTS reconciliation_order_lines (
 	reconciliation_order_id INTEGER NOT NULL,
 	isbn TEXT NOT NULL,
 	quantity INTEGER NOT NULL DEFAULT 1,
@@ -113,11 +113,11 @@ CREATE TABLE reconciliation_order_lines (
 	-- FOREIGN KEY (reconciliation_order_id) REFERENCES reconciliation_order(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	-- FOREIGN KEY (isbn) REFERENCES book(isbn) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_reconciliation_order_lines_reconciliation_order_id ON reconciliation_order_lines(reconciliation_order_id);
-CREATE INDEX idx_reconciliation_order_lines_isbn ON reconciliation_order_lines(isbn);
+CREATE INDEX IF NOT EXISTS idx_reconciliation_order_lines_reconciliation_order_id ON reconciliation_order_lines(reconciliation_order_id);
+CREATE INDEX IF NOT EXISTS idx_reconciliation_order_lines_isbn ON reconciliation_order_lines(isbn);
 SELECT crsql_as_crr('reconciliation_order_lines');
 
-CREATE TABLE customer_order_line_supplier_order (
+CREATE TABLE IF NOT EXISTS customer_order_line_supplier_order (
 	customer_order_line_id INTEGER NOT NULL,
 	supplier_order_id INTEGER NOT NULL,
 	placed INTEGER DEFAULT 0,
@@ -125,11 +125,11 @@ CREATE TABLE customer_order_line_supplier_order (
 	-- FOREIGN KEY (customer_order_line_id) REFERENCES customer_order_lines(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	-- FOREIGN KEY (supplier_order_id) REFERENCES supplier_order(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_customer_order_line_supplier_order_customer_order_line_id ON customer_order_line_supplier_order(customer_order_line_id);
-CREATE INDEX idx_customer_order_line_supplier_order_supplier_order_id ON customer_order_line_supplier_order(supplier_order_id);
+CREATE INDEX IF NOT EXISTS idx_customer_order_line_supplier_order_customer_order_line_id ON customer_order_line_supplier_order(customer_order_line_id);
+CREATE INDEX IF NOT EXISTS idx_customer_order_line_supplier_order_supplier_order_id ON customer_order_line_supplier_order(supplier_order_id);
 SELECT crsql_as_crr('customer_order_line_supplier_order');
 
-CREATE TABLE warehouse (
+CREATE TABLE IF NOT EXISTS warehouse (
 	-- 0 id is reserved -- when warehouse id is unassigned (in a book txn for ex.) we're defaulting to 0
 	-- using 0 instead of NULL as 0 = 0 and NULL != NULL
     id INTEGER NOT NULL CHECK (id <> 0),
@@ -142,7 +142,7 @@ SELECT crsql_as_crr('warehouse');
 -- if warehouse_id is not null, the note is inbound
 -- if is_reconciliation_note is true (1) - it's a reconciliation note (obvious)
 -- if the note is not inbound, nor reconciliation, it is outbound
-CREATE TABLE note (
+CREATE TABLE IF NOT EXISTS note (
 	id INTEGER NOT NULL,
 	display_name TEXT,
 	warehouse_id INTEGER,
@@ -155,12 +155,12 @@ CREATE TABLE note (
 	-- FOREIGN KEY (warehouse_id) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL,
 	-- FOREIGN KEY (default_warehouse) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE SET NULL
 );
-CREATE INDEX idx_note_warehouse_id ON note(warehouse_id);
-CREATE INDEX idx_note_default_warehouse ON note(default_warehouse);
-CREATE INDEX idx_note_committed_at ON note(committed_at);
+CREATE INDEX IF NOT EXISTS idx_note_warehouse_id ON note(warehouse_id);
+CREATE INDEX IF NOT EXISTS idx_note_default_warehouse ON note(default_warehouse);
+CREATE INDEX IF NOT EXISTS idx_note_committed_at ON note(committed_at);
 SELECT crsql_as_crr('note');
 
-CREATE TABLE book_transaction (
+CREATE TABLE IF NOT EXISTS book_transaction (
 	isbn TEXT NOT NULL,
 	quantity INTEGER NOT NULL DEFAULT 0,
 	note_id INTEGER NOT NULL,
@@ -172,14 +172,14 @@ CREATE TABLE book_transaction (
 	-- FOREIGN KEY (note_id) REFERENCES note(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	-- FOREIGN KEY (warehouse_id) REFERENCES warehouse(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_book_transaction_isbn ON book_transaction(isbn);
-CREATE INDEX idx_book_transaction_note_id ON book_transaction(note_id);
-CREATE INDEX idx_book_transaction_warehouse_id ON book_transaction(warehouse_id);
-CREATE INDEX idx_book_transaction_committed_at ON book_transaction(committed_at);
+CREATE INDEX IF NOT EXISTS idx_book_transaction_isbn ON book_transaction(isbn);
+CREATE INDEX IF NOT EXISTS idx_book_transaction_note_id ON book_transaction(note_id);
+CREATE INDEX IF NOT EXISTS idx_book_transaction_warehouse_id ON book_transaction(warehouse_id);
+CREATE INDEX IF NOT EXISTS idx_book_transaction_committed_at ON book_transaction(committed_at);
 SELECT crsql_as_crr('book_transaction');
 
 
-CREATE TABLE custom_item (
+CREATE TABLE IF NOT EXISTS custom_item (
 	id INTEGER NOT NULL,
 	title TEXT,
 	price DECIMAL,
@@ -188,5 +188,5 @@ CREATE TABLE custom_item (
 	PRIMARY KEY (id, note_id)
 	-- FOREIGN KEY (note_id) REFERENCES note(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
-CREATE INDEX idx_custom_item_note_id ON custom_item(note_id);
+CREATE INDEX IF NOT EXISTS idx_custom_item_note_id ON custom_item(note_id);
 SELECT crsql_as_crr('custom_item');

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -212,8 +212,9 @@
 		// Clear all the data in CR-SQLite IndexedDB
 		await clearDb();
 
-		// Invalidate all - reinitialise the DB
-		await invalidateAll();
+		// Reload the window - to avoid a huge number of issues related to
+		// having to account for DB not being available, but becoming available within the same lifetime
+		window.location.reload();
 	};
 
 	const forceDBVersion = (wantVersion: bigint) => async () => {
@@ -221,8 +222,9 @@
 		const db = await getDB($dbid);
 		await db.exec("UPDATE crsql_master SET value = ? WHERE key = 'schema_version'", [wantVersion]);
 
-		// Invalidate all - reinitialise the DB
-		await invalidateAll();
+		// Reload the window - to avoid a huge number of issues related to
+		// having to account for DB not being available, but becoming available within the same lifetime
+		window.location.reload();
 	};
 </script>
 

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 
 	import { sync, syncConfig, syncActive, dbid, newSyncProgressStore } from "$lib/db";
 	import { clearDb, ErrDBSchemaMismatch, getDB, schemaName, schemaContent } from "$lib/db/cr-sqlite/db";
-
+	import * as migrations from "$lib/db/cr-sqlite/debug/migrations";
 	import * as books from "$lib/db/cr-sqlite/books";
 	import * as customers from "$lib/db/cr-sqlite/customers";
 	import * as note from "$lib/db/cr-sqlite/note";
@@ -75,6 +75,8 @@
 			window["warehouse"] = warehouse;
 
 			window["sync"] = sync;
+
+			window["migrations"] = migrations;
 		}
 
 		// This shouldn't affect much, but is here for the purpose of exhaustive handling
@@ -221,7 +223,8 @@
 	const automigrateDB = async () => {
 		// We need to retrieve the DB directly, as the broken DB won't be passed down from the load function
 		const db = await getDB($dbid);
-		await db.automigrateTo(schemaName, schemaContent);
+		// NOTE: using the pure JS implementation for debug purposes
+		await migrations.jsAutomigrateTo(db, schemaName, schemaContent);
 
 		// Reload the window - to avoid a huge number of issues related to
 		// having to account for DB not being available, but becoming available within the same lifetime

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -223,13 +223,15 @@
 	const automigrateDB = async () => {
 		// We need to retrieve the DB directly, as the broken DB won't be passed down from the load function
 		const db = await getDB($dbid);
-		// NOTE: using the pure JS implementation for debug purposes
-		await migrations.jsAutomigrateTo(db, schemaName, schemaContent);
+
+		console.log("automigrating db to latest versin....");
+		await db.automigrateTo(schemaName, schemaContent);
+		console.log("automigration done");
 
 		// Reload the window - to avoid a huge number of issues related to
 		// having to account for DB not being available, but becoming available within the same lifetime
 		// NOTE: commented out so we can observe the errors before navigating away, TODO: uncomment when stable
-		// window.location.reload();
+		window.location.reload();
 	};
 </script>
 

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -134,7 +134,7 @@
 		// Control the invalidation of the stock cache in central spot
 		// On every 'book_transaction' change, we run 'maybeInvalidate', which, in turn checks for relevant changes
 		// between the last cached value and the current one and invalidates the cache if needed
-		disposer = dbCtx.rx.onRange(["book_transaction"], () => stockCache.maybeInvalidate(dbCtx.db));
+		disposer = dbCtx?.rx?.onRange(["book_transaction"], () => stockCache.maybeInvalidate(dbCtx.db));
 	});
 
 	onDestroy(() => {

--- a/apps/web-client/src/routes/books/+page.svelte
+++ b/apps/web-client/src/routes/books/+page.svelte
@@ -40,9 +40,7 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-		disposer = rx.onRange(["book"], () => invalidate("book:data"));
+		disposer = data.dbCtx?.rx?.onRange(["book"], () => invalidate("book:data"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -28,12 +28,9 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when book data changes, or when a note "changes" (we're interested in committed change)
 		// We don't subscribe to book_transaction as we're only interested in committed txns - and this is triggered by note change
-		disposer = rx.onRange(["book", "note"], () => invalidate("history:transactions"));
+		disposer = data.dbCtx?.rx?.onRange(["book", "note"], () => invalidate("history:transactions"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -34,15 +34,12 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when book data changes, or when a note "changes" (we're interested in committed change)
 		// We also subscribe to warehouse data changes (for naming/discount changes)
 		// We don't subscribe to book_transaction as we're only interested in committed txns - and this is triggered by note change
 		//
 		// TODO: subscribe to only the book data for the particular ISBN
-		disposer = rx.onRange(["warehouse", "book", "note"], () => invalidate("history:transactions"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse", "book", "note"], () => invalidate("history:transactions"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -29,11 +29,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when note/warehouse changes (warehouse name/discount, note committed status)
-		disposer = rx.onRange(["note", "warehouse"], () => invalidate("history:notes"));
+		disposer = data.dbCtx?.rx?.onRange(["note", "warehouse"], () => invalidate("history:notes"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
@@ -32,12 +32,9 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Here we only care about updates to warehouses (displayName)
 		// as the rest of the data is immutable at this point (archived)
-		disposer = rx.onRange(["warehouse"], () => invalidate("note:books"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse"], () => invalidate("note:books"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -20,11 +20,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when warehouse data changes
-		disposer = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse"], () => invalidate("warehouse:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
@@ -32,12 +32,9 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when book data changes, or when a note "changes" (we're interested in committed change)
 		// We don't subscribe to book_transaction as we're only interested in committed txns - and this is triggered by note change
-		disposer = rx.onRange(["book", "note"], () => invalidate("history:transactions"));
+		disposer = data.dbCtx?.rx?.onRange(["book", "note"], () => invalidate("history:transactions"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -37,10 +37,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
 		// Warehouse (names), note (names/list) and book_transaction (note's totalBooks) all affect the list
-		disposer = rx.onRange(["warehouse", "note", "book_transaction"], () => invalidate("inbound:list"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse", "note", "book_transaction"], () => invalidate("inbound:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
@@ -67,13 +67,10 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when note
-		const disposer1 = rx.onPoint("note", BigInt(data.id), () => invalidate("note:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("note", BigInt(data.id), () => invalidate("note:data"));
 		// Reload when entries change
-		const disposer2 = rx.onRange(["book", "book_transaction"], () => invalidate("note:books"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["book", "book_transaction"], () => invalidate("note:books"));
 		disposer = () => (disposer1(), disposer2());
 	});
 	onDestroy(() => {

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -42,11 +42,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when warehouse data changes
-		disposer = rx.onRange(["warehouse"], () => invalidate("warehouse:list"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse"], () => invalidate("warehouse:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -50,13 +50,10 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when warehouse data changes
-		const disposer1 = rx.onPoint("warehouse", BigInt(data.id), () => invalidate("warehouse:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("warehouse", BigInt(data.id), () => invalidate("warehouse:data"));
 		// Reload when some stock changes (note being committed)
-		const disposer2 = rx.onRange(["book"], () => invalidate("warehouse:books"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["book"], () => invalidate("warehouse:books"));
 		// Reload when stock cache invalidates
 		const disposer3 = stockCache.onInvalidated(() => invalidate("warehouse:books"));
 

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -32,11 +32,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload all customer order/customer order line data dependants when the data changes
-		disposer = rx.onRange(["customer", "customer_order_lines"], () => invalidate("customer:list"));
+		disposer = data.dbCtx?.rx?.onRange(["customer", "customer_order_lines"], () => invalidate("customer:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -67,13 +67,10 @@
 	let disposer: () => void;
 
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload add customer data dependants when the data changes
-		const disposer1 = rx.onPoint("customer", BigInt(customerId), () => invalidate("customer:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("customer", BigInt(customerId), () => invalidate("customer:data"));
 		// Reload all customer order line/book data dependants when the data changes
-		const disposer2 = rx.onRange(["customer_order_lines", "book"], () => invalidate("customer:books"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["customer_order_lines", "book"], () => invalidate("customer:books"));
 		disposer = () => (disposer1(), disposer2());
 	});
 

--- a/apps/web-client/src/routes/orders/suppliers/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/+page.svelte
@@ -27,12 +27,9 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when note
 		// Reload when entries (book/custom item) change
-		disposer = rx.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:list"));
+		disposer = data.dbCtx?.rx?.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -31,13 +31,10 @@
 	let disposer: () => void;
 
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload add supplier data dependants when the data changes
-		const disposer1 = rx.onPoint("supplier", BigInt($page.params.id), () => invalidate("supplier:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("supplier", BigInt($page.params.id), () => invalidate("supplier:data"));
 		// Changes to supplier orders, supplier publishers
-		const disposer2 = rx.onRange(["supplier_publisher", "supplier_order"], () => invalidate("supplier:orders"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["supplier_publisher", "supplier_order"], () => invalidate("supplier:orders"));
 		disposer = () => (disposer1(), disposer2());
 	});
 

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
@@ -18,12 +18,9 @@
 
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
-		const disposer1 = rx.onRange(["book"], () => invalidate("books:data"));
-		const disposer2 = rx.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
-		const disposer3 = rx.onRange(["customer_order_lines"], () => invalidate("customers:order_lines"));
+		const disposer1 = data.dbCtx?.rx?.onRange(["book"], () => invalidate("books:data"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
+		const disposer3 = data.dbCtx?.rx?.onRange(["customer_order_lines"], () => invalidate("customers:order_lines"));
 
 		disposer = () => (disposer1(), disposer2(), disposer3());
 	});

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -29,13 +29,10 @@
 
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
-		const disposer1 = rx.onRange(["book"], () => invalidate("books:data"));
-		const disposer2 = rx.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
-		const disposer3 = rx.onRange(["customer_order_lines"], () => invalidate("customers:order_lines"));
-		const disposer4 = rx.onRange(["reconciliation_order"], () => invalidate("reconciliation:orders"));
+		const disposer1 = data.dbCtx?.rx?.onRange(["book"], () => invalidate("books:data"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
+		const disposer3 = data.dbCtx?.rx?.onRange(["customer_order_lines"], () => invalidate("customers:order_lines"));
+		const disposer4 = data.dbCtx?.rx?.onRange(["reconciliation_order"], () => invalidate("reconciliation:orders"));
 
 		disposer = () => (disposer1(), disposer2(), disposer3(), disposer4());
 	});

--- a/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.svelte
@@ -18,11 +18,8 @@
 	let disposer: () => void;
 
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
-		const disposer1 = rx.onRange(["reconciliation_order"], () => invalidate("reconciliation:orders"));
-		const disposer2 = rx.onRange(["book"], () => invalidate("book:data"));
+		const disposer1 = data.dbCtx?.rx?.onRange(["reconciliation_order"], () => invalidate("reconciliation:orders"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["book"], () => invalidate("book:data"));
 		disposer = () => (disposer1(), disposer2());
 	});
 

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
@@ -39,11 +39,10 @@
 
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
-		const disposer1 = rx.onPoint("reconciliationOrder", BigInt($page.params.id), () => invalidate("reconciliationOrder:data"));
-		const disposer2 = rx.onRange(["reconciliation_order", "reconciliation_order_lines"], () => invalidate("reconciliationOrder:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("reconciliationOrder", BigInt($page.params.id), () => invalidate("reconciliationOrder:data"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["reconciliation_order", "reconciliation_order_lines"], () =>
+			invalidate("reconciliationOrder:data")
+		);
 		disposer = () => (disposer1(), disposer2());
 	});
 	onDestroy(async () => {

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -31,10 +31,8 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
 		// Note (names/list) and book_transaction (note's totalBooks) all affect the list
-		disposer = rx.onRange(["note", "book_transaction"], () => invalidate("outbound:list"));
+		disposer = data.dbCtx?.rx?.onRange(["note", "book_transaction"], () => invalidate("outbound:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount

--- a/apps/web-client/src/routes/outbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[id]/+page.svelte
@@ -81,13 +81,10 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-
 		// Reload when note
-		const disposer1 = rx.onPoint("note", BigInt(data.id), () => invalidate("note:data"));
+		const disposer1 = data.dbCtx?.rx?.onPoint("note", BigInt(data.id), () => invalidate("note:data"));
 		// Reload when entries (book/custom item) change
-		const disposer2 = rx.onRange(["book", "book_transaction", "custom_item", "warehouse"], () => invalidate("note:books"));
+		const disposer2 = data.dbCtx?.rx?.onRange(["book", "book_transaction", "custom_item", "warehouse"], () => invalidate("note:books"));
 		disposer = () => (disposer1(), disposer2());
 	});
 	onDestroy(() => {

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -37,9 +37,7 @@
 	// #region reactivity
 	let disposer: () => void;
 	onMount(() => {
-		// NOTE: dbCtx should always be defined on client
-		const { rx } = data.dbCtx;
-		disposer = rx.onRange(["book"], () => invalidate("book:data"));
+		disposer = data.dbCtx?.rx?.onRange(["book"], () => invalidate("book:data"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount


### PR DESCRIPTION
Goes after #965 
Instead of merely forcing the DB version, on DB version error, the user is presented with a dialog prompting for automigration.

Under the hood is uses `db.automigrateTo(schemaName, schemaContent` from cr-sqlite api (extremely straightforward).

This didn't work at first (with an ambiguous error: unable to apply schema). To investigate further, I went and ported the Rust code to JS (for debugging). The (original) `db.automigrateTo` goes something like this:
- the vlcn JS code checks for schema name/version and decides whether it should nuke the DB and apply the schema anew or do automigration
- we're interested in automigration ofc - this is done (by the aforementioned code) by calling 
```ts
db.exec("SELECT crsql_automigrate(?)", [schemaContent])
```
- the underlying (SQL) function is implemented as part of the SQL extension (Rust code)
- the debug version is a port of the Rust code defining `crsql_automigrate` and is written almost verbatim (with the difference being the JS code uses the high level api and interacts with the `db` instance in a req-res manner vs. Rust's integrated low level stream processing, but the functionality it the same)

I've used the aforementioned JS debug code to figure out the initial issue. I've solved it, but the debug is still there as I imagine if might be useful for debugging of any would-be downstream bugs.

Now, the issue was with `CREATE TABLE` vs `CREATE TABLE IF NOT EXISTS` as `crsql_automigrate`:
- creates an intermediary DB with desired schema applied
- diffs the existing DB and the temp one
- removes or updates tables, columns and indices
- it does't add tables/indices in a granular manner, but rather applies the entire schema (to account for added tables)
- the last step depends on `IF NOT EXISTS` and produces `UNIQUE CONSTRAINT` errors otherwise

With respect to the mentioned bug, I've updated our schema to define every table with `IF NOT EXISTS` clause for idempotency. I know @silviot was against it at first, preferring the fail-fast approach, letting us know if we've applied schema more times than we should have. However, thanks to this update the `db.automigrateTo(schemaName, schemaContent)` now works out of the box.

Please give me your thoughts

PS for every function of the JS implementation, I've added links to their original counterparts for anyone interested.