### PR TITLE
Add check for suspicious files

### DIFF
--- a/.github/workflow.templates/on-pr.yml
+++ b/.github/workflow.templates/on-pr.yml
@@ -1,0 +1,21 @@
+name: PR Safety Check
+
+"on":
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check_pr_integrity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history needed
+
+      - name: Install file utility
+        run: sudo apt-get install -y file
+
+      - name: Run safety checks
+        run: ./scripts/check-pr.sh

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,0 +1,19 @@
+name: PR Safety Check
+"on":
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+jobs:
+  check_pr_integrity:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout PR
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install file utility
+      run: sudo apt-get install -y file
+    - name: Run safety checks
+      run: ./scripts/check-pr.sh

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# check-pr.sh  —  detect add→delete, large, and binary files in a PR
+# Usage:
+#   BASE_BRANCH=origin/main TARGET_REF=my-feature ./check-pr.sh
+
+set -euo pipefail
+
+BASE_BRANCH="${BASE_BRANCH:-origin/main}"   # branch you will merge into
+TARGET_REF="${TARGET_REF:-HEAD}"            # tip of the PR (HEAD in CI)
+
+git fetch --quiet origin "$(echo "$BASE_BRANCH" | cut -d/ -f2-)"
+
+echo "🔍 scanning commits between $BASE_BRANCH and $TARGET_REF …"
+
+##########################
+# 1. files added AND deleted somewhere in the range
+##########################
+mapfile -t added_deleted_files < <(
+  git log --pretty=format: --name-status "$BASE_BRANCH".."$TARGET_REF" |
+  awk '$1=="A"{add[$2]=1} $1=="D"{del[$2]=1} END{for(f in add) if(f in del) print f}'
+)
+
+if ((${#added_deleted_files[@]})); then
+  echo "❌ files added *and* removed in this PR:"
+  printf '%s\n' "${added_deleted_files[@]}"
+  exit 1
+fi
+
+##########################
+# 2. fresh additions (persisting in HEAD) — size & binary checks
+##########################
+mapfile -t added_files < <(
+  git diff --diff-filter=A --name-only "$BASE_BRANCH".."$TARGET_REF"
+)
+
+BINARY_DETECTED=0
+LARGE_DETECTED=0
+
+for f in "${added_files[@]}"; do
+  [[ -f "$f" ]] || continue
+
+  size=$(stat -c%s -- "$f")
+  if (( size > 1048576 )); then      # >1 MiB
+    echo "❌ file too large: $f ($size bytes)"
+    LARGE_DETECTED=1
+  fi
+
+  mime=$(file -b --mime -- "$f")
+  if [[ "$mime" != text/* ]]; then
+    echo "❌ binary/blob file detected: $f ($mime)"
+    BINARY_DETECTED=1
+  fi
+done
+
+if (( LARGE_DETECTED || BINARY_DETECTED )); then
+  echo "❌ PR contains large or binary files. Refactor before merging."
+  exit 1
+fi
+
+echo "✅ all checks passed."


### PR DESCRIPTION
This PR adds a CI check.

[I tested it](https://github.com/librocco/librocco/actions/runs/16321125726/job/46098897086), confirmed it works, and then fixed this PR.

It's meant to flag PRs containing files that were added and removed entirely in PR commits.

It also checks for files that should use LFS but don't.

The bash code has been written by Gemini. I don't understand it 100%. I should probably read this book:

<img width="200" height="263" alt="image" src="https://github.com/user-attachments/assets/3644e80f-db6a-47f4-aaa7-9cfcb5541034" />
