### PR TITLE
Fix: svelte-check warnings

### DIFF
--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -117,12 +117,12 @@
 				</h2>
 
 				<div id="history-table" class="w-full">
-					<ul class="divide-base-300 w-full divide-y">
+					<ul class="w-full divide-y divide-base-300">
 						{#each bookList as { isbn, title, quantity, warehouseName, committedAt, noteType, noteName, noteId }}
 							<li
-								class="entity-list-row text-base-content grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
+								class="entity-list-row grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 text-base-content sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
 							>
-								<p data-property="isbn" class="text-base-content text-xl font-medium leading-none lg:col-span-3 xl:col-span-2">{isbn}</p>
+								<p data-property="isbn" class="text-xl font-medium leading-none text-base-content lg:col-span-3 xl:col-span-2">{isbn}</p>
 								<p
 									data-property="title"
 									class="col-span-2 overflow-hidden whitespace-nowrap text-xl font-medium lg:col-span-5 xl:col-span-3"
@@ -145,7 +145,7 @@
 										href={appPath("history/notes/archive", noteId)}
 										class="{noteType === 'outbound'
 											? 'text-error'
-											: 'text-success'} bg-base-200 mx-4 flex items-center rounded-sm border px-3 py-0.5 hover:font-semibold"
+											: 'text-success'} mx-4 flex items-center rounded-sm border bg-base-200 px-3 py-0.5 hover:font-semibold"
 									>
 										{#if noteType === "inbound"}
 											<p><ArrowLeft size={16} /></p>
@@ -196,7 +196,7 @@
 		@apply pointer-events-none opacity-40;
 	}
 	[data-melt-calendar-cell][data-unavailable] {
-		@apply text-error pointer-events-none line-through;
+		@apply pointer-events-none text-error line-through;
 	}
 
 	[data-melt-calendar-cell][data-selected] {

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -168,6 +168,7 @@
 	</div>
 </HistoryPage>
 
+<!-- svelte-ignore css-unused-selector -->
 <style lang="postcss">
 	[data-melt-calendar-prevbutton][data-disabled] {
 		@apply pointer-events-none rounded-lg p-1 opacity-40;
@@ -207,4 +208,5 @@
 	[data-melt-calendar-cell][data-outside-month] {
 		@apply pointer-events-none cursor-default opacity-0;
 	}
+	/* purgecss end ignore */
 </style>

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -117,12 +117,12 @@
 				</h2>
 
 				<div id="history-table" class="w-full">
-					<ul class="w-full divide-y divide-base-300">
+					<ul class="divide-base-300 w-full divide-y">
 						{#each bookList as { isbn, title, quantity, warehouseName, committedAt, noteType, noteName, noteId }}
 							<li
-								class="entity-list-row grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 text-base-content sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
+								class="entity-list-row text-base-content grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
 							>
-								<p data-property="isbn" class="text-xl font-medium leading-none text-base-content lg:col-span-3 xl:col-span-2">{isbn}</p>
+								<p data-property="isbn" class="text-base-content text-xl font-medium leading-none lg:col-span-3 xl:col-span-2">{isbn}</p>
 								<p
 									data-property="title"
 									class="col-span-2 overflow-hidden whitespace-nowrap text-xl font-medium lg:col-span-5 xl:col-span-3"
@@ -145,7 +145,7 @@
 										href={appPath("history/notes/archive", noteId)}
 										class="{noteType === 'outbound'
 											? 'text-error'
-											: 'text-success'} mx-4 flex items-center rounded-sm border bg-base-200 px-3 py-0.5 hover:font-semibold"
+											: 'text-success'} bg-base-200 mx-4 flex items-center rounded-sm border px-3 py-0.5 hover:font-semibold"
 									>
 										{#if noteType === "inbound"}
 											<p><ArrowLeft size={16} /></p>
@@ -168,6 +168,8 @@
 	</div>
 </HistoryPage>
 
+<!-- * Svelte check is not aware of the classes that melt adds to the calendar components
+ * so in this case we know more than it, and should tell it to quiet down-->
 <!-- svelte-ignore css-unused-selector -->
 <style lang="postcss">
 	[data-melt-calendar-prevbutton][data-disabled] {
@@ -194,7 +196,7 @@
 		@apply pointer-events-none opacity-40;
 	}
 	[data-melt-calendar-cell][data-unavailable] {
-		@apply pointer-events-none text-error line-through;
+		@apply text-error pointer-events-none line-through;
 	}
 
 	[data-melt-calendar-cell][data-selected] {
@@ -208,5 +210,4 @@
 	[data-melt-calendar-cell][data-outside-month] {
 		@apply pointer-events-none cursor-default opacity-0;
 	}
-	/* purgecss end ignore */
 </style>

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -72,14 +72,16 @@
 	<div use:dropdown>
 		<ul data-testid={testId("search-completions-container")} class="w-full divide-y overflow-y-auto rounded border bg-base-100 shadow-2xl">
 			{#each entries as { isbn, title, authors, year, publisher }}
-				<li
-					class="cursor-pointer items-start px-4 py-3"
-					on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
-					data-testid={testId("search-completion")}
-				>
-					<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
-					<p data-property="title" class="text-xl font-medium">{title}</p>
-					<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
+				<li>
+					<button
+						class="cursor-pointer items-start px-4 py-3"
+						on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
+						data-testid={testId("search-completion")}
+					>
+						<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
+						<p data-property="title" class="text-xl font-medium">{title}</p>
+						<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
+					</button>
 				</li>
 			{/each}
 		</ul>

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -73,7 +73,7 @@
 		<div>
 			<Search />
 			{#key isbn}
-				<input data-testid={testId("search-input")} autofocus use:input placeholder="Search" class="w-full" />
+				<input data-testid={testId("search-input")} use:input placeholder="Search" class="w-full" />
 			{/key}
 		</div>
 
@@ -171,14 +171,16 @@
 	<div use:dropdown>
 		<ul data-testid={testId("search-completions-container")} class="w-full divide-y overflow-y-auto rounded border bg-base-100 shadow-2xl">
 			{#each entries as { isbn, title, authors, year, publisher }}
-				<li
-					data-testid={testId("search-completion")}
-					on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
-					class="w-full cursor-pointer px-4 py-3"
-				>
-					<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
-					<p data-property="title" class="text-xl font-medium">{title}</p>
-					<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
+				<li>
+					<button
+						data-testid={testId("search-completion")}
+						on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
+						class="w-full cursor-pointer px-4 py-3"
+					>
+						<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
+						<p data-property="title" class="text-xl font-medium">{title}</p>
+						<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
+					</button>
 				</li>
 			{/each}
 		</ul>

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -213,14 +213,14 @@
 								{@const active = addSQLite3Suffix(file) === addSQLite3Suffix($dbid)}
 								{#if selectionOn}
 									<!-- svelte-ignore a11y_click_events_have_key_events -->
-									<li
-										on:click={handleSelect(file)}
-										data-active={active}
-										class="group flex h-16 cursor-pointer items-center justify-between px-4 py-3 {active
-											? 'bg-green-300'
-											: 'hover:bg-gray-50'}"
-									>
-										<span>{file}</span>
+									<li>
+										<button>
+											on:click={handleSelect(file)}
+											data-active={active}
+											class="group flex h-16 cursor-pointer items-center justify-between px-4 py-3 {active
+												? "bg-green-300"
+												: "hover:bg-gray-50"}" > file
+										</button>
 									</li>
 								{:else}
 									<li


### PR DESCRIPTION
Cleans up remaining svelte-check warnings about accessibility and unused css selectors

Fixes #563 