### PR TITLE
Make the @sentry/svelte plugin run only for production build (#1042):

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -9,7 +9,7 @@
 		"start:debug": "echo \"Starting dev server in DEBUG mode...\" && PUBLIC_IS_DEBUG=true vite dev",
 		"start:e2e": "echo \"Starting dev server for e2e purposes...\" && PUBLIC_IS_E2E=true vite dev",
 		"build": "echo \"Skipping web app build as part of rush's bulk 'build' script. To build the app for production run: 'rushx build:prod'\"",
-		"build:prod": "VITE_GIT_SHA=$(git rev-parse --short HEAD) vite build",
+		"build:prod": "BUILD_WITH_SENTRY=true VITE_GIT_SHA=$(git rev-parse --short HEAD) vite build",
 		"build:prod-rootdir": "VITE_GIT_SHA=$(git rev-parse --short HEAD) BASE_PATH= vite build",
 		"build:e2e": "VITE_GIT_SHA=$(git rev-parse --short HEAD) PUBLIC_IS_E2E=true vite build",
 		"format": "prettier --write .",

--- a/apps/web-client/vite.config.js
+++ b/apps/web-client/vite.config.js
@@ -10,8 +10,13 @@ export const DEFAULT_BASE_PATH = "/preview";
 
 const dev = process.env.NODE_ENV === "development";
 const CURRENT_SHA = process.env.CURRENT_SHA;
-let BASE_PATH = process.env.BASE_PATH;
+const BUILD_WITH_SENTRY = process.env.BUILD_WITH_SENTRY === "true";
 
+if (BUILD_WITH_SENTRY) {
+	console.log("building with sentry...");
+}
+
+let BASE_PATH = process.env.BASE_PATH;
 if (typeof BASE_PATH === "undefined") {
 	// If no BASE_PATH was passed as environment variable, we default to either
 	// `/preview` or (if CURRENT_SHA is defined) to `/preview/<CURRENT_SHA>`
@@ -25,7 +30,7 @@ const config = {
 		"import.meta.env.VITE_PKG_VERSION": `"${pkg.version}"`
 	},
 	plugins: [
-		sentrySvelteKit(),
+		BUILD_WITH_SENTRY && sentrySvelteKit(),
 		sveltekit(),
 		{
 			name: "configure-response-headers",


### PR DESCRIPTION
This is #1043 resurrected.

* it only runs if 'BUILD_WITH_SENTRY' is true
* update 'build:prod' script to include the 'BUILD_WITH_SENTRY=true'
* this fixes a chokidar/fsevents issue (on Mac) when trying to 'build:e2e'

Fixes #1042 