### PR TITLE
Chore: improve lucide-imports to reduce build time

### DIFF
--- a/apps/web-client/src/lib/components/Breadcrumbs/Breadcrumbs.svelte
+++ b/apps/web-client/src/lib/components/Breadcrumbs/Breadcrumbs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronRight } from "lucide-svelte";
+	import ChevronRight from "$lucide/chevron-right";
 
 	import type { Breadcrumb } from "./types";
 
@@ -7,7 +7,7 @@
 </script>
 
 <nav id="breadcrumbs" {...$$restProps}>
-	<ul class="flex select-none flex-wrap items-center gap-y-2 whitespace-nowrap text-sm font-medium leading-5 xs:gap-x-2">
+	<ul class="xs:gap-x-2 flex select-none flex-wrap items-center gap-y-2 whitespace-nowrap text-sm font-medium leading-5">
 		{#each links as { label, href }, i}
 			{@const isLast = i === links.length - 1}
 			{@const hasLink = Boolean(href)}

--- a/apps/web-client/src/lib/components/CalendarPicker.svelte
+++ b/apps/web-client/src/lib/components/CalendarPicker.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { getLocalTimeZone, now, type DateValue } from "@internationalized/date";
 	import { createDatePicker, melt } from "@melt-ui/svelte";
-	import { Calendar, ChevronLeft, ChevronRight } from "lucide-svelte";
+	import Calendar from "$lucide/calendar";
+	import ChevronLeft from "$lucide/chevron-left";
+	import ChevronRight from "$lucide/chevron-right";
 	import { fade } from "svelte/transition";
 
 	import { testId, type TestId } from "@librocco/shared";
@@ -35,7 +37,7 @@
 </script>
 
 <div>
-	<div class="px mt-1.5 flex min-w-[200px] items-center gap-x-2 border border-base-100 bg-base-100 p-1.5" use:melt={$field}>
+	<div class="px border-base-100 bg-base-100 mt-1.5 flex min-w-[200px] items-center gap-x-2 border p-1.5" use:melt={$field}>
 		<p class="flex items-center gap-x-0.5">
 			<span use:melt={$segment("day")}>{day}</span>
 			<span>/</span>
@@ -66,11 +68,11 @@
 {#if $open}
 	<div
 		data-testid={testId("calendar-picker")}
-		class="z-10 min-w-[320px] bg-base-100 shadow-sm"
+		class="bg-base-100 z-10 min-w-[320px] shadow-sm"
 		transition:fade={{ duration: 100 }}
 		use:melt={$content}
 	>
-		<div class="w-full rounded-lg bg-base-100 p-3 shadow-sm" use:melt={$calendar}>
+		<div class="bg-base-100 w-full rounded-lg p-3 shadow-sm" use:melt={$calendar}>
 			<div data-testid={testId("calendar-picker-month-select")} class="flex items-center justify-between pb-2">
 				<button class="btn-neutral btn p-1 transition-all" use:melt={$prevButton}>
 					<ChevronLeft size={24} />
@@ -141,11 +143,11 @@
 		@apply pointer-events-none opacity-40;
 	}
 	[data-melt-calendar-cell][data-unavailable] {
-		@apply pointer-events-none text-error-content line-through;
+		@apply text-error-content pointer-events-none line-through;
 	}
 
 	[data-melt-calendar-cell][data-selected] {
-		@apply bg-success text-base text-success-content;
+		@apply bg-success text-success-content text-base;
 	}
 
 	[data-melt-calendar-cell][data-outside-visible-months] {

--- a/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Save } from "lucide-svelte";
+	import Save from "$lucide/save";
 	import { createEventDispatcher } from "svelte";
 
 	const dispatch = createEventDispatcher<{ cancel: void; confirm: void }>();

--- a/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
+++ b/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 	import { Story } from "@storybook/addon-svelte-csf";
-	import { Mail } from "lucide-svelte";
+	import Mail from "$lucide/mail";
 </script>
 
 <Story name="Default">

--- a/apps/web-client/src/lib/components/Melt/DropdownWrapper.svelte
+++ b/apps/web-client/src/lib/components/Melt/DropdownWrapper.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { fly } from "svelte/transition";
 
-	import { MoreVertical } from "lucide-svelte";
+	import MoreVertical from "$lucide/more-vertical";
+
 	import { createDropdownMenu, melt } from "@melt-ui/svelte";
 	import { testId } from "@librocco/shared";
 
@@ -15,7 +16,7 @@
 	data-testid="dropdown-control"
 	data-open={$open}
 	use:melt={$trigger}
-	class="bg-content btn-sm btn items-center border border-base-content py-[9px] pl-[17px] pr-[15px] hover:bg-base-300"
+	class="bg-content btn-sm btn border-base-content hover:bg-base-300 items-center border py-[9px] pl-[17px] pr-[15px]"
 >
 	<MoreVertical class="border-base-300" size={14} />
 </button>
@@ -25,7 +26,7 @@
 		data-testid={testId("dropdown-menu")}
 		use:melt={$menu}
 		transition:fly|global={{ duration: 150, y: -10 }}
-		class="z-50 min-w-[224px] overflow-hidden bg-base-100 shadow-lg ring-1 ring-primary ring-opacity-5"
+		class="bg-base-100 ring-primary z-50 min-w-[224px] overflow-hidden shadow-lg ring-1 ring-opacity-5"
 	>
 		<slot separator={$separator} item={$item} />
 	</div>

--- a/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
+++ b/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fade } from "svelte/transition";
 	import { expoInOut } from "svelte/easing";
-	import { X } from "lucide-svelte";
+	import X from "$lucide/x";
 
 	import { melt } from "@melt-ui/svelte";
 	import type { Dialog } from "@melt-ui/svelte";

--- a/apps/web-client/src/lib/components/PageLayout.svelte
+++ b/apps/web-client/src/lib/components/PageLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Search, ScanBarcode } from "lucide-svelte";
+	import Search from "$lucide/search";
+	import ScanBarcode from "$lucide/scan-barcode";
 
 	import { testId, type WebClientView } from "@librocco/shared";
 	import LL from "@librocco/shared/i18n-svelte";
@@ -14,7 +15,7 @@
 <!-- Main content -->
 <div data-view={view} id={testId("page-container")} class="h-full w-full">
 	<div class="flex h-full w-full flex-col overflow-y-auto" id="content">
-		<div class="sticky top-0 z-20 flex h-16 items-center justify-between border-b border-base-content bg-base-200">
+		<div class="border-base-content bg-base-200 sticky top-0 z-20 flex h-16 items-center justify-between border-b">
 			<h1 class="pl-[70px] text-lg font-medium lg:pl-5">{title}</h1>
 			<!-- TODO: add strings to dicts -->
 			<div class="flex gap-x-2 p-4">
@@ -32,7 +33,7 @@
 		<div class="flex h-full w-full flex-col justify-between divide-y" id="content">
 			<slot name="main" />
 
-			<div class="sticky bottom-0 flex basis-8 items-center justify-end border-t bg-base-200 px-4">
+			<div class="bg-base-200 sticky bottom-0 flex basis-8 items-center justify-end border-t px-4">
 				<slot name="footer" />
 			</div>
 		</div>

--- a/apps/web-client/src/lib/components/Sidebar.svelte
+++ b/apps/web-client/src/lib/components/Sidebar.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-	import {
-		BookCopy,
-		Library,
-		PackageMinus,
-		Search,
-		Settings,
-		PersonStanding,
-		Book,
-		Truck,
-		ChevronDown,
-		Moon,
-		Sun,
-		Globe,
-		CalendarClock
-	} from "lucide-svelte";
+	import BookCopy from "$lucide/book-copy";
+	import Library from "$lucide/library";
+	import PackageMinus from "$lucide/package-minus";
+	import Search from "$lucide/search";
+	import Settings from "$lucide/settings";
+	import PersonStanding from "$lucide/person-standing";
+	import Book from "$lucide/book";
+	import Truck from "$lucide/truck";
+	import ChevronDown from "$lucide/chevron-down";
+	import Moon from "$lucide/moon";
+	import Sun from "$lucide/sun";
+	import Globe from "$lucide/globe";
+	import CalendarClock from "$lucide/calendar-clock";
 
 	import { LL } from "@librocco/shared/i18n-svelte";
 
@@ -75,8 +73,8 @@
 </script>
 
 <div class="flex h-full w-full flex-col">
-	<div class="relative flex h-16 w-full items-center border-b border-base-content">
-		<div class="px-6 py-4 text-primary">
+	<div class="border-base-content relative flex h-16 w-full items-center border-b">
+		<div class="text-primary px-6 py-4">
 			<BookCopy strokeWidth={2} size={36} />
 		</div>
 		<!-- TODO: better app name font? -->
@@ -103,10 +101,10 @@
 				<ChevronDown size={16} />
 			</div>
 			<div
-				class="dropdown-content top-px mt-16 w-40 overflow-y-auto rounded-box border border-white/5 bg-base-200 text-base-content shadow-2xl outline-1 outline-black/5"
+				class="dropdown-content rounded-box bg-base-200 text-base-content top-px mt-16 w-40 overflow-y-auto border border-white/5 shadow-2xl outline-1 outline-black/5"
 			>
 				<!-- TODO: iterate list of langs that we have in dicts -->
-				<ul class="menu menu-sm w-full bg-base-200">
+				<ul class="menu menu-sm bg-base-200 w-full">
 					<li>
 						<button class="active">
 							<span class="font-mono font-bold opacity-40">EN</span>

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/BooksTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/BooksTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Writable } from "svelte/store";
-	import { ChevronDown, ChevronUp } from "lucide-svelte";
+	import ChevronDown from "$lucide/chevron-down";
+	import ChevronUp from "$lucide/chevron-up";
 
 	import { type createTable } from "$lib/actions";
 

--- a/apps/web-client/src/lib/components/Tables/OrderTables/BodyLink.svelte
+++ b/apps/web-client/src/lib/components/Tables/OrderTables/BodyLink.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ChevronRight } from "lucide-svelte";
+	import ChevronRight from "$lucide/chevron-right";
 
 	export let link: string;
 	export let label: string;

--- a/apps/web-client/src/lib/components/Tables/OrderTables/CustomerOrderTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/OrderTables/CustomerOrderTable.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { UserRound, Hash, CalendarClock } from "lucide-svelte";
+	import UserRound from "$lucide/user-round";
+	import Hash from "$lucide/hash";
+	import CalendarClock from "$lucide/calendar-clock";
 
 	import { HeadCol, BodyMultiRow } from "../Cells";
 

--- a/apps/web-client/src/lib/components/Tables/OrderTables/SupplierOrderTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/OrderTables/SupplierOrderTable.svelte
@@ -13,7 +13,9 @@
 </script>
 
 <script lang="ts">
-	import { Building2, Hash, CalendarClock } from "lucide-svelte";
+	import Building2 from "$lucide/building-2";
+	import Hash from "$lucide/hash";
+	import CalendarClock from "$lucide/calendar-clock";
 	import type { Writable } from "svelte/store";
 
 	import { HeadCol, BodyMultiRow } from "../Cells";

--- a/apps/web-client/src/lib/components/Tables/OrderTables/SupplierTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/OrderTables/SupplierTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Building2, Hash, CalendarClock } from "lucide-svelte";
+	import Building2 from "$lucide/building-2";
+
 	import type { Writable } from "svelte/store";
 
 	import type { SupplierExtended } from "$lib/db/cr-sqlite/types";

--- a/apps/web-client/src/lib/components/Tables/stories/Cells.stories.svelte
+++ b/apps/web-client/src/lib/components/Tables/stories/Cells.stories.svelte
@@ -14,7 +14,7 @@
 <script lang="ts">
 	import { Story } from "@storybook/addon-svelte-csf";
 
-	import { UserRound } from "lucide-svelte";
+	import UserRound from "$lucide/user-round";
 </script>
 
 <Story name="Head Column Cell">

--- a/apps/web-client/src/lib/components/Tables/stories/InventoryTables.stories.svelte
+++ b/apps/web-client/src/lib/components/Tables/stories/InventoryTables.stories.svelte
@@ -12,7 +12,7 @@
 	import { Story } from "@storybook/addon-svelte-csf";
 
 	import { writable } from "svelte/store";
-	import { FileEdit } from "lucide-svelte";
+	import FileEdit from "$lucide/file-edit";
 
 	import { createTable } from "$lib/actions";
 

--- a/apps/web-client/src/lib/components/TextEditable/NumberEditable.svelte
+++ b/apps/web-client/src/lib/components/TextEditable/NumberEditable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tick } from "svelte";
-	import { PencilLine } from "lucide-svelte";
+	import PencilLine from "$lucide/pencil-line";
 	import { clickOutside } from "$lib/actions";
 
 	export let name: string;

--- a/apps/web-client/src/lib/components/TextEditable/TextEditable.svelte
+++ b/apps/web-client/src/lib/components/TextEditable/TextEditable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tick } from "svelte";
-	import { PencilLine } from "lucide-svelte";
+	import PencilLine from "$lucide/pencil-line";
 	import { clickOutside } from "$lib/actions";
 	import { createEventDispatcher } from "svelte";
 	import { testId } from "@librocco/shared";

--- a/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
+++ b/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import { createEventDispatcher, onMount, tick } from "svelte";
+	import { createEventDispatcher } from "svelte";
 
 	import { createSelect } from "@melt-ui/svelte";
-	import { Check, ChevronsUpDown, RefreshCcwDot } from "lucide-svelte";
+	import Check from "$lucide/check";
+	import ChevronsUpDown from "$lucide/chevrons-up-down";
+	import RefreshCcwDot from "$lucide/refresh-ccw-dot";
 
 	import { testId } from "@librocco/shared";
 
@@ -62,7 +64,7 @@
 <button
 	data-testid={testId("dropdown-control")}
 	data-open={open}
-	class="border-base flex w-full gap-x-2 rounded border-2 bg-transparent p-2 shadow focus:border-primary focus:outline-none focus:ring-0"
+	class="border-base focus:border-primary flex w-full gap-x-2 rounded border-2 bg-transparent p-2 shadow focus:outline-none focus:ring-0"
 	{...$trigger}
 	use:trigger
 	aria-label="Warehouse"
@@ -80,14 +82,14 @@
 {#if $open}
 	<div
 		data-testid={testId("dropdown-menu")}
-		class="z-10 flex max-h-[300px] flex-col gap-y-1.5 overflow-y-auto rounded-lg bg-base-100 p-1 text-base-content shadow-md focus:!ring-0"
+		class="bg-base-100 text-base-content z-10 flex max-h-[300px] flex-col gap-y-1.5 overflow-y-auto rounded-lg p-1 shadow-md focus:!ring-0"
 		{...$menu}
 		use:menu
 	>
 		{#each options as warehouse}
 			{@const { label, value } = warehouse}
 			<div
-				class="relative flex cursor-pointer items-center justify-between rounded p-1 focus:z-10 data-[highlighted]:bg-primary data-[highlighted]:text-primary-content"
+				class="data-[highlighted]:bg-primary data-[highlighted]:text-primary-content relative flex cursor-pointer items-center justify-between rounded p-1 focus:z-10"
 				{...$option(warehouse)}
 				use:option
 			>

--- a/apps/web-client/src/lib/components/supplier-orders/CompletedTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/CompletedTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ListTodo } from "lucide-svelte";
+	import ListTodo from "$lucide/list-todo";
 	import type { PlacedSupplierOrder } from "$lib/db/cr-sqlite/types";
 	import { goto } from "$lib/utils/navigation";
 	import LL from "@librocco/shared/i18n-svelte";

--- a/apps/web-client/src/lib/components/supplier-orders/OrderedTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/OrderedTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ListTodo } from "lucide-svelte";
+	import ListTodo from "$lucide/list-todo";
 	import type { PlacedSupplierOrder } from "$lib/db/cr-sqlite/types";
 	import { goto } from "$lib/utils/navigation";
 	import { base } from "$app/paths";

--- a/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/ReconcilingTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { ClockArrowUp, Scan } from "lucide-svelte";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
+	import Scan from "$lucide/scan";
 
 	import { goto } from "$lib/utils/navigation";
 	import type { ReconciliationOrder } from "$lib/db/cr-sqlite/types";

--- a/apps/web-client/src/lib/components/supplier-orders/UnorderedTable.svelte
+++ b/apps/web-client/src/lib/components/supplier-orders/UnorderedTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Truck } from "lucide-svelte";
+	import Truck from "$lucide/truck";
 
 	export let orders: Array<{
 		supplier_name: string;

--- a/apps/web-client/src/lib/controllers/HistoryPage.svelte
+++ b/apps/web-client/src/lib/controllers/HistoryPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Book, Calendar, Search } from "lucide-svelte";
+	import Book from "$lucide/book";
+	import Calendar from "$lucide/calendar";
 
 	import { browser } from "$app/environment";
 	import { page } from "$app/stores";

--- a/apps/web-client/src/lib/controllers/InventoryManagementPage.svelte
+++ b/apps/web-client/src/lib/controllers/InventoryManagementPage.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { Building, Plus, CopyPlus } from "lucide-svelte";
+	import Building from "$lucide/building";
+	import Plus from "$lucide/plus";
+	import CopyPlus from "$lucide/copy-plus";
 
 	import { page } from "$app/stores";
 

--- a/apps/web-client/src/lib/forms/BookForm.svelte
+++ b/apps/web-client/src/lib/forms/BookForm.svelte
@@ -6,7 +6,10 @@
 	import { superForm, numberProxy, stringProxy } from "sveltekit-superforms/client";
 
 	import { createCombobox, melt, type ComboboxOptionProps } from "@melt-ui/svelte";
-	import { Check, ChevronUp, ChevronDown, Euro } from "lucide-svelte";
+	import Check from "$lucide/check";
+	import ChevronUp from "$lucide/chevron-up";
+	import ChevronDown from "$lucide/chevron-down";
+	import Euro from "$lucide/euro";
 
 	import { testId } from "@librocco/shared";
 
@@ -182,12 +185,12 @@
 				{#if $open}
 					<ul
 						use:melt={$menu}
-						class="absolute z-[200] mt-1 max-h-60 w-full overflow-auto rounded-md bg-base-100 py-1 text-base shadow-md"
+						class="bg-base-100 absolute z-[200] mt-1 max-h-60 w-full overflow-auto rounded-md py-1 text-base shadow-md"
 						transition:fly|global={{ duration: 150, y: -5 }}
 					>
 						{#each $selectedStates as { publisher, isSelected, isHighlighted }}
 							<li
-								class="relative cursor-pointer select-none py-2 pl-10 pr-4 text-base-content data-[highlighted]:bg-primary data-[highlighted]:text-primary-content"
+								class="text-base-content data-[highlighted]:bg-primary data-[highlighted]:text-primary-content relative cursor-pointer select-none py-2 pl-10 pr-4"
 								use:melt={$option(toOption(publisher))}
 							>
 								<span class="block truncate {isSelected ? 'font-medium' : 'font-normal'}">{publisher}</span>

--- a/apps/web-client/src/lib/forms/CustomItemForm.svelte
+++ b/apps/web-client/src/lib/forms/CustomItemForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { superForm, numberProxy } from "sveltekit-superforms/client";
-	import { Euro } from "lucide-svelte";
+	import Euro from "$lucide/euro";
 
 	import { testId } from "@librocco/shared";
 

--- a/apps/web-client/src/lib/forms/CustomerOrderMetaForm.svelte
+++ b/apps/web-client/src/lib/forms/CustomerOrderMetaForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms/client";
-	import { Save } from "lucide-svelte";
+	import Save from "$lucide/save";
 
 	import { FormFieldProxy, TextControl } from "$lib/forms/controls";
 

--- a/apps/web-client/src/lib/forms/DaisyUIScannerForm.svelte
+++ b/apps/web-client/src/lib/forms/DaisyUIScannerForm.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import { defaults } from "sveltekit-superforms";
-	import type { FormOptions } from "sveltekit-superforms";
 	import { superForm } from "sveltekit-superforms/client";
+	import QrCode from "$lucide/qr-code";
 
-	import { scannerSchema, type ScannerSchema } from "$lib/forms/schemas";
+	import { scannerSchema } from "$lib/forms/schemas";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { QrCode } from "lucide-svelte";
 
 	export let onSubmit: (isbn: string) => void | Promise<void>;
 

--- a/apps/web-client/src/lib/forms/ScannerForm.svelte
+++ b/apps/web-client/src/lib/forms/ScannerForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms/client";
-	import { QrCode } from "lucide-svelte";
+	import QrCode from "$lucide/qr-code";
 
 	import { testId } from "@librocco/shared";
 

--- a/apps/web-client/src/lib/forms/SupplierMetaForm.svelte
+++ b/apps/web-client/src/lib/forms/SupplierMetaForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms/client";
-	import { Save } from "lucide-svelte";
+	import Save from "$lucide/save";
 
 	import { FormFieldProxy, TextControl } from "$lib/forms/controls";
 

--- a/apps/web-client/src/lib/forms/WarehouseForm.svelte
+++ b/apps/web-client/src/lib/forms/WarehouseForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Percent } from "lucide-svelte";
+	import Percent from "$lucide/percent";
 	import { superForm, numberProxy } from "sveltekit-superforms/client";
 
 	import { Input } from "$lib/components/FormControls";

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 
 	import { Subscription } from "rxjs";
 	import { createDialog, melt } from "@melt-ui/svelte";
-	import { Menu } from "lucide-svelte";
+	import Menu from "$lucide/menu";
 
 	import { afterNavigate } from "$app/navigation";
 	import { browser } from "$app/environment";
@@ -235,7 +235,7 @@
 	};
 </script>
 
-<div class="flex h-full bg-base-200 lg:divide-x lg:divide-base-content">
+<div class="bg-base-200 lg:divide-base-content flex h-full lg:divide-x">
 	<div class="hidden h-full w-72 lg:block">
 		<Sidebar />
 	</div>
@@ -259,7 +259,7 @@
 
 		<div
 			use:melt={$mobileNavContent}
-			class="fixed bottom-0 left-0 top-0 z-[200] h-full w-2/3 max-w-md overflow-y-auto bg-base-200"
+			class="bg-base-200 fixed bottom-0 left-0 top-0 z-[200] h-full w-2/3 max-w-md overflow-y-auto"
 			transition:fly|global={{
 				x: -350,
 				duration: 300,

--- a/apps/web-client/src/routes/books/+page.svelte
+++ b/apps/web-client/src/routes/books/+page.svelte
@@ -7,7 +7,11 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { Search, FileEdit, X, Loader2 as Loader, Printer, MoreVertical } from "lucide-svelte";
+	import Search from "$lucide/search";
+	import FileEdit from "$lucide/file-edit";
+	import X from "$lucide/x";
+	import Printer from "$lucide/printer";
+	import MoreVertical from "$lucide/more-vertical";
 
 	import type { BookData } from "@librocco/shared";
 	import { testId } from "@librocco/shared";
@@ -226,15 +230,15 @@
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$content}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-				bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+				overflow-y-auto shadow-lg focus:outline-none"
 			transition:fly|global={{
 				x: 350,
 				duration: 300,
 				opacity: 1
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$title} class="text-lg font-medium">{$LL.stock_page.labels.edit_book_details()}</h2>
 					<p use:melt={$description} class="leading-normal">

--- a/apps/web-client/src/routes/debug/+page.svelte
+++ b/apps/web-client/src/routes/debug/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import { Plus, RotateCcw, Play, BookPlus } from "lucide-svelte";
+	import Plus from "$lucide/plus";
+	import RotateCcw from "$lucide/rotate-ccw";
+	import Play from "$lucide/play";
+	import BookPlus from "$lucide/book-plus";
+
 	import { onMount } from "svelte";
 
 	import { wrapIter } from "@librocco/shared";
@@ -284,7 +288,7 @@
 </script>
 
 <div id="content" class="h-full w-full overflow-y-auto">
-	<header class="flex h-16 items-center justify-between border-b border-base-content">
+	<header class="border-base-content flex h-16 items-center justify-between border-b">
 		<h2 class="pl-[70px] text-lg font-medium lg:pl-5">Debug</h2>
 	</header>
 

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { Library, ArrowLeft, ArrowRight } from "lucide-svelte";
+	import Library from "$lucide/library";
+	import ArrowLeft from "$lucide/arrow-left";
+	import ArrowRight from "$lucide/arrow-right";
 	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
 	import { invalidate } from "$app/navigation";
 
@@ -117,12 +119,12 @@
 				</h2>
 
 				<div id="history-table" class="w-full">
-					<ul class="w-full divide-y divide-base-300">
+					<ul class="divide-base-300 w-full divide-y">
 						{#each bookList as { isbn, title, quantity, warehouseName, committedAt, noteType, noteName, noteId }}
 							<li
-								class="entity-list-row grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 text-base-content sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
+								class="entity-list-row text-base-content grid w-full grid-cols-2 items-center gap-x-4 gap-y-3 py-6 sm:grid-cols-3 lg:grid-cols-12 lg:gap-y-2 lg:py-4 xl:grid-cols-12"
 							>
-								<p data-property="isbn" class="text-xl font-medium leading-none text-base-content lg:col-span-3 xl:col-span-2">{isbn}</p>
+								<p data-property="isbn" class="text-base-content text-xl font-medium leading-none lg:col-span-3 xl:col-span-2">{isbn}</p>
 								<p
 									data-property="title"
 									class="col-span-2 overflow-hidden whitespace-nowrap text-xl font-medium lg:col-span-5 xl:col-span-3"
@@ -145,7 +147,7 @@
 										href={appPath("history/notes/archive", noteId)}
 										class="{noteType === 'outbound'
 											? 'text-error'
-											: 'text-success'} mx-4 flex items-center rounded-sm border bg-base-200 px-3 py-0.5 hover:font-semibold"
+											: 'text-success'} bg-base-200 mx-4 flex items-center rounded-sm border px-3 py-0.5 hover:font-semibold"
 									>
 										{#if noteType === "inbound"}
 											<p><ArrowLeft size={16} /></p>
@@ -193,7 +195,7 @@
 		@apply pointer-events-none opacity-40;
 	}
 	[data-melt-calendar-cell][data-unavailable] {
-		@apply pointer-events-none text-error line-through;
+		@apply text-error pointer-events-none line-through;
 	}
 
 	[data-melt-calendar-cell][data-selected] {

--- a/apps/web-client/src/routes/history/isbn/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { writable } from "svelte/store";
-	import { Search } from "lucide-svelte";
+	import Search from "$lucide/search";
 
 	import { entityListView, testId, type BookData } from "@librocco/shared";
 
@@ -50,7 +50,7 @@
 		<div class="flex w-full p-4">
 			<label class="input-bordered input flex flex-1 items-center gap-2">
 				<Search />
-				<input data-testid={testId("search-input")} use:input placeholder="Search" class="w-full" />
+				<input data-testid={testId("search-input")} autocomplete use:input placeholder="Search" class="w-full" />
 			</label>
 		</div>
 		<!-- Start entity list contaier -->
@@ -70,14 +70,14 @@
 
 {#if $open && entries?.length}
 	<div use:dropdown>
-		<ul data-testid={testId("search-completions-container")} class="w-full divide-y overflow-y-auto rounded border bg-base-100 shadow-2xl">
+		<ul data-testid={testId("search-completions-container")} class="bg-base-100 w-full divide-y overflow-y-auto rounded border shadow-2xl">
 			{#each entries as { isbn, title, authors, year, publisher }}
 				<li
 					class="cursor-pointer items-start px-4 py-3"
 					on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
 					data-testid={testId("search-completion")}
 				>
-					<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
+					<p data-property="isbn" class="text-base-content mt-2 text-sm font-semibold leading-none">{isbn}</p>
 					<p data-property="title" class="text-xl font-medium">{title}</p>
 					<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
 				</li>

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
 	import { writable } from "svelte/store";
-	import { Search, Library, ArrowLeft, ArrowRight } from "lucide-svelte";
-	import { invalidate } from "$app/navigation";
+	import Search from "$lucide/search";
+	import Library from "$lucide/library";
+	import ArrowLeft from "$lucide/arrow-left";
+	import ArrowRight from "$lucide/arrow-right";
 
+	import { invalidate } from "$app/navigation";
 	import { page } from "$app/stores";
 
 	import { entityListView, testId, type BookData } from "@librocco/shared";
@@ -73,12 +76,12 @@
 		<div>
 			<Search />
 			{#key isbn}
-				<input data-testid={testId("search-input")} autofocus use:input placeholder="Search" class="w-full" />
+				<input data-testid={testId("search-input")} use:input placeholder="Search" class="w-full" />
 			{/key}
 		</div>
 
-		<div class="w-full text-base-content">
-			<h1 class="mb-1 mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</h1>
+		<div class="text-base-content w-full">
+			<h1 class="text-base-content mb-1 mt-2 text-sm font-semibold leading-none">{isbn}</h1>
 			{#if bookData}
 				<p class="mb-1 min-h-[32px] text-2xl">
 					{#if bookData.title}<span class="font-bold">{bookData.title}, </span>{/if}
@@ -95,8 +98,8 @@
 
 			<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
 			<div class={testId("entity-list-container")} data-view={entityListView("outbound-list")}>
-				<div class="border-b border-base-300">
-					<h2 class="border-b border-base-300 px-4 py-4 pt-8 text-xl font-semibold">{t.titles.stock()}</h2>
+				<div class="border-base-300 border-b">
+					<h2 class="border-base-300 border-b px-4 py-4 pt-8 text-xl font-semibold">{t.titles.stock()}</h2>
 
 					<div data-testid={testId("history-stock-report")} class="divide grid grid-cols-4 gap-x-24 gap-y-4 p-4">
 						{#each stock as s}
@@ -110,7 +113,7 @@
 									<span data-property="warehouse" class="entity-list-text-sm mr-4">{s.warehouseName}</span>
 								</p>
 
-								<p data-property="quantity" class="rounded border border-base-300 bg-base-200 px-2 py-0.5">{s.quantity}</p>
+								<p data-property="quantity" class="border-base-300 bg-base-200 rounded border px-2 py-0.5">{s.quantity}</p>
 							</div>
 						{/each}
 					</div>
@@ -124,14 +127,14 @@
 					</div>
 				{:else}
 					<div class="sticky top-0">
-						<h2 class="border-b border-base-300 bg-base-100 px-4 py-4 pt-8 text-xl font-semibold">
+						<h2 class="border-base-300 bg-base-100 border-b px-4 py-4 pt-8 text-xl font-semibold">
 							{$LL.history_page.isbn_tab.titles.transactions()}
 						</h2>
 					</div>
-					<ul id="history-table" class="grid w-full grid-cols-12 divide-y divide-base-300">
+					<ul id="history-table" class="divide-base-300 grid w-full grid-cols-12 divide-y">
 						{#each transactions as { quantity, noteId, noteName, noteType, committedAt, warehouseName }}
 							<li class="col-span-12 grid grid-cols-12">
-								<div class="entity-list-row col-span-8 grid grid-cols-8 items-center text-base-content">
+								<div class="entity-list-row text-base-content col-span-8 grid grid-cols-8 items-center">
 									<p data-property="committedAt" class="col-span-2">
 										{generateUpdatedAtString(committedAt)}
 									</p>
@@ -169,14 +172,14 @@
 
 {#if $open && entries?.length}
 	<div use:dropdown>
-		<ul data-testid={testId("search-completions-container")} class="w-full divide-y overflow-y-auto rounded border bg-base-100 shadow-2xl">
+		<ul data-testid={testId("search-completions-container")} class="bg-base-100 w-full divide-y overflow-y-auto rounded border shadow-2xl">
 			{#each entries as { isbn, title, authors, year, publisher }}
 				<li
 					data-testid={testId("search-completion")}
 					on:click={() => (goto(appPath("history/isbn", isbn)), ($open = false))}
 					class="w-full cursor-pointer px-4 py-3"
 				>
-					<p data-property="isbn" class="mt-2 text-sm font-semibold leading-none text-base-content">{isbn}</p>
+					<p data-property="isbn" class="text-base-content mt-2 text-sm font-semibold leading-none">{isbn}</p>
 					<p data-property="title" class="text-xl font-medium">{title}</p>
 					<p data-property="meta">{createMetaString({ authors, year, publisher })}</p>
 				</li>

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { Library } from "lucide-svelte";
+	import Library from "$lucide/library";
 	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
 	import { browser } from "$app/environment";
 	import { invalidate } from "$app/navigation";
@@ -85,17 +85,17 @@
 					{@const totalBooks = note.totalBooks}
 					{@const href = appPath("history/notes/archive", note.id)}
 
-					<div class="group entity-list-row">
+					<div class="entity-list-row group">
 						<div class="block w-full">
-							<a {href} class="entity-list-text-lg mb-2 block text-base-content hover:underline focus:underline">{displayName}</a>
+							<a {href} class="entity-list-text-lg text-base-content mb-2 block hover:underline focus:underline">{displayName}</a>
 
 							<div class="grid w-full grid-cols-4 items-start gap-2 lg:grid-cols-8">
 								<div class="order-1 col-span-2 flex gap-x-0.5 lg:col-span-1">
-									<Library class="mr-1 text-base-content" size={24} />
+									<Library class="text-base-content mr-1" size={24} />
 									<span class="entity-list-text-sm text-base-content">{totalBooks} {t.date.books()}</span>
 								</div>
 
-								<p class="order-2 col-span-2 text-base-content lg:order-3">
+								<p class="text-base-content order-2 col-span-2 lg:order-3">
 									{t.date.total_cover_price()}:
 									<span class="text-base-content">{note.totalCoverPrice.toFixed(2)}</span>
 								</p>
@@ -106,7 +106,7 @@
 									</span>
 								</p>
 
-								<p class="order-4 col-span-2 text-base-content">
+								<p class="text-base-content order-4 col-span-2">
 									{t.date.total_discounted_price()}:
 									<span class="text-base-content">{note.totalDiscountedPrice.toFixed(2)}</span>
 								</p>

--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import { writable } from "svelte/store";
 	import { invalidate } from "$app/navigation";
 
-	import { QrCode, Loader2 as Loader, Search } from "lucide-svelte";
+	import QrCode from "$lucide/qr-code";
 
 	import type { PageData } from "./$types";
 
@@ -93,8 +93,8 @@
 		<div class="flex w-full items-center justify-between">
 			<div class="flex max-w-md flex-col">
 				<div class="relative block w-full p-2">
-					<div class="flex flex-row items-center gap-x-2 text-base-content">
-						<h1 class="text-2xl font-bold leading-7 text-base-content">{displayName}</h1>
+					<div class="text-base-content flex flex-row items-center gap-x-2">
+						<h1 class="text-base-content text-2xl font-bold leading-7">{displayName}</h1>
 					</div>
 				</div>
 

--- a/apps/web-client/src/routes/history/warehouse/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { Library, Percent } from "lucide-svelte";
+	import Library from "$lucide/library";
+	import Percent from "$lucide/percent";
 	import { invalidate } from "$app/navigation";
 
 	import { entityListView, testId } from "@librocco/shared";
@@ -58,7 +59,7 @@
 					{@const href = appPath("history/warehouse", warehouse.id)}
 					{@const warehouseDiscount = warehouse.discount}
 
-					<div class="group entity-list-row">
+					<div class="entity-list-row group">
 						<div class="flex flex-col gap-y-2 self-start">
 							<a {href} class="entity-list-text-lg text-base-content hover:underline focus:underline">{displayName}</a>
 
@@ -77,7 +78,7 @@
 
 								{#if warehouseDiscount}
 									<div class="flex items-center gap-x-1">
-										<div class="border border-base-content p-[1px]">
+										<div class="border-base-content border p-[1px]">
 											<Percent class="text-base-content" size={14} />
 										</div>
 										<span class="entity-list-text-sm text-base-content">{warehouseDiscount}% {t.stats.discount()}</span>

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { ArrowLeft, ArrowRight } from "lucide-svelte";
+	import ArrowLeft from "$lucide/arrow-left";
+	import ArrowRight from "$lucide/arrow-right";
 	import { now, getLocalTimeZone, type DateValue } from "@internationalized/date";
 	import { download, generateCsv, mkConfig } from "export-to-csv";
 	import { browser } from "$app/environment";
@@ -125,7 +126,7 @@
 <HistoryPage view="history/date" {db} {plugins}>
 	<div slot="main" class="h-full w-full">
 		<div class="flex w-full flex-wrap justify-between gap-y-4 xl:flex-nowrap">
-			<h1 class="order-1 whitespace-nowrap text-2xl font-bold leading-7 text-base-content">
+			<h1 class="text-base-content order-1 whitespace-nowrap text-2xl font-bold leading-7">
 				{displayName || ""}
 				{t.heading.history()}
 			</h1>
@@ -149,7 +150,7 @@
 
 				<p>{t.heading.filter()}:</p>
 				<div id="inbound-outbound-filter" class="inline-block">
-					<div class="mt-1 flex items-center divide-x divide-base-300 overflow-hidden rounded-md border">
+					<div class="divide-base-300 mt-1 flex items-center divide-x overflow-hidden rounded-md border">
 						{#each options as { label, value }}
 							{@const active = value === filter}
 							<button
@@ -179,13 +180,13 @@
 				</div>
 			{:else}
 				<div class="sticky top-0">
-					<h2 class="border-b border-base-300 bg-base-100 px-4 py-4 pt-8 text-xl font-semibold">
+					<h2 class="border-base-300 bg-base-100 border-b px-4 py-4 pt-8 text-xl font-semibold">
 						{t.titles.transactions()}
 					</h2>
 				</div>
-				<ul id="history-table" class="grid w-full grid-cols-12 divide-y divide-base-300">
+				<ul id="history-table" class="divide-base-300 grid w-full grid-cols-12 divide-y">
 					{#each transactions as txn}
-						<li class="entity-list-row col-span-12 grid grid-cols-12 items-center gap-4 whitespace-nowrap text-base-content">
+						<li class="entity-list-row text-base-content col-span-12 grid grid-cols-12 items-center gap-4 whitespace-nowrap">
 							<p data-property="committedAt" class="col-span-12 overflow-hidden font-semibold lg:col-span-2 lg:font-normal">
 								{generateUpdatedAtString(txn.committedAt)}
 							</p>

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -4,7 +4,11 @@
 	import { invalidate } from "$app/navigation";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
-	import { ClockArrowUp, FilePlus, Layers, Library, Trash } from "lucide-svelte";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
+	import FilePlus from "$lucide/file-plus";
+	import Layers from "$lucide/layers";
+	import Library from "$lucide/library";
+	import Trash from "$lucide/trash";
 
 	import { entityListView, testId } from "@librocco/shared";
 
@@ -110,17 +114,17 @@
 					{@const totalBooks = note.totalBooks}
 					{@const href = appPath("inbound", note.id)}
 
-					<div class="group entity-list-row">
+					<div class="entity-list-row group">
 						<div class="flex flex-col gap-y-2">
 							<a {href} class="entity-list-text-lg text-base-content hover:underline focus:underline">{displayName}</a>
 
 							<div class="flex flex-row gap-x-8 gap-y-2 max-sm:flex-col">
 								<div class="flex gap-x-2">
 									<Layers size={18} />
-									<span class="entity-list-text-sm text-sm text-base-content"> {t.stats.books({ no_of_books: totalBooks })}</span>
+									<span class="entity-list-text-sm text-base-content text-sm"> {t.stats.books({ no_of_books: totalBooks })}</span>
 								</div>
 								{#if note.updatedAt}
-									<div class="flex items-center gap-x-2 text-sm text-base-content">
+									<div class="text-base-content flex items-center gap-x-2 text-sm">
 										<ClockArrowUp size={18} />
 										{t.stats.last_updated()}:
 										{updatedAt}

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
@@ -8,7 +8,13 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { Printer, QrCode, Trash2, FileEdit, MoreVertical, X, FileCheck } from "lucide-svelte";
+	import Printer from "$lucide/printer";
+	import QrCode from "$lucide/qr-code";
+	import Trash2 from "$lucide/trash-2";
+	import FileEdit from "$lucide/file-edit";
+	import MoreVertical from "$lucide/more-vertical";
+	import X from "$lucide/x";
+	import FileCheck from "$lucide/file-check";
 
 	import { testId } from "@librocco/shared";
 	import type { BookData } from "@librocco/shared";
@@ -255,7 +261,7 @@
 
 				<div class="ml-auto flex items-center gap-x-2">
 					<button
-						class="btn-primary btn-sm btn hidden xs:block"
+						class="btn-primary btn-sm btn xs:block hidden"
 						use:melt={$confirmDialogTrigger}
 						on:m-click={() => {
 							dialogContent = {
@@ -290,7 +296,7 @@
 									type: "commit"
 								};
 							}}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300 xs:hidden"
+							class="text-base-content data-[highlighted]:bg-base-300 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 						>
 							<FileCheck class="text-base-content/70" size={20} /><span class="text-base-content">{tInbound.labels.commit()}</span>
 						</div>
@@ -298,7 +304,7 @@
 							{...item}
 							use:item.action
 							on:m-click={handlePrintReceipt}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300"
+							class="text-base-content data-[highlighted]:bg-base-300 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 						>
 							<Printer class="text-base-content/70" size={20} /><span class="text-base-content">{tInbound.labels.print()}</span>
 						</div>
@@ -306,7 +312,7 @@
 							{...item}
 							use:item.action
 							on:m-click={autoPrintLabels.toggle}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300 {$autoPrintLabels
+							class="text-base-content data-[highlighted]:bg-base-300 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 {$autoPrintLabels
 								? '!bg-success text-success-content'
 								: ''}"
 						>
@@ -319,7 +325,7 @@
 							{...item}
 							use:item.action
 							use:melt={$confirmDialogTrigger}
-							class="flex w-full items-center gap-2 bg-error px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-error/80"
+							class="bg-error data-[highlighted]:bg-error/80 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 							on:m-click={() => {
 								dialogContent = {
 									onConfirm: handleDeleteSelf,
@@ -469,8 +475,8 @@
 		<div use:melt={$editDialogOverlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$editDialogContent}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-				bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+				overflow-y-auto shadow-lg focus:outline-none"
 			in:fly|global={{
 				x: 350,
 				duration: 300,
@@ -481,7 +487,7 @@
 				duration: 100
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$editDialogTitle} class="text-lg font-medium">{tCommon.edit_book_dialog.title()}</h2>
 					<p use:melt={$editDialogDescription} class="leading-normal">

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -5,7 +5,12 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { Edit, Table2, Trash2, HousePlus, Layers, SquarePercent } from "lucide-svelte";
+	import Edit from "$lucide/edit";
+	import Table2 from "$lucide/table-2";
+	import Trash2 from "$lucide/trash-2";
+	import HousePlus from "$lucide/house-plus";
+	import Layers from "$lucide/layers";
+	import SquarePercent from "$lucide/square-percent";
 
 	import { entityListView, testId } from "@librocco/shared";
 
@@ -130,14 +135,14 @@
 				{#each warehouses as { id, displayName, discount }}
 					{@const href = appPath("warehouses", id)}
 
-					<div class="group entity-list-row">
+					<div class="entity-list-row group">
 						<div class="flex flex-col gap-y-2 self-start">
 							<a data-sveltekit-preload-data="hover" {href} class="entity-list-text-lg text-base-content hover:underline focus:underline"
 								>{displayName}</a
 							>
 
-							<div class="flex flex-row gap-x-8 gap-y-2 max-xs:flex-col">
-								<div class="entity-list-text-sm flex items-center gap-x-2 text-sm text-base-content">
+							<div class="max-xs:flex-col flex flex-row gap-x-8 gap-y-2">
+								<div class="entity-list-text-sm text-base-content flex items-center gap-x-2 text-sm">
 									<Layers size={18} />
 
 									<div>
@@ -151,7 +156,7 @@
 								</div>
 
 								{#if discount}
-									<div class="flex items-center gap-x-2 text-sm text-base-content">
+									<div class="text-base-content flex items-center gap-x-2 text-sm">
 										<SquarePercent size={18} />
 
 										<span class="entity-list-text-sm">{discount}% discount</span>
@@ -176,19 +181,19 @@
 									on:m-keydown={() => {
 										warehouseToEdit = { name: displayName, discount, id };
 									}}
-									class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300"
+									class="text-base-content data-[highlighted]:bg-base-300 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 								>
 									<Edit aria-hidden size={18} />
 									<span>Edit</span>
 								</div>
 
-								<div {...separator} use:separator.action class="h-[1px] bg-base-300"></div>
+								<div {...separator} use:separator.action class="bg-base-300 h-[1px]"></div>
 
 								<a
 									{href}
 									{...item}
 									use:item.action
-									class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300"
+									class="text-base-content data-[highlighted]:bg-base-300 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 								>
 									<Table2 aria-hidden size={18} />
 									<span>View Stock</span>
@@ -204,7 +209,7 @@
 									on:m-keydown={() => {
 										warehouseToDelete = { id, displayName };
 									}}
-									class="flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-error"
+									class="data-[highlighted]:bg-error flex w-full items-center gap-2 bg-red-400 px-4 py-3 text-sm font-normal leading-5"
 								>
 									<Trash2 class="text-error-content" size={18} />
 									<span class="text-error-content">Delete</span>

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -8,7 +8,12 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { FileEdit, X, Loader2 as Loader, Printer, MoreVertical, FilePlus } from "lucide-svelte";
+	import FileEdit from "$lucide/file-edit";
+	import X from "$lucide/x";
+	import Loader from "$lucide/loader-2";
+	import Printer from "$lucide/printer";
+	import MoreVertical from "$lucide/more-vertical";
+	import FilePlus from "$lucide/file-plus";
 
 	import { testId } from "@librocco/shared";
 	import type { BookData } from "@librocco/shared";
@@ -268,15 +273,15 @@
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$content}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-			bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+			overflow-y-auto shadow-lg focus:outline-none"
 			transition:fly|global={{
 				x: 350,
 				duration: 300,
 				opacity: 1
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$title} class="text-lg font-medium">{$LL.stock_page.labels.edit_book_details()}</h2>
 					<p use:melt={$description} class="leading-normal">

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { Plus } from "lucide-svelte";
+	import Plus from "$lucide/plus";
 	import { createDialog } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
@@ -11,8 +11,6 @@
 	import CustomerOrderMetaForm from "$lib/forms/CustomerOrderMetaForm.svelte";
 	import { createCustomerOrderSchema } from "$lib/forms";
 	import { appPath, appHash } from "$lib/paths";
-
-	import { base } from "$app/paths";
 
 	import { getCustomerDisplayIdSeq, upsertCustomer } from "$lib/db/cr-sqlite/customers";
 	import { Page } from "$lib/controllers";
@@ -79,8 +77,8 @@
 <Page title="Customer Orders" view="orders/customers" {db} {plugins}>
 	<div slot="main" class="flex flex-col gap-y-6 overflow-x-auto py-2">
 		{#if !customerOrders.length}
-			<div class="flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-base-300 p-6">
-				<p class="text-center text-base-content/70">No customer orders yet. Create your first order to get started.</p>
+			<div class="border-base-300 flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed p-6">
+				<p class="text-base-content/70 text-center">No customer orders yet. Create your first order to get started.</p>
 				<button class="btn-primary btn gap-2" on:click={() => newOrderDialogOpen.set(true)}>
 					<Plus size={20} />
 					{t.labels.new_order()}

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
 	import { filter, scan } from "rxjs";
-	import {
-		BookUp,
-		X,
-		Trash2,
-		Mail,
-		FileEdit,
-		ReceiptEuro,
-		UserCircle,
-		MoreVertical,
-		ArrowRight,
-		ClockArrowUp,
-		PencilLine,
-		Phone
-	} from "lucide-svelte";
+	import BookUp from "$lucide/book-up";
+	import X from "$lucide/x";
+	import Trash2 from "$lucide/trash-2";
+	import Mail from "$lucide/mail";
+	import FileEdit from "$lucide/file-edit";
+	import ReceiptEuro from "$lucide/receipt-euro";
+	import UserCircle from "$lucide/user-circle";
+	import MoreVertical from "$lucide/more-vertical";
+	import ArrowRight from "$lucide/arrow-right";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
+	import PencilLine from "$lucide/pencil-line";
+	import Phone from "$lucide/phone";
+
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
@@ -233,7 +232,7 @@
 							<div class="flex w-full flex-col gap-y-4 py-6">
 								{#if data?.customer}
 									<div class="flex w-full flex-wrap justify-between gap-y-4 md:flex-col">
-										<div class="max-w-96 flex flex-col gap-y-4">
+										<div class="flex max-w-96 flex-col gap-y-4">
 											<div class="flex gap-x-3">
 												<dt>
 													<span class="sr-only">Customer name</span>

--- a/apps/web-client/src/routes/orders/suppliers/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/+page.svelte
@@ -18,7 +18,7 @@
 	import { writable } from "svelte/store";
 	import SupplierMetaForm from "$lib/forms/SupplierMetaForm.svelte";
 	import type { Supplier } from "$lib/db/cr-sqlite/types";
-	import { Plus } from "lucide-svelte";
+	import Plus from "$lucide/plus";
 	import { appHash, appPath } from "$lib/paths";
 	import LL from "@librocco/shared/i18n-svelte";
 

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
-	import { Mail, UserCircle, PencilLine, Plus } from "lucide-svelte";
+	import Mail from "$lucide/mail";
+	import UserCircle from "$lucide/user-circle";
+	import PencilLine from "$lucide/pencil-line";
+	import Plus from "$lucide/plus";
 	import { createDialog } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
@@ -95,7 +98,7 @@
 			<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 				<div class="card h-full">
 					<div class="card-body gap-y-2 p-0">
-						<div class="sticky top-0 flex flex-col gap-y-2 bg-base-100 pb-3">
+						<div class="bg-base-100 sticky top-0 flex flex-col gap-y-2 pb-3">
 							<div class="flex flex-row items-center justify-between gap-y-2 md:flex-col md:items-start">
 								<h2 class="prose">#{supplier?.id}</h2>
 							</div>
@@ -105,7 +108,7 @@
 							<dl class="flex flex-col">
 								<div class="flex w-full flex-col gap-y-4 py-6">
 									<div class="flex w-full flex-wrap justify-between gap-y-4 md:flex-col">
-										<div class="max-w-96 flex flex-col gap-y-4">
+										<div class="flex max-w-96 flex-col gap-y-4">
 											<div class="flex gap-x-3">
 												<dt>
 													<span class="sr-only">{t.details.supplier_name()}</span>
@@ -176,7 +179,7 @@
 								</thead>
 								<tbody>
 									{#each assignedPublishers as publisher}
-										<tr class="hover flex w-full justify-between focus-within:bg-base-200">
+										<tr class="hover focus-within:bg-base-200 flex w-full justify-between">
 											<td class="px-2">{publisher}</td>
 											<td class="px-2 text-end"
 												><button
@@ -267,7 +270,7 @@
 							</thead>
 							<tbody>
 								{#each assignedPublishers as publisher}
-									<tr class="hover flex w-full justify-between focus-within:bg-base-200">
+									<tr class="hover focus-within:bg-base-200 flex w-full justify-between">
 										<td class="px-2">{publisher}</td>
 										<td class="px-2 text-end"
 											><button on:click={handleUnassignPublisher(publisher)} class="btn-primary btn-xs btn flex-nowrap gap-x-2.5 rounded-lg"

--- a/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/new-order/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
-	import { Truck } from "lucide-svelte";
+	import Truck from "$lucide/truck";
 
 	import { invalidate } from "$app/navigation";
 
@@ -112,7 +112,7 @@
 			<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 				<div class="card">
 					<div class="card-body gap-y-2 p-0">
-						<div class="sticky top-0 flex gap-2 bg-base-100 pb-3 md:flex-col">
+						<div class="bg-base-100 sticky top-0 flex gap-2 pb-3 md:flex-col">
 							<h1 class="prose card-title">{supplier_name}</h1>
 
 							<div class="flex flex-row items-center justify-between gap-y-2 md:flex-col md:items-start">
@@ -211,7 +211,7 @@
 
 				{#if canPlaceOrder}
 					<div class="card fixed bottom-4 left-0 z-10 flex w-screen flex-row bg-transparent md:absolute md:bottom-24 md:mx-2 md:w-full">
-						<div class="mx-2 flex w-full flex-row justify-between bg-base-300 px-4 py-2 shadow-lg">
+						<div class="bg-base-300 mx-2 flex w-full flex-row justify-between px-4 py-2 shadow-lg">
 							<dl class="stats flex">
 								<div class="stat flex shrink flex-row place-items-center py-2 max-md:px-4">
 									<div class="stat-title">{t.stats.selected_books()}:</div>

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
 	import { invalidate } from "$app/navigation";
-	import { Settings, Plus } from "lucide-svelte";
+	import Settings from "$lucide/settings";
+	import Plus from "$lucide/plus";
 	import { createDialog } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
@@ -136,8 +137,8 @@
 			<div class="h-full w-full">
 				{#if orderStatusFilter === "unordered"}
 					{#if data?.possibleOrders.length === 0 && data?.placedOrders.length === 0}
-						<div class="flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-base-300 p-6">
-							<p class="text-center text-base-content/70">
+						<div class="border-base-300 flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed p-6">
+							<p class="text-base-content/70 text-center">
 								{t.placeholder.description()}
 							</p>
 							<button class="btn-primary btn gap-2" on:click={() => newOrderDialogOpen.set(true)}>

--- a/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
-	import { ArrowRight, ListTodo } from "lucide-svelte";
+	import ArrowRight from "$lucide/arrow-right";
+	import ListTodo from "$lucide/list-todo";
 
 	import type { PageData } from "./$types";
 
@@ -70,7 +71,7 @@
 			<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 				<div class="card">
 					<div class="card-body gap-y-2 p-0">
-						<div class="sticky top-0 flex gap-2 bg-base-100 pb-3 md:flex-col">
+						<div class="bg-base-100 sticky top-0 flex gap-2 pb-3 md:flex-col">
 							<h1 class="prose card-title">{supplier_order_id}</h1>
 
 							{#if reconciled}

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	import { ArrowRight, ClockArrowUp, Check, MinusCircle, PlusCircle, Trash } from "lucide-svelte";
+	import ArrowRight from "$lucide/arrow-right";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
+	import Check from "$lucide/check";
+	import MinusCircle from "$lucide/minus-circle";
+	import PlusCircle from "$lucide/plus-circle";
+	import Trash from "$lucide/trash";
 	import { filter, scan } from "rxjs";
 	import { onDestroy, onMount } from "svelte";
 
@@ -146,7 +151,7 @@
 		<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 			<div class="card">
 				<div class="card-body gap-y-2 p-0">
-					<div class="sticky top-0 flex flex-col gap-y-2 bg-base-100 pb-3">
+					<div class="bg-base-100 sticky top-0 flex flex-col gap-y-2 pb-3">
 						<div class="flex flex-row items-center justify-between gap-y-2 md:flex-col md:items-start">
 							<h2 class="prose">#{data?.reconciliationOrder.id}</h2>
 
@@ -221,7 +226,7 @@
 									on:click={async () => (!data?.reconciliationOrder.finalized ? (currentStep = step) : null)}
 								>
 									{#if isCompleted}
-										<span class="flex shrink-0 items-center justify-center rounded-full bg-primary p-1">
+										<span class="bg-primary flex shrink-0 items-center justify-center rounded-full p-1">
 											<Check aria-hidden="true" class="text-white" size={22} />
 										</span>
 									{:else}
@@ -251,8 +256,8 @@
 			<div class="relative h-full overflow-x-auto">
 				{#if currentStep === 1}
 					{#if books.length === 0}
-						<div class="flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-base-300 p-6">
-							<p class="text-center text-base-content/70">{t.placeholder.description()}</p>
+						<div class="border-base-300 flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed p-6">
+							<p class="text-base-content/70 text-center">{t.placeholder.description()}</p>
 						</div>
 					{:else}
 						<div class="relative h-full overflow-x-auto">
@@ -314,7 +319,7 @@
 				{/if}
 
 				<div class="card fixed bottom-4 left-0 z-10 flex w-screen flex-row bg-transparent md:absolute md:bottom-24 md:mx-2 md:w-full">
-					<div class="mx-2 flex w-full flex-row justify-between bg-base-300 px-4 py-2 shadow-lg">
+					<div class="bg-base-300 mx-2 flex w-full flex-row justify-between px-4 py-2 shadow-lg">
 						{#if currentStep > 1}
 							<dl class="stats flex">
 								<div class="stat flex shrink flex-row place-items-center py-2 max-md:px-4">

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -4,7 +4,12 @@
 	import { invalidate } from "$app/navigation";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
-	import { Plus, Trash, Library, FilePlus, Layers, ClockArrowUp } from "lucide-svelte";
+	import Plus from "$lucide/plus";
+	import Trash from "$lucide/trash";
+	import Library from "$lucide/library";
+	import FilePlus from "$lucide/file-plus";
+	import Layers from "$lucide/layers";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
 
 	import { racefreeGoto } from "$lib/utils/navigation";
 
@@ -114,19 +119,19 @@
 						{@const totalBooks = note.totalBooks}
 						{@const href = appPath("outbound", note.id)}
 
-						<div class="group entity-list-row">
+						<div class="entity-list-row group">
 							<div class="flex flex-col gap-y-2">
 								<a {href} class="entity-list-text-lg text-base-content hover:underline focus:underline">{displayName}</a>
 
 								<div class="flex flex-row gap-x-8 gap-y-2 max-sm:flex-col">
 									<div class="flex gap-x-2">
 										<Layers size={18} />
-										<span class="entity-list-text-sm text-sm text-base-content">{tOutboundPage.stats.books({ bookCount: totalBooks })}</span
+										<span class="entity-list-text-sm text-base-content text-sm">{tOutboundPage.stats.books({ bookCount: totalBooks })}</span
 										>
 									</div>
 
 									{#if note.updatedAt}
-										<div class="flex items-center gap-x-2 text-sm text-base-content">
+										<div class="text-base-content flex items-center gap-x-2 text-sm">
 											<ClockArrowUp size={18} />
 											{tOutboundPage.stats.last_updated()}:
 											{updatedAt}

--- a/apps/web-client/src/routes/outbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[id]/+page.svelte
@@ -8,7 +8,13 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { Printer, QrCode, Trash2, FileEdit, MoreVertical, X, Loader2 as Loader, FileCheck, Plus } from "lucide-svelte";
+	import Printer from "$lucide/printer";
+	import QrCode from "$lucide/qr-code";
+	import Trash2 from "$lucide/trash-2";
+	import FileEdit from "$lucide/file-edit";
+	import MoreVertical from "$lucide/more-vertical";
+	import X from "$lucide/x";
+	import FileCheck from "$lucide/file-check";
 
 	import { desc, testId } from "@librocco/shared";
 	import { type BookData } from "@librocco/shared";
@@ -436,7 +442,7 @@
 						</select>
 					</div>
 					<button
-						class="btn-primary btn-sm btn hidden xs:block"
+						class="btn-primary btn-sm btn xs:block hidden"
 						use:melt={$confirmDialogTrigger}
 						on:m-click={() => {
 							dialogContent = {
@@ -471,7 +477,7 @@
 									type: "commit"
 								};
 							}}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300 xs:hidden"
+							class="text-base-content data-[highlighted]:bg-base-300 xs:hidden flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 						>
 							<FileCheck class="text-base-content/70" size={20} /><span class="text-base-content">Commit</span>
 						</div>
@@ -479,7 +485,7 @@
 							{...item}
 							use:item.action
 							on:m-click={handlePrintReceipt}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300"
+							class="text-base-content data-[highlighted]:bg-base-300 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 						>
 							<Printer class="text-base-content/70" size={20} /><span class="text-base-content">Print</span>
 						</div>
@@ -487,7 +493,7 @@
 							{...item}
 							use:item.action
 							use:melt={$confirmDialogTrigger}
-							class="flex w-full items-center gap-2 bg-error px-4 py-3 text-sm font-normal leading-5 data-[highlighted]:bg-error/80"
+							class="bg-error data-[highlighted]:bg-error/80 flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5"
 							on:m-click={() => {
 								dialogContent = {
 									onConfirm: handleDeleteSelf,
@@ -705,8 +711,8 @@
 		<div use:melt={$editBookDialogOverlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$editBookDialogContent}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-			bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+			overflow-y-auto shadow-lg focus:outline-none"
 			in:fly|global={{
 				x: 350,
 				duration: 300,
@@ -717,7 +723,7 @@
 				duration: 100
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$editBookDialogTitle} class="text-lg font-medium">{tCommon.edit_book_dialog.title()}</h2>
 					<p use:melt={$editBookDialogDescription} class="leading-normal">
@@ -766,8 +772,8 @@
 		<div use:melt={$customItemDialogOverlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$customItemDialogContent}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-			bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+			overflow-y-auto shadow-lg focus:outline-none"
 			in:fly|global={{
 				x: 350,
 				duration: 300,
@@ -778,7 +784,7 @@
 				duration: 100
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$customItemDialogTitle} class="text-lg font-medium">
 						{customItemFormData ? tCommon.edit_custom_item_dialog.title() : tCommon.create_custom_item_dialog.title()}

--- a/apps/web-client/src/routes/settings/+page.svelte
+++ b/apps/web-client/src/routes/settings/+page.svelte
@@ -2,7 +2,8 @@
 	import { onMount } from "svelte";
 	import { fade } from "svelte/transition";
 	import { get } from "svelte/store";
-	import { Download, Trash } from "lucide-svelte";
+	import Download from "$lucide/download";
+	import Trash from "$lucide/trash";
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { zod } from "sveltekit-superforms/adapters";
 
@@ -266,7 +267,7 @@
 							{/each}
 						{:else}
 							<div
-								class="flex h-full items-center justify-center border-2 border-dashed border-base-100"
+								class="border-base-100 flex h-full items-center justify-center border-2 border-dashed"
 								on:drop={handleDrop}
 								role="region"
 								aria-label="Drop zone"

--- a/apps/web-client/src/routes/stock/+page.svelte
+++ b/apps/web-client/src/routes/stock/+page.svelte
@@ -7,7 +7,11 @@
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { Search, FileEdit, X, Printer, MoreVertical } from "lucide-svelte";
+	import Search from "$lucide/search";
+	import FileEdit from "$lucide/file-edit";
+	import X from "$lucide/x";
+	import Printer from "$lucide/printer";
+	import MoreVertical from "$lucide/more-vertical";
 
 	import type { BookData } from "@librocco/shared";
 	import { testId } from "@librocco/shared";
@@ -236,15 +240,15 @@
 		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 		<div
 			use:melt={$content}
-			class="divide-y-secondary fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y overflow-y-auto
-				bg-base-200 shadow-lg focus:outline-none"
+			class="divide-y-secondary bg-base-200 fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col gap-y-4 divide-y
+				overflow-y-auto shadow-lg focus:outline-none"
 			transition:fly|global={{
 				x: 350,
 				duration: 300,
 				opacity: 1
 			}}
 		>
-			<div class="flex w-full flex-row justify-between bg-base-200 p-6">
+			<div class="bg-base-200 flex w-full flex-row justify-between p-6">
 				<div>
 					<h2 use:melt={$title} class="text-lg font-medium">{$LL.stock_page.labels.edit_book_details()}</h2>
 					<p use:melt={$description} class="leading-normal">

--- a/apps/web-client/svelte.config.js
+++ b/apps/web-client/svelte.config.js
@@ -13,7 +13,8 @@ const config = {
 	preprocess: sequence([preprocess(), preprocessMeltUI()]),
 	kit: {
 		alias: {
-			"$i18n/*": "./src/i18n/*"
+			"$i18n/*": "./src/i18n/*",
+			$lucide: "node_modules/lucide-svelte/dist/icons"
 		},
 		serviceWorker: {
 			register: false


### PR DESCRIPTION
I noticed [this issue](https://github.com/lucide-icons/lucide/issues/1475) with lucide imports awhile ago. This adds an import alias for lucide and updates imports in all components/controllers/pages. We should now use this pattern to import icons `import IconName from $lucide/icon-name`. This speeds up our production build. It's a small update but easy to do with an LLM