### PR TITLE
Fix path to run `rushx typesafe-i18n-check` in the CI

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -168,7 +168,7 @@ jobs:
       -  #@ rush_install()
       -  #@ rush_build()
       - name: Run the check
-        run: cd apps/web-client && rushx typesafe-i18n-check
+        run: cd pkg/shared && rushx typesafe-i18n-check
 
   perform-monorepo-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -349,7 +349,7 @@ jobs:
     - name: Build packages
       run: rush build
     - name: Run the check
-      run: cd apps/web-client && rushx typesafe-i18n-check
+      run: cd pkg/shared && rushx typesafe-i18n-check
   perform-monorepo-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -23,8 +23,8 @@
 		"test": "vitest --ui",
 		"test:ci": "npx playwright install --with-deps && vitest --",
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold error",
-		"typesafe-i18n": "typesafe-i18n",
-		"typesafe-i18n-check": "typesafe-i18n --no-watch && git diff --quiet || (echo 'Error: Changes detected in i18n files. Please commit the changes.' && exit 1)"
+		"typesafe-i18n": "echo please run this in ../../pkg/shared ; exit 1",
+		"typesafe-i18n-check": "echo please run this in ../../pkg/shared ; exit 1"
 	},
 	"dependencies": {
 		"@vlcn.io/crsqlite": "file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz",

--- a/pkg/shared/package.json
+++ b/pkg/shared/package.json
@@ -49,7 +49,7 @@
 		"test:ci": "CI=true vitest run",
 		"typecheck": "tsc --noEmit",
 		"typesafe-i18n": "typesafe-i18n",
-		"typesafe-i18n-check": "typesafe-i18n --no-watch && git diff --quiet || (echo 'Error: Changes detected in i18n files. Please commit the changes.' && exit 1)",
+		"typesafe-i18n-check": "typesafe-i18n --no-watch && git diff || (echo 'Error: Changes detected in i18n files. Please commit the changes.' && exit 1)",
 		"typesafe-i18n-sync": "typesafe-i18n --no-watch && tsx ./src/i18n/export-json.ts"
 	},
 	"devDependencies": {

--- a/pkg/shared/src/i18n/README.md
+++ b/pkg/shared/src/i18n/README.md
@@ -34,6 +34,8 @@ This auto-generates the required i18n support files:
 - formatters.ts
 
 These ensure type safety and autocompletion throughout your app.
+For these changes to be picked up in other packages besides `shared`,
+you need to run `rushx build` in this package.
 
 ### 3. Export JSON for Translators
 


### PR DESCRIPTION
I believe this has been broken for a long time, and the check didn't really work: our translations live in `pkg/shared/`. So we should run `rushx typesafe-i18n-check` there to check whether we have out of sync translations.

Fixes #1031 