### PR TITLE
Fix/customer touchups

### DIFF
--- a/apps/web-client/src/lib/forms/CustomerSearchForm.svelte
+++ b/apps/web-client/src/lib/forms/CustomerSearchForm.svelte
@@ -15,9 +15,7 @@
 
 	export let input: HTMLElement | undefined = undefined;
 
-	const form = superForm(data, {
-		...options
-	});
+	const form = superForm(data, options);
 
 	const { form: formStore, enhance } = form;
 </script>
@@ -27,6 +25,7 @@
 		<svelte:component this={icon} />
 		<input
 			name="fullname"
+			class="w-full"
 			id="fullname"
 			autocomplete="off"
 			data-testid={testId("customer-search-form")}

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -134,7 +134,7 @@
 				</div>
 			{:else}
 				<div use:scroll.container={{ rootMargin: "50px" }} class="h-full overflow-y-auto" style="scrollbar-width: thin">
-					<table class="table-sm table-zebra table">
+					<table class="table-zebra table-sm table">
 						<thead>
 							<tr>
 								<th scope="col">{t.table_columns.order_id()}</th>
@@ -157,7 +157,7 @@
 										{email === "N/A" ? "-" : email}
 									</td>
 									<td>
-										<span class="badge badge-primary badge-outline gap-x-2">
+										<span class="badge-primary badge-outline badge gap-x-2">
 											<ClockArrowUp size={16} />
 											<time dateTime={new Date(updatedAt).toISOString()}>{new Date(updatedAt).toLocaleString()}</time>
 										</span>

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -107,11 +107,15 @@
 				options={{
 					SPA: true,
 					dataType: "json",
+					invalidateAll: false,
+					resetForm: false,
 					validators: zod(customerSearchSchema),
-					validationMethod: "submit-only",
-					onUpdate: async ({ form }) => {
-						const { fullname } = form?.data as CustomerOrderListItem;
-						search.set(fullname);
+					validationMethod: "oninput",
+					onChange: async (event) => {
+						const [fullNamePath] = event.paths;
+						const fullName = event.get(fullNamePath);
+
+						search.set(fullName); // reactively update the store on input change
 					}
 				}}
 			/>

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -146,7 +146,7 @@
 						</thead>
 						<tbody>
 							{#each $tableStore as { id, fullname, email, updatedAt, displayId }}
-								<tr class="hover focus-within:bg-base-200">
+								<tr class="hover focus-within:bg-base-200 hover:cursor-pointer" on:click={() => goto(appPath("customers", id))}>
 									<th>
 										<span class="font-medium">#{displayId}</span>
 									</th>
@@ -163,7 +163,7 @@
 										</span>
 									</td>
 									<td>
-										<a href={appPath("customers", id)} class="btn-outline btn-sm btn">{t.labels.update()}</a>
+										<a href={appPath("customers", id)} class="btn-outline btn-sm btn">{t.labels.edit()}</a>
 									</td>
 								</tr>
 							{/each}

--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -1,29 +1,33 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import Plus from "$lucide/plus";
+	import { writable } from "svelte/store";
+
 	import { createDialog } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
 
+	import Plus from "$lucide/plus";
+	import User from "$lucide/user";
+	import ClockArrowUp from "$lucide/clock-arrow-up";
+
 	import LL from "@librocco/shared/i18n-svelte";
+
+	import { PageCenterDialog, defaultDialogConfig } from "$lib/components/Melt";
+	import CustomerOrderMetaForm from "$lib/forms/CustomerOrderMetaForm.svelte";
+	import CustomerSearchForm from "$lib/forms/CustomerSearchForm.svelte";
+	import PlaceholderBox from "$lib/components/Placeholders/PlaceholderBox.svelte";
+	import { createCustomerOrderSchema, customerSearchSchema } from "$lib/forms";
 
 	import { invalidate } from "$app/navigation";
 	import { racefreeGoto } from "$lib/utils/navigation";
-	import { PageCenterDialog, defaultDialogConfig } from "$lib/components/Melt";
-	import CustomerOrderMetaForm from "$lib/forms/CustomerOrderMetaForm.svelte";
-	import { createCustomerOrderSchema, customerSearchSchema } from "$lib/forms";
 	import { appPath, appHash } from "$lib/paths";
+	import { Page } from "$lib/controllers";
+	import { createIntersectionObserver } from "$lib/actions";
 
 	import { getCustomerDisplayIdSeq, upsertCustomer } from "$lib/db/cr-sqlite/customers";
-
-	import { Page } from "$lib/controllers";
 	import type { Customer, CustomerOrderListItem } from "$lib/db/cr-sqlite/types";
 
 	import type { PageData } from "./$types";
-
-	import CustomerSearchForm from "$lib/forms/CustomerSearchForm.svelte";
-	import { writable } from "svelte/store";
-	import { createIntersectionObserver } from "$lib/actions";
 
 	export let data: PageData;
 
@@ -75,8 +79,6 @@
 		orderFilterStatus = status;
 	}
 
-	$: hasCompletedOrders = customerOrders.some(({ completed }) => completed);
-
 	const createCustomer = async (customer: Omit<Customer, "id" | "displayId">) => {
 		/**@TODO replace randomId with incremented id */
 		// get latest/biggest id and increment by 1
@@ -96,8 +98,8 @@
 </script>
 
 <Page title="Customer Orders" view="orders/customers" {db} {plugins}>
-	<div slot="main" class="flex flex-col gap-y-6 overflow-x-auto py-2">
-		<div class="p-4">
+	<div slot="main" class="flex h-full flex-col gap-y-2 divide-y">
+		<div class="flex flex-row gap-x-2 p-4">
 			<CustomerSearchForm
 				bind:input={searchField}
 				placeholder={t.placeholder.search()}
@@ -113,57 +115,68 @@
 					}
 				}}
 			/>
-		</div>
-		{#if !customerOrders.length}
-			<div class="flex h-96 flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-base-300 p-6">
-				<p class="text-center text-base-content/70">{t.placeholder.no_orders()}</p>
-				<button class="btn-primary btn gap-2" on:click={() => newOrderDialogOpen.set(true)}>
-					<Plus size={20} />
-					{t.labels.new_order()}
-				</button>
-			</div>
-		{:else}
 			<button class="btn-primary btn gap-2" on:click={() => newOrderDialogOpen.set(true)}>
 				<Plus size={20} />
 				{t.labels.new_order()}
 			</button>
-			<div use:scroll.container={{ rootMargin: "50px" }} class="h-full overflow-y-auto" style="scrollbar-width: thin">
-				<table class="table-lg table">
-					<thead>
-						<tr>
-							<th scope="col">{t.table.customer()}</th>
-							<th scope="col">{t.table.order_id()}</th>
-							<th scope="col"> <span class="sr-only"> {t.labels.update_order()} </span></th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each $tableStore as { id, fullname, email, displayId }}
-							<tr class="hover focus-within:bg-base-200">
-								<td>
-									<dl class="flex flex-col gap-y-1">
-										<dt class="sr-only">{t.table.customer_details()}</dt>
-										<dd>{fullname}</dd>
-										<dd class="text-sm">{email ?? ""}</dd>
-									</dl>
-								</td>
-								<td>
-									<span class="font-medium">{displayId}</span>
-								</td>
-								<td class="text-right">
-									<a href={appPath("customers", id)} class="btn-outline btn-sm btn">{t.labels.update()}</a>
-								</td>
+		</div>
+		<div class="h-full p-4">
+			{#if !customerOrders.length}
+				<div class="mx-auto max-w-xl translate-y-1/2">
+					<PlaceholderBox title={t.placeholder.no_orders.title()} description={t.placeholder.no_orders.description()}>
+						<User slot="icon" />
+
+						<button slot="actions" class="btn-primary btn gap-2" on:click={() => newOrderDialogOpen.set(true)}>
+							<Plus size={20} />
+							{t.labels.new_order()}
+						</button>
+					</PlaceholderBox>
+				</div>
+			{:else}
+				<div use:scroll.container={{ rootMargin: "50px" }} class="h-full overflow-y-auto" style="scrollbar-width: thin">
+					<table class="table-sm table-zebra table">
+						<thead>
+							<tr>
+								<th scope="col">{t.table_columns.order_id()}</th>
+								<th scope="col">{t.table_columns.name()}</th>
+								<th scope="col">{t.table_columns.email()}</th>
+								<th scope="col">{t.table_columns.updated()}</th>
+								<th scope="col" class="sr-only">{t.table_columns.actions()}</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-				<!-- Trigger for the infinite scroll intersection observer -->
-				{#if $tableStore?.length === maxResults && filteredOrders.length > maxResults}
-					<div use:scroll.trigger></div>
-				{/if}
-			</div>
-		{/if}
+						</thead>
+						<tbody>
+							{#each $tableStore as { id, fullname, email, updatedAt, displayId }}
+								<tr class="hover focus-within:bg-base-200">
+									<th>
+										<span class="font-medium">#{displayId}</span>
+									</th>
+									<td>
+										{fullname}
+									</td>
+									<td>
+										{email === "N/A" ? "-" : email}
+									</td>
+									<td>
+										<span class="badge badge-primary badge-outline gap-x-2">
+											<ClockArrowUp size={16} />
+											<time dateTime={new Date(updatedAt).toISOString()}>{new Date(updatedAt).toLocaleString()}</time>
+										</span>
+									</td>
+									<td>
+										<a href={appPath("customers", id)} class="btn-outline btn-sm btn">{t.labels.update()}</a>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+					<!-- Trigger for the infinite scroll intersection observer -->
+					{#if $tableStore?.length === maxResults && filteredOrders.length > maxResults}
+						<div use:scroll.trigger></div>
+					{/if}
+				</div>
+			{/if}
+		</div>
 	</div>
-	<!-- </div> -->
 </Page>
 
 <PageCenterDialog dialog={newOrderDialog} title="" description="">
@@ -185,10 +198,3 @@
 		onCancel={() => newOrderDialogOpen.set(false)}
 	/>
 </PageCenterDialog>
-
-<style>
-	.table-lg td {
-		padding-top: 1rem;
-		padding-bottom: 1rem;
-	}
-</style>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -99,9 +99,6 @@
 	} = nonUniqueIdDialog;
 	let submittingCustomer: Customer | null = null;
 
-	const nonUniqueIdDialogHeading = "Non unique customer ID";
-	const nonUniqueIdDialogDescription = "There's at least one more order with the same ID. Please confirm you're ok with this?";
-
 	const handleOpenNonUniqueIdDialog = (data: Customer) => {
 		submittingCustomer = data;
 		nonUniqueIdDialogOpen.set(true);
@@ -189,7 +186,7 @@
 	let dialogContent: DialogContent & { type: "delete" | "edit-row" };
 </script>
 
-<Page title="Customer Orders" view="orders/customers/id" {db} {plugins}>
+<Page title={$LL.customer_orders_page.title()} view="orders/customers/id" {db} {plugins}>
 	<div slot="main" class="flex h-full flex-col gap-y-4 max-md:overflow-y-auto md:flex-row md:divide-x">
 		<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 			<div class="card md:h-full">
@@ -200,7 +197,7 @@
 								<h2 class="text-2xl font-medium">{customer.fullname}</h2>
 
 								<span class="badge-accent badge-outline badge badge-md gap-x-2">
-									<span class="sr-only">Last updated</span>
+									<span class="sr-only">{$LL.customer_orders_page.customer_details.last_updated()}</span>
 									<ClockArrowUp size={16} aria-hidden />
 									<time dateTime={data?.customer?.updatedAt ? new Date(data?.customer?.updatedAt).toISOString() : ""}>
 										{new Date(data?.customer?.updatedAt || "").toLocaleString()}
@@ -215,7 +212,7 @@
 										<div class="flex max-w-96 flex-col gap-y-4">
 											<div class="flex gap-x-3">
 												<dt>
-													<span class="sr-only">Customer ID</span>
+													<span class="sr-only">{$LL.customer_orders_page.customer_details.customer_id()}</span>
 													<IdCard aria-hidden="true" class="h-6 w-5 text-gray-400" />
 												</dt>
 												<dd class="truncate">{customer?.displayId || ""}</dd>
@@ -223,14 +220,14 @@
 
 											<div class="flex gap-x-3">
 												<dt>
-													<span class="sr-only">Customer email</span>
+													<span class="sr-only">{$LL.customer_orders_page.customer_details.customer_email()}</span>
 													<Mail aria-hidden="true" class="h-6 w-5 text-gray-400" />
 												</dt>
 												<dd class="truncate">{data?.customer?.email || ""}</dd>
 											</div>
 											<div class="flex gap-x-3">
 												<dt>
-													<span class="sr-only">Customer phone</span>
+													<span class="sr-only">{$LL.customer_orders_page.customer_details.customer_phone()}</span>
 													<Phone aria-hidden="true" class="h-6 w-5 text-gray-400" />
 												</dt>
 												<dd class="truncate">
@@ -241,7 +238,7 @@
 											</div>
 											<div class="flex gap-x-3">
 												<dt>
-													<span class="sr-only">Secondary phone</span>
+													<span class="sr-only">{$LL.customer_orders_page.customer_details.secondary_phone()}</span>
 													<Phone aria-hidden="true" class="h-6 w-5 text-gray-400" />
 												</dt>
 												<dd class="truncate">{data?.customer?.phone?.split(",")[1] || ""}</dd>
@@ -249,10 +246,10 @@
 										</div>
 										<div class="flex gap-x-3">
 											<dt>
-												<span class="sr-only">Deposit</span>
+												<span class="sr-only">{$LL.customer_orders_page.customer_details.deposit()}</span>
 												<ReceiptEuro aria-hidden="true" class="h-6 w-5 text-gray-400" />
 											</dt>
-											<dd>€{data?.customer?.deposit || 0} deposit</dd>
+											<dd>{$LL.customer_orders_page.customer_details.deposit_amount({ amount: data?.customer?.deposit || 0 })}</dd>
 										</div>
 									</div>
 								{/if}
@@ -262,15 +259,15 @@
 							<button
 								class="btn-secondary btn-outline btn-sm btn w-full"
 								type="button"
-								aria-label="Edit customer order name, email or deposit"
+								aria-label={$LL.forms.customer_order_meta.aria.form()}
 								on:click={() => customerMetaDialogOpen.set(true)}
 								disabled={!data?.customer}
 							>
-								Edit customer
+								{$LL.customer_orders_page.labels.edit_customer()}
 								<PencilLine aria-hidden size={16} />
 							</button>
 							<button class="btn-secondary btn-outline btn-sm btn w-full" type="button" disabled>
-								Print receipt
+								{$LL.customer_orders_page.labels.print_receipt()}
 								<Printer aria-hidden size={20} />
 							</button>
 						</div>
@@ -282,10 +279,10 @@
 		<div class="flex h-full w-full flex-col gap-y-6 px-4 md:overflow-y-auto">
 			<div class="top-o sticky flex w-full max-w-full flex-col gap-y-3">
 				<div class="flex items-center justify-between pb-2 pt-4">
-					<h3 class="text-xl font-medium">Books</h3>
+					<h3 class="text-xl font-medium">{$LL.customer_orders_page.customer_details.books_heading()}</h3>
 
 					<div class="badge badge-primary badge-lg gap-x-2">
-						<span>Total:</span>
+						<span>{$LL.customer_orders_page.customer_details.total()}</span>
 						<span class="font-bold">€{totalAmount}</span>
 					</div>
 				</div>
@@ -312,13 +309,13 @@
 					<table class="table">
 						<thead>
 							<tr>
-								<th>ISBN</th>
-								<th>Title</th>
-								<th>Authors</th>
-								<th>Price</th>
-								<th>Publisher</th>
-								<th>Status</th>
-								<th>Actions</th>
+								<th>{$LL.customer_orders_page.table_columns.isbn()}</th>
+								<th>{$LL.customer_orders_page.table_columns.title()}</th>
+								<th>{$LL.customer_orders_page.table_columns.authors()}</th>
+								<th>{$LL.customer_orders_page.table_columns.price()}</th>
+								<th>{$LL.customer_orders_page.table_columns.publisher()}</th>
+								<th>{$LL.customer_orders_page.table_columns.status()}</th>
+								<th>{$LL.table_components.inventory_tables.outbound_table.row_actions()}</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -332,19 +329,19 @@
 									<td>
 										{#if status === OrderLineStatus.Collected}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Collected - <time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
+												{$LL.customer_orders_page.status.collected()} - <time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Received}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Delivered - <time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
+												{$LL.customer_orders_page.status.delivered()} - <time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Placed}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Placed - <time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
+												{$LL.customer_orders_page.status.placed()} - <time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
 											</div>
 										{:else}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Pending - <time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
+												{$LL.customer_orders_page.status.pending()} - <time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
 											</div>
 										{/if}
 									</td>
@@ -365,7 +362,7 @@
 												use:trigger.action
 												class="rounded p-3 text-gray-500 hover:bg-gray-50 hover:text-gray-900"
 											>
-												<span class="sr-only">Edit line</span>
+												<span class="sr-only">{$LL.customer_orders_page.labels.edit_line()}</span>
 												<span class="aria-hidden">
 													<MoreVertical />
 												</span>
@@ -395,7 +392,7 @@
 														};
 													}}
 												>
-													<span class="sr-only">Edit row</span>
+													<span class="sr-only">{$LL.customer_orders_page.labels.edit_row()}</span>
 													<span class="aria-hidden">
 														<FileEdit />
 													</span>
@@ -407,7 +404,7 @@
 														data-testid={testId("collect-row")}
 														on:click={() => handleCollect(id)}
 													>
-														<span class="sr-only">Collect</span>
+														<span class="sr-only">{$LL.customer_orders_page.labels.collect()}</span>
 														<span class="aria-hidden">
 															<BookUp />
 														</span>
@@ -420,7 +417,7 @@
 														data-testid={testId("delete-row")}
 														on:click={() => handleDeleteLine(id)}
 													>
-														<span class="sr-only">Delete row</span>
+														<span class="sr-only">{$LL.customer_orders_page.labels.delete_row()}</span>
 														<span class="aria-hidden">
 															<Trash2 />
 														</span>
@@ -512,8 +509,8 @@
 
 <PageCenterDialog dialog={customerMetaDialog} title="" description="">
 	<CustomerOrderMetaForm
-		heading="Update customer details"
-		saveLabel="Update"
+		heading={$LL.customer_orders_page.dialogs.edit_customer.title()}
+		saveLabel={$LL.customer_orders_page.dialogs.edit_customer.save_label()}
 		kind="update"
 		data={defaults(stripNulls({ ...customer, phone1, phone2 }), zod(createCustomerOrderSchema("update")))}
 		options={{
@@ -539,8 +536,8 @@
 	<ConfirmDialog
 		on:confirm={handleConfirmNonUniqueIdDialog}
 		on:cancel={() => nonUniqueIdDialogOpen.set(false)}
-		heading={nonUniqueIdDialogHeading}
-		description={nonUniqueIdDialogDescription}
-		labels={{ confirm: "Confirm", cancel: "Cancel" }}
+		heading={$LL.customer_orders_page.dialogs.non_unique_id.title()}
+		description={$LL.customer_orders_page.dialogs.non_unique_id.description()}
+		labels={{ confirm: $LL.common.actions.confirm(), cancel: $LL.common.actions.cancel() }}
 	/>
 </PageCenterDialog>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -332,19 +332,19 @@
 									<td>
 										{#if status === OrderLineStatus.Collected}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Collected <time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
+												Collected - <time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Received}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Delivered <time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
+												Delivered - <time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Placed}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Placed <time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
+												Placed - <time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
 											</div>
 										{:else}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												Pending <time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
+												Pending - <time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
 											</div>
 										{/if}
 									</td>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -329,19 +329,23 @@
 									<td>
 										{#if status === OrderLineStatus.Collected}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												{$LL.customer_orders_page.status.collected()} - <time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
+												{$LL.customer_orders_page.status.collected()} -
+												<time datetime={collected.toISOString()} class="badge-xs badge">{collected.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Received}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												{$LL.customer_orders_page.status.delivered()} - <time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
+												{$LL.customer_orders_page.status.delivered()} -
+												<time datetime={received.toISOString()} class="badge-xs badge">{received.toDateString()}</time>
 											</div>
 										{:else if status === OrderLineStatus.Placed}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												{$LL.customer_orders_page.status.placed()} - <time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
+												{$LL.customer_orders_page.status.placed()} -
+												<time datetime={placed.toISOString()} class="badge-xs badge">{placed.toDateString()}</time>
 											</div>
 										{:else}
 											<div class="badge-primary badge-outline badge text-xs font-semibold">
-												{$LL.customer_orders_page.status.pending()} - <time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
+												{$LL.customer_orders_page.status.pending()} -
+												<time datetime={created.toISOString()} class="badge-xs badge">{created.toDateString()}</time>
 											</div>
 										{/if}
 									</td>
@@ -510,7 +514,7 @@
 <PageCenterDialog dialog={customerMetaDialog} title="" description="">
 	<CustomerOrderMetaForm
 		heading={$LL.customer_orders_page.dialogs.edit_customer.title()}
-		saveLabel={$LL.customer_orders_page.dialogs.edit_customer.save_label()}
+		saveLabel={$LL.customer_orders_page.labels.save()}
 		kind="update"
 		data={defaults(stripNulls({ ...customer, phone1, phone2 }), zod(createCustomerOrderSchema("update")))}
 		options={{

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -27,8 +27,7 @@
 	import { PopoverWrapper, Dialog } from "$lib/components";
 	import { PageCenterDialog, defaultDialogConfig } from "$lib/components/Melt";
 	import CustomerOrderMetaForm from "$lib/forms/CustomerOrderMetaForm.svelte";
-	import DaisyUiScannerForm from "$lib/forms/DaisyUIScannerForm.svelte";
-	import { DaisyUIBookForm, bookSchema, createCustomerOrderSchema, type BookFormSchema } from "$lib/forms";
+	import { ScannerForm, DaisyUIBookForm, bookSchema, scannerSchema, createCustomerOrderSchema, type BookFormSchema } from "$lib/forms";
 	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
 
 	import { Page } from "$lib/controllers";
@@ -291,7 +290,21 @@
 					</div>
 				</div>
 
-				<DaisyUiScannerForm onSubmit={handleAddLine} />
+				<ScannerForm
+					data={defaults(zod(scannerSchema))}
+					options={{
+						SPA: true,
+						dataType: "json",
+						validators: zod(scannerSchema),
+						validationMethod: "submit-only",
+						resetForm: true,
+						onUpdated: async ({ form }) => {
+							const { isbn } = form?.data;
+
+							await handleAddLine(isbn);
+						}
+					}}
+				/>
 			</div>
 
 			<div class="h-full overflow-x-auto">

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -192,7 +192,7 @@
 			<div class="card md:h-full">
 				{#if customer}
 					<div class="card-body gap-y-2 p-0">
-						<div class="bg-base-200 flex flex-col gap-y-2 border-b px-4 py-2.5 max-md:sticky max-md:top-0">
+						<div class="flex flex-col gap-y-2 border-b bg-base-200 px-4 py-2.5 max-md:sticky max-md:top-0">
 							<div class="flex flex-row items-center justify-between gap-y-4 pb-2 md:flex-col md:items-start">
 								<h2 class="text-2xl font-medium">{customer.fullname}</h2>
 
@@ -209,7 +209,7 @@
 							<div class="flex w-full flex-col gap-y-4">
 								{#if data?.customer}
 									<div class="flex w-full flex-wrap justify-between gap-y-4 md:flex-col">
-										<div class="flex max-w-96 flex-col gap-y-4">
+										<div class="max-w-96 flex flex-col gap-y-4">
 											<div class="flex gap-x-3">
 												<dt>
 													<span class="sr-only">{$LL.customer_orders_page.customer_details.customer_id()}</span>
@@ -281,7 +281,7 @@
 				<div class="flex items-center justify-between pb-2 pt-4">
 					<h3 class="text-xl font-medium">{$LL.customer_orders_page.customer_details.books_heading()}</h3>
 
-					<div class="badge badge-primary badge-lg gap-x-2">
+					<div class="badge-primary badge-lg badge gap-x-2">
 						<span>{$LL.customer_orders_page.customer_details.total()}</span>
 						<span class="font-bold">€{totalAmount}</span>
 					</div>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -7,12 +7,12 @@
 	import Mail from "$lucide/mail";
 	import FileEdit from "$lucide/file-edit";
 	import ReceiptEuro from "$lucide/receipt-euro";
-	import UserCircle from "$lucide/user-circle";
 	import MoreVertical from "$lucide/more-vertical";
-	import ArrowRight from "$lucide/arrow-right";
 	import ClockArrowUp from "$lucide/clock-arrow-up";
 	import PencilLine from "$lucide/pencil-line";
 	import Phone from "$lucide/phone";
+	import IdCard from "$lucide/id-card";
+	import Printer from "$lucide/printer";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
 	import { defaults, type SuperForm } from "sveltekit-superforms";
@@ -22,20 +22,19 @@
 	import { fade, fly } from "svelte/transition";
 
 	import { testId, stripNulls, type BookData } from "@librocco/shared";
+	import LL from "@librocco/shared/i18n-svelte";
 
-	import { OrderLineStatus, type Customer } from "$lib/db/cr-sqlite/types";
 	import { PopoverWrapper, Dialog } from "$lib/components";
-
-	import type { PageData } from "./$types";
-
-	import { type DialogContent } from "$lib/types";
-
-	import { createExtensionAvailabilityStore } from "$lib/stores";
 	import { PageCenterDialog, defaultDialogConfig } from "$lib/components/Melt";
 	import CustomerOrderMetaForm from "$lib/forms/CustomerOrderMetaForm.svelte";
+	import DaisyUiScannerForm from "$lib/forms/DaisyUIScannerForm.svelte";
 	import { DaisyUIBookForm, bookSchema, createCustomerOrderSchema, type BookFormSchema } from "$lib/forms";
 	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
+
 	import { Page } from "$lib/controllers";
+	import { createExtensionAvailabilityStore } from "$lib/stores";
+	import { type DialogContent } from "$lib/types";
+	import { mergeBookData } from "$lib/utils/misc";
 
 	import {
 		addBooksToCustomer,
@@ -44,14 +43,10 @@
 		upsertCustomer,
 		markCustomerOrderLinesAsCollected
 	} from "$lib/db/cr-sqlite/customers";
-
+	import { OrderLineStatus, type Customer } from "$lib/db/cr-sqlite/types";
 	import { getBookData, upsertBook } from "$lib/db/cr-sqlite/books";
 
-	import { mergeBookData } from "$lib/utils/misc";
-	import DaisyUiScannerForm from "$lib/forms/DaisyUIScannerForm.svelte";
-	import LL from "@librocco/shared/i18n-svelte";
-
-	// import { createIntersectionObserver } from "$lib/actions";
+	import type { PageData } from "./$types";
 
 	export let data: PageData;
 
@@ -82,15 +77,6 @@
 	$: totalAmount = customerOrderLines?.reduce((acc, cur) => acc + cur.price, 0) || 0;
 
 	$: bookDataExtensionAvailable = createExtensionAvailabilityStore(plugins);
-
-	// #region infinite-scroll
-	// let maxResults = 20;
-	// // Allow for pagination-like behaviour (rendering 20 by 20 results on see more clicks)
-	// const seeMore = () => (maxResults += 20);
-	// // We're using in intersection observer to create an infinite scroll effect
-	// const scroll = createIntersectionObserver(seeMore);
-
-	// #endregion infinite-scroll
 
 	// #region dialog
 	const customerMetaDialog = createDialog(defaultDialogConfig);
@@ -205,41 +191,37 @@
 </script>
 
 <Page title="Customer Orders" view="orders/customers/id" {db} {plugins}>
-	<div slot="main" class="flex h-full flex-col gap-y-10 px-4 max-md:overflow-y-auto md:flex-row md:divide-x">
+	<div slot="main" class="flex h-full flex-col gap-y-4 max-md:overflow-y-auto md:flex-row md:divide-x">
 		<div class="min-w-fit md:basis-96 md:overflow-y-auto">
-			<div class="card h-full">
+			<div class="card md:h-full">
 				{#if customer}
 					<div class="card-body gap-y-2 p-0">
-						<div class="sticky top-0 flex flex-col gap-y-2 pb-3">
-							<div class="flex flex-row items-center justify-between gap-y-2 md:flex-col md:items-start">
-								<h2 class="prose">#{customer.displayId}</h2>
+						<div class="bg-base-200 flex flex-col gap-y-2 border-b px-4 py-2.5 max-md:sticky max-md:top-0">
+							<div class="flex flex-row items-center justify-between gap-y-4 pb-2 md:flex-col md:items-start">
+								<h2 class="text-2xl font-medium">{customer.fullname}</h2>
 
-								<span class="badge-accent badge-outline badge badge-md gap-x-2 py-2.5">
+								<span class="badge-accent badge-outline badge badge-md gap-x-2">
 									<span class="sr-only">Last updated</span>
 									<ClockArrowUp size={16} aria-hidden />
-									<time dateTime={data?.customer?.updatedAt ? new Date(data?.customer?.updatedAt).toISOString() : ""}
-										>{new Date(data?.customer?.updatedAt || "").toLocaleString()}</time
-									>
+									<time dateTime={data?.customer?.updatedAt ? new Date(data?.customer?.updatedAt).toISOString() : ""}>
+										{new Date(data?.customer?.updatedAt || "").toLocaleString()}
+									</time>
 								</span>
 							</div>
 						</div>
-						<dl class="flex flex-col">
-							<div class="border-b py-4 font-bold">
-								<dt class="max-md:sr-only">Total amount</dt>
-								<dd class="mt-1">€{totalAmount}</dd>
-							</div>
-
-							<div class="flex w-full flex-col gap-y-4 py-6">
+						<dl class="hidden border-b p-4 md:flex md:flex-col">
+							<div class="flex w-full flex-col gap-y-4">
 								{#if data?.customer}
 									<div class="flex w-full flex-wrap justify-between gap-y-4 md:flex-col">
-										<div class="max-w-96 flex flex-col gap-y-4">
+										<div class="flex max-w-96 flex-col gap-y-4">
 											<div class="flex gap-x-3">
 												<dt>
-													<span class="sr-only">Customer name</span>
-													<UserCircle aria-hidden="true" class="h-6 w-5 text-gray-400" />
+													<span class="sr-only">Customer ID</span>
+													<IdCard aria-hidden="true" class="h-6 w-5 text-gray-400" />
 												</dt>
-												<dd class="truncate">{data?.customer?.fullname || ""}</dd>
+												<dd class="truncate">{customer?.displayId || ""}</dd>
 											</div>
+
 											<div class="flex gap-x-3">
 												<dt>
 													<span class="sr-only">Customer email</span>
@@ -274,25 +256,23 @@
 											<dd>€{data?.customer?.deposit || 0} deposit</dd>
 										</div>
 									</div>
-
-									<div class="w-full pr-2">
-										<button
-											class="btn-secondary btn-outline btn-xs btn w-full"
-											type="button"
-											aria-label="Edit customer order name, email or deposit"
-											on:click={() => customerMetaDialogOpen.set(true)}
-											disabled={!data?.customer}
-										>
-											<PencilLine aria-hidden size={16} />
-										</button>
-									</div>
 								{/if}
 							</div>
 						</dl>
-						<div class="card-actions border-t py-6 md:mb-20">
-							<button class="btn-secondary btn-outline btn-sm btn" type="button" disabled>
+						<div class="card-actions w-full flex-col p-4 md:mb-20">
+							<button
+								class="btn-secondary btn-outline btn-sm btn w-full"
+								type="button"
+								aria-label="Edit customer order name, email or deposit"
+								on:click={() => customerMetaDialogOpen.set(true)}
+								disabled={!data?.customer}
+							>
+								Edit customer
+								<PencilLine aria-hidden size={16} />
+							</button>
+							<button class="btn-secondary btn-outline btn-sm btn w-full" type="button" disabled>
 								Print receipt
-								<ArrowRight aria-hidden size={20} />
+								<Printer aria-hidden size={20} />
 							</button>
 						</div>
 					</div>
@@ -300,16 +280,23 @@
 			</div>
 		</div>
 
-		<div class="mb-20 flex h-full w-full flex-col gap-y-6 md:overflow-y-auto">
-			<div class="prose flex w-full max-w-full flex-col gap-y-3 md:px-4">
-				<h3 class="max-md:divider-start max-md:divider">Books</h3>
+		<div class="flex h-full w-full flex-col gap-y-6 px-4 md:overflow-y-auto">
+			<div class="top-o sticky flex w-full max-w-full flex-col gap-y-3">
+				<div class="flex items-center justify-between pb-2 pt-4">
+					<h3 class="text-xl font-medium">Books</h3>
+
+					<div class="badge badge-primary badge-lg gap-x-2">
+						<span>Total:</span>
+						<span class="font-bold">€{totalAmount}</span>
+					</div>
+				</div>
 
 				<DaisyUiScannerForm onSubmit={handleAddLine} />
 			</div>
 
 			<div class="h-full overflow-x-auto">
 				<div class="h-full">
-					<table class="table-pin-rows table">
+					<table class="table">
 						<thead>
 							<tr>
 								<th>ISBN</th>
@@ -544,16 +531,3 @@
 		labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	/>
 </PageCenterDialog>
-
-<style global>
-	:global(html) {
-		overflow-x: hidden;
-		height: 100%;
-		margin-right: calc(-1 * (100vw - 100%));
-	}
-
-	:global(body) {
-		height: 100%;
-		padding: 0;
-	}
-</style>

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -209,12 +209,14 @@ const customer_orders_page = {
 
 	labels: {
 		new_order: "New Order",
-		update: "Edit",
+		edit: "Edit",
+		save: "Save",
 		edit_customer: "Edit customer",
 		print_receipt: "Print receipt",
 		edit_line: "Edit line",
 		collect: "Collect",
-		delete_row: "Delete row"
+		delete_row: "Delete row",
+		edit_row: "Edit row"
 	},
 	table_columns: {
 		order_id: "ID",
@@ -261,8 +263,7 @@ const customer_orders_page = {
 	},
 	dialogs: {
 		edit_customer: {
-			title: "Update customer details",
-			save_label: "Update"
+			title: "Edit customer details"
 		},
 		non_unique_id: {
 			title: "Non unique customer ID",

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -209,25 +209,65 @@ const customer_orders_page = {
 
 	labels: {
 		new_order: "New Order",
-		update: "Edit"
+		update: "Edit",
+		edit_customer: "Edit customer",
+		print_receipt: "Print receipt",
+		edit_line: "Edit line",
+		collect: "Collect",
+		delete_row: "Delete row"
 	},
 	table_columns: {
 		order_id: "ID",
 		name: "Name",
 		email: "Email",
 		updated: "Updated",
-		actions: "Actions"
+		actions: "Actions",
+		isbn: "ISBN",
+		title: "Title",
+		authors: "Authors",
+		price: "Price",
+		publisher: "Publisher",
+		status: "Status"
 	},
 	placeholder: {
 		search: "Search for customers by name",
 		no_orders: {
 			title: "No customers",
 			description: "Get started by creating a new order"
-		}
+		},
+		scan_title: "Scan to add books",
+		scan_description: "Plugin your barcode scanner and pull the trigger"
 	},
 	new_customer_dialog: {
 		title: "new customer form dialog",
 		description: "enter new customer details"
+	},
+	customer_details: {
+		last_updated: "Last updated",
+		customer_id: "Customer ID",
+		customer_email: "Customer email",
+		customer_phone: "Customer phone",
+		secondary_phone: "Secondary phone",
+		deposit: "Deposit",
+		deposit_amount: "€{amount} deposit",
+		books_heading: "Books",
+		total: "Total:"
+	},
+	status: {
+		collected: "Collected",
+		delivered: "Delivered",
+		placed: "Placed",
+		pending: "Pending"
+	},
+	dialogs: {
+		edit_customer: {
+			title: "Update customer details",
+			save_label: "Update"
+		},
+		non_unique_id: {
+			title: "Non unique customer ID",
+			description: "There's at least one more order with the same ID. Please confirm you're ok with this?"
+		}
 	}
 };
 const new_order_page = {

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -209,17 +209,25 @@ const customer_orders_page = {
 
 	labels: {
 		new_order: "New Order",
-		update_order: "Update Order",
-		update: "Update"
+		update: "Edit"
 	},
-	table: {
-		customer: "Customer",
-		order_id: "Order ID",
-		customer_details: "Customer Details"
+	table_columns: {
+		order_id: "ID",
+		name: "Name",
+		email: "Email",
+		updated: "Updated",
+		actions: "Actions"
 	},
 	placeholder: {
 		search: "Search for customers by name",
-		no_orders: "No customer orders yet. Create your first order to get started."
+		no_orders: {
+			title: "No customers",
+			description: "Get started by creating a new order"
+		}
+	},
+	new_customer_dialog: {
+		title: "new customer form dialog",
+		description: "enter new customer details"
 	}
 };
 const new_order_page = {

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -441,37 +441,192 @@ type RootTranslation = {
 			 */
 			new_order: string
 			/**
-			 * U​p​d​a​t​e​ ​O​r​d​e​r
+			 * E​d​i​t
 			 */
-			update_order: string
+			edit: string
 			/**
-			 * U​p​d​a​t​e
+			 * S​a​v​e
 			 */
-			update: string
+			save: string
+			/**
+			 * E​d​i​t​ ​c​u​s​t​o​m​e​r
+			 */
+			edit_customer: string
+			/**
+			 * P​r​i​n​t​ ​r​e​c​e​i​p​t
+			 */
+			print_receipt: string
+			/**
+			 * E​d​i​t​ ​l​i​n​e
+			 */
+			edit_line: string
+			/**
+			 * C​o​l​l​e​c​t
+			 */
+			collect: string
+			/**
+			 * D​e​l​e​t​e​ ​r​o​w
+			 */
+			delete_row: string
+			/**
+			 * E​d​i​t​ ​r​o​w
+			 */
+			edit_row: string
 		}
-		table: {
+		table_columns: {
 			/**
-			 * C​u​s​t​o​m​e​r
-			 */
-			customer: string
-			/**
-			 * O​r​d​e​r​ ​I​D
+			 * I​D
 			 */
 			order_id: string
 			/**
-			 * C​u​s​t​o​m​e​r​ ​D​e​t​a​i​l​s
+			 * N​a​m​e
 			 */
-			customer_details: string
+			name: string
+			/**
+			 * E​m​a​i​l
+			 */
+			email: string
+			/**
+			 * U​p​d​a​t​e​d
+			 */
+			updated: string
+			/**
+			 * A​c​t​i​o​n​s
+			 */
+			actions: string
+			/**
+			 * I​S​B​N
+			 */
+			isbn: string
+			/**
+			 * T​i​t​l​e
+			 */
+			title: string
+			/**
+			 * A​u​t​h​o​r​s
+			 */
+			authors: string
+			/**
+			 * P​r​i​c​e
+			 */
+			price: string
+			/**
+			 * P​u​b​l​i​s​h​e​r
+			 */
+			publisher: string
+			/**
+			 * S​t​a​t​u​s
+			 */
+			status: string
 		}
 		placeholder: {
 			/**
 			 * S​e​a​r​c​h​ ​f​o​r​ ​c​u​s​t​o​m​e​r​s​ ​b​y​ ​n​a​m​e
 			 */
 			search: string
+			no_orders: {
+				/**
+				 * N​o​ ​c​u​s​t​o​m​e​r​s
+				 */
+				title: string
+				/**
+				 * G​e​t​ ​s​t​a​r​t​e​d​ ​b​y​ ​c​r​e​a​t​i​n​g​ ​a​ ​n​e​w​ ​o​r​d​e​r
+				 */
+				description: string
+			}
 			/**
-			 * N​o​ ​c​u​s​t​o​m​e​r​ ​o​r​d​e​r​s​ ​y​e​t​.​ ​C​r​e​a​t​e​ ​y​o​u​r​ ​f​i​r​s​t​ ​o​r​d​e​r​ ​t​o​ ​g​e​t​ ​s​t​a​r​t​e​d​.
+			 * S​c​a​n​ ​t​o​ ​a​d​d​ ​b​o​o​k​s
 			 */
-			no_orders: string
+			scan_title: string
+			/**
+			 * P​l​u​g​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
+			 */
+			scan_description: string
+		}
+		new_customer_dialog: {
+			/**
+			 * n​e​w​ ​c​u​s​t​o​m​e​r​ ​f​o​r​m​ ​d​i​a​l​o​g
+			 */
+			title: string
+			/**
+			 * e​n​t​e​r​ ​n​e​w​ ​c​u​s​t​o​m​e​r​ ​d​e​t​a​i​l​s
+			 */
+			description: string
+		}
+		customer_details: {
+			/**
+			 * L​a​s​t​ ​u​p​d​a​t​e​d
+			 */
+			last_updated: string
+			/**
+			 * C​u​s​t​o​m​e​r​ ​I​D
+			 */
+			customer_id: string
+			/**
+			 * C​u​s​t​o​m​e​r​ ​e​m​a​i​l
+			 */
+			customer_email: string
+			/**
+			 * C​u​s​t​o​m​e​r​ ​p​h​o​n​e
+			 */
+			customer_phone: string
+			/**
+			 * S​e​c​o​n​d​a​r​y​ ​p​h​o​n​e
+			 */
+			secondary_phone: string
+			/**
+			 * D​e​p​o​s​i​t
+			 */
+			deposit: string
+			/**
+			 * €​{​a​m​o​u​n​t​}​ ​d​e​p​o​s​i​t
+			 * @param {unknown} amount
+			 */
+			deposit_amount: RequiredParams<'amount'>
+			/**
+			 * B​o​o​k​s
+			 */
+			books_heading: string
+			/**
+			 * T​o​t​a​l​:
+			 */
+			total: string
+		}
+		status: {
+			/**
+			 * C​o​l​l​e​c​t​e​d
+			 */
+			collected: string
+			/**
+			 * D​e​l​i​v​e​r​e​d
+			 */
+			delivered: string
+			/**
+			 * P​l​a​c​e​d
+			 */
+			placed: string
+			/**
+			 * P​e​n​d​i​n​g
+			 */
+			pending: string
+		}
+		dialogs: {
+			edit_customer: {
+				/**
+				 * E​d​i​t​ ​c​u​s​t​o​m​e​r​ ​d​e​t​a​i​l​s
+				 */
+				title: string
+			}
+			non_unique_id: {
+				/**
+				 * N​o​n​ ​u​n​i​q​u​e​ ​c​u​s​t​o​m​e​r​ ​I​D
+				 */
+				title: string
+				/**
+				 * T​h​e​r​e​'​s​ ​a​t​ ​l​e​a​s​t​ ​o​n​e​ ​m​o​r​e​ ​o​r​d​e​r​ ​w​i​t​h​ ​t​h​e​ ​s​a​m​e​ ​I​D​.​ ​P​l​e​a​s​e​ ​c​o​n​f​i​r​m​ ​y​o​u​'​r​e​ ​o​k​ ​w​i​t​h​ ​t​h​i​s​?
+				 */
+				description: string
+			}
 		}
 	}
 	suppliers_page: {
@@ -2881,37 +3036,191 @@ export type TranslationFunctions = {
 			 */
 			new_order: () => LocalizedString
 			/**
-			 * Update Order
+			 * Edit
 			 */
-			update_order: () => LocalizedString
+			edit: () => LocalizedString
 			/**
-			 * Update
+			 * Save
 			 */
-			update: () => LocalizedString
+			save: () => LocalizedString
+			/**
+			 * Edit customer
+			 */
+			edit_customer: () => LocalizedString
+			/**
+			 * Print receipt
+			 */
+			print_receipt: () => LocalizedString
+			/**
+			 * Edit line
+			 */
+			edit_line: () => LocalizedString
+			/**
+			 * Collect
+			 */
+			collect: () => LocalizedString
+			/**
+			 * Delete row
+			 */
+			delete_row: () => LocalizedString
+			/**
+			 * Edit row
+			 */
+			edit_row: () => LocalizedString
 		}
-		table: {
+		table_columns: {
 			/**
-			 * Customer
-			 */
-			customer: () => LocalizedString
-			/**
-			 * Order ID
+			 * ID
 			 */
 			order_id: () => LocalizedString
 			/**
-			 * Customer Details
+			 * Name
 			 */
-			customer_details: () => LocalizedString
+			name: () => LocalizedString
+			/**
+			 * Email
+			 */
+			email: () => LocalizedString
+			/**
+			 * Updated
+			 */
+			updated: () => LocalizedString
+			/**
+			 * Actions
+			 */
+			actions: () => LocalizedString
+			/**
+			 * ISBN
+			 */
+			isbn: () => LocalizedString
+			/**
+			 * Title
+			 */
+			title: () => LocalizedString
+			/**
+			 * Authors
+			 */
+			authors: () => LocalizedString
+			/**
+			 * Price
+			 */
+			price: () => LocalizedString
+			/**
+			 * Publisher
+			 */
+			publisher: () => LocalizedString
+			/**
+			 * Status
+			 */
+			status: () => LocalizedString
 		}
 		placeholder: {
 			/**
 			 * Search for customers by name
 			 */
 			search: () => LocalizedString
+			no_orders: {
+				/**
+				 * No customers
+				 */
+				title: () => LocalizedString
+				/**
+				 * Get started by creating a new order
+				 */
+				description: () => LocalizedString
+			}
 			/**
-			 * No customer orders yet. Create your first order to get started.
+			 * Scan to add books
 			 */
-			no_orders: () => LocalizedString
+			scan_title: () => LocalizedString
+			/**
+			 * Plugin your barcode scanner and pull the trigger
+			 */
+			scan_description: () => LocalizedString
+		}
+		new_customer_dialog: {
+			/**
+			 * new customer form dialog
+			 */
+			title: () => LocalizedString
+			/**
+			 * enter new customer details
+			 */
+			description: () => LocalizedString
+		}
+		customer_details: {
+			/**
+			 * Last updated
+			 */
+			last_updated: () => LocalizedString
+			/**
+			 * Customer ID
+			 */
+			customer_id: () => LocalizedString
+			/**
+			 * Customer email
+			 */
+			customer_email: () => LocalizedString
+			/**
+			 * Customer phone
+			 */
+			customer_phone: () => LocalizedString
+			/**
+			 * Secondary phone
+			 */
+			secondary_phone: () => LocalizedString
+			/**
+			 * Deposit
+			 */
+			deposit: () => LocalizedString
+			/**
+			 * €{amount} deposit
+			 */
+			deposit_amount: (arg: { amount: unknown }) => LocalizedString
+			/**
+			 * Books
+			 */
+			books_heading: () => LocalizedString
+			/**
+			 * Total:
+			 */
+			total: () => LocalizedString
+		}
+		status: {
+			/**
+			 * Collected
+			 */
+			collected: () => LocalizedString
+			/**
+			 * Delivered
+			 */
+			delivered: () => LocalizedString
+			/**
+			 * Placed
+			 */
+			placed: () => LocalizedString
+			/**
+			 * Pending
+			 */
+			pending: () => LocalizedString
+		}
+		dialogs: {
+			edit_customer: {
+				/**
+				 * Edit customer details
+				 */
+				title: () => LocalizedString
+			}
+			non_unique_id: {
+				/**
+				 * Non unique customer ID
+				 */
+				title: () => LocalizedString
+				/**
+				 * There's at least one more order with the same ID. Please confirm you're ok with this?
+				 */
+				description: () => LocalizedString
+			}
 		}
 	}
 	suppliers_page: {


### PR DESCRIPTION
Clean up on the customer order routes: 
- improves the layout of the customer list view
- makes each customer rows clickable
- makes customer search work on change and stops the form from being reset 
- improves the layout of the customer order view
- removes the duplicate DaisyUIScannerForm in place of the updated original
- Adds the entire views strings to the dictionaries

Outstanding work - which will be tackled in a separate PR:
- Add new customer order search e2e tests

- Fixes #1011 
- Fixes #984 