### PR TITLE
Make librocco work even with a missing trailing slash

### DIFF
--- a/apps/web-client/src/app.html
+++ b/apps/web-client/src/app.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html lang="en" data-theme="lofi">
 	<head>
+		<script>
+			if (!window.location.href.endsWith("/")) {
+				// Make sure we have a trailing slash.
+				// sveltekit's trailingSlash is not available with hash routing
+				window.location.replace(window.location.href + "/");
+			}
+		</script>
 		<meta charset="utf-8" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />


### PR DESCRIPTION
This PR adds a couple of lines of code to the HTML used to generate the final page.

The code will be executed before any other javascript code. It checks if the current URL ends with a `/`. If it doesn't, it reloads the page with the URL obtained adding `/` to the current URL.

TL;DR; It works, check it out here: https://test.libroc.co/fix/trailing-slash - it's not much code - it should be safe.