### PR TITLE
Preview Weblate translations on the fly

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -202,6 +202,12 @@ jobs:
       -  #@ rush_add_path()
       -  #@ rush_install()
       -  #@ rush_build()
+      - name: Prepare Weblate env (only for weblate branches)
+        if: contains(github.head_ref || github.ref_name, 'weblate')
+        run: |
+          echo "PUBLIC_WEBLATE_API_KEY=${{ secrets.PUBLIC_WEBLATE_API_KEY }}" >> "$GITHUB_ENV"
+          echo "PUBLIC_WEBLATE_COMPONENT_URL=${{ vars.PUBLIC_WEBLATE_COMPONENT_URL }}" >> "$GITHUB_ENV"
+
       - name: Build web-client app using prefix ${{ github.head_ref || github.ref_name }}
         run: cd apps/web-client && rushx build:prod
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -419,6 +419,11 @@ jobs:
       run: rush update
     - name: Build packages
       run: rush build
+    - name: Prepare Weblate env (only for weblate branches)
+      if: contains(github.head_ref || github.ref_name, 'weblate')
+      run: |
+        echo "PUBLIC_WEBLATE_API_KEY=${{ secrets.PUBLIC_WEBLATE_API_KEY }}" >> "$GITHUB_ENV"
+        echo "PUBLIC_WEBLATE_COMPONENT_URL=${{ vars.PUBLIC_WEBLATE_COMPONENT_URL }}" >> "$GITHUB_ENV"
     - name: Build web-client app using prefix ${{ github.head_ref || github.ref_name }}
       run: cd apps/web-client && rushx build:prod
       env:

--- a/apps/web-client/src/lib/__tests__/i18n-customizations.test.ts
+++ b/apps/web-client/src/lib/__tests__/i18n-customizations.test.ts
@@ -1,0 +1,46 @@
+/** @vitest-environment node */
+
+import { describe, it, expect } from "vitest";
+import { getLanguageUrl } from "$lib/i18n-overrides-lib";
+
+describe("getLanguageUrl", () => {
+	it("should return the correct URL for a valid weblate URL with a trailing slash", () => {
+		const baseUrl = "https://weblate.codemyriad.io/projects/librocco/web-client/";
+		const language = "it";
+		const expectedUrl = "https://weblate.codemyriad.io/api/translations/librocco/web-client/it/file/";
+		expect(getLanguageUrl(baseUrl, language)).toBe(expectedUrl);
+	});
+
+	it("should return the correct URL for a valid weblate URL without a trailing slash", () => {
+		const baseUrl = "https://weblate.codemyriad.io/projects/librocco/web-client";
+		const language = "fr";
+		const expectedUrl = "https://weblate.codemyriad.io/api/translations/librocco/web-client/fr/file/";
+		expect(getLanguageUrl(baseUrl, language)).toBe(expectedUrl);
+	});
+
+	it("should return an empty string for a URL that does not point to a weblate projects path", () => {
+		const baseUrl = "https://example.com/some/other/path/";
+		const language = "de";
+		expect(getLanguageUrl(baseUrl, language)).toBe("");
+	});
+
+	it("should return an empty string for an invalid URL", () => {
+		const baseUrl = "not a valid url";
+		const language = "es";
+		expect(getLanguageUrl(baseUrl, language)).toBe("");
+	});
+
+	it("should handle different languages correctly", () => {
+		const baseUrl = "https://weblate.codemyriad.io/projects/librocco/web-client/";
+		const language = "zh-Hans";
+		const expectedUrl = "https://weblate.codemyriad.io/api/translations/librocco/web-client/zh-Hans/file/";
+		expect(getLanguageUrl(baseUrl, language)).toBe(expectedUrl);
+	});
+
+	it("should handle different project and component names", () => {
+		const baseUrl = "https://weblate.example.com/projects/another-project/another-component/";
+		const language = "ja";
+		const expectedUrl = "https://weblate.example.com/api/translations/another-project/another-component/ja/file/";
+		expect(getLanguageUrl(baseUrl, language)).toBe(expectedUrl);
+	});
+});

--- a/apps/web-client/src/lib/components/ExtensionStatusBanner.svelte
+++ b/apps/web-client/src/lib/components/ExtensionStatusBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { PluginsInterface } from "$lib/plugins";
+	import { invalidateAll } from "$app/navigation";
 	import { createDBConnectivityStore, createExtensionAvailabilityStore } from "$lib/stores";
 	import { updateTranslationOverrides, translationOverridesStore, TRANSLATION_OVERRIDES_ENABLED } from "$lib/i18n-overrides";
 	import LL from "@librocco/shared/i18n-svelte";
@@ -11,6 +12,7 @@
 
 	async function updateTranslationsButtonClicked() {
 		await updateTranslationOverrides({ notOlderThanSecs: 0 });
+		invalidateAll();
 	}
 </script>
 

--- a/apps/web-client/src/lib/components/ExtensionStatusBanner.svelte
+++ b/apps/web-client/src/lib/components/ExtensionStatusBanner.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
 	import type { PluginsInterface } from "$lib/plugins";
 	import { createDBConnectivityStore, createExtensionAvailabilityStore } from "$lib/stores";
+	import { updateTranslationOverrides, translationOverridesStore, TRANSLATION_OVERRIDES_ENABLED } from "$lib/i18n-overrides";
 	import LL from "@librocco/shared/i18n-svelte";
 
 	export let plugins: PluginsInterface;
 
 	$: extensionAvailable = createExtensionAvailabilityStore(plugins);
 	$: dbConnectivity = createDBConnectivityStore();
+
+	async function updateTranslationsButtonClicked() {
+		await updateTranslationOverrides({ notOlderThanSecs: 0 });
+	}
 </script>
 
 <div class="flex items-center gap-4 py-1.5">
+	{#if TRANSLATION_OVERRIDES_ENABLED}
+		<button on:click={updateTranslationsButtonClicked} class="badge-content badge-outline badge badge-md gap-x-2">
+			<div class="block h-3 w-3 rounded-full align-baseline {$translationOverridesStore.loading ? 'bg-error' : 'bg-success'}"></div>
+			<p class="leading-none">{$LL.misc_components.extension_banner.reload_translations_override()}</p>
+		</button>
+	{/if}
 	<div class="badge-content badge-outline badge badge-md gap-x-2">
 		<div class="block h-3 w-3 rounded-full align-baseline {$extensionAvailable ? 'bg-success' : 'bg-error'}"></div>
 

--- a/apps/web-client/src/lib/i18n-overrides-lib.ts
+++ b/apps/web-client/src/lib/i18n-overrides-lib.ts
@@ -1,0 +1,11 @@
+export function getLanguageUrl(baseUrl: string, language: string) {
+	try {
+		const urlWithSlash = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+		const url = new URL(urlWithSlash);
+		if (!url.pathname.startsWith("/projects/")) return "";
+		const newPath = url.pathname.replace("/projects/", "/api/translations/") + `${language}/file/`;
+		return new URL(newPath, url.origin).href;
+	} catch {
+		return "";
+	}
+}

--- a/apps/web-client/src/lib/i18n-overrides.ts
+++ b/apps/web-client/src/lib/i18n-overrides.ts
@@ -1,0 +1,100 @@
+import { loadedLocales } from "@librocco/shared/i18n-util";
+import { writable } from "svelte/store";
+
+import { env as publicEnv } from "$env/dynamic/public";
+
+const PUBLIC_WEBLATE_COMPONENT_URL = publicEnv.PUBLIC_WEBLATE_COMPONENT_URL;
+const PUBLIC_WEBLATE_API_KEY = publicEnv.PUBLIC_WEBLATE_API_KEY;
+const LOCAL_STORAGE_KEY = "weblate_translation_overrides";
+
+// TODO: update the rest of the code to use translationOverridesStore correctly
+export const translationOverridesStore = writable({
+	loading: true,
+	lastFetched: null as Date | null
+});
+
+console.log(PUBLIC_WEBLATE_COMPONENT_URL);
+// The function to fetch and update the data
+export async function updateTranslationOverrides() {
+	if (!PUBLIC_WEBLATE_COMPONENT_URL) {
+		return;
+	}
+	console.log("Inside update");
+
+	for (const language of Object.keys(loadedLocales)) {
+		console.log("Loading language", language);
+		const url = getLanguageUrl(PUBLIC_WEBLATE_COMPONENT_URL, language);
+		if (!url) {
+			console.error(`Invalid URL for language ${language}`);
+			continue;
+		}
+
+		try {
+			const headers: Record<string, string> = {};
+			if (PUBLIC_WEBLATE_API_KEY) {
+				headers["Authorization"] = `Token ${PUBLIC_WEBLATE_API_KEY}`;
+			}
+			const response = await fetch(url, {
+				headers
+			});
+
+			if (response.ok) {
+				const downloadedTranslations = await response.json();
+				deepMergeInPlace(loadedLocales[language], downloadedTranslations);
+			} else {
+				console.error(`Failed to fetch translations for ${language}: ${response.statusText}`);
+			}
+		} catch (error) {
+			console.error(`Error fetching translations for ${language}:`, error);
+		}
+	}
+}
+
+function getLanguageUrl(baseUrl: string, language: string) {
+	/* Takes a weblate component URL like https://weblate.codemyriad.io/projects/librocco/web-client/
+	   and a language like `it`. It returns a URL to download the updated translations, like
+	   https://weblate.codemyriad.io/api/translations/librocco/web-client/it/file/
+	*/
+	try {
+		// Ensure trailing slash for base URL for proper path joining
+		const urlWithSlash = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+		const url = new URL(urlWithSlash);
+		if (!url.pathname.startsWith("/projects/")) {
+			return "";
+		}
+		const newPath = url.pathname.replace("/projects/", "/api/translations/") + `${language}/file/`;
+		return new URL(newPath, url.origin).href;
+	} catch (e) {
+		// Invalid URL will throw, so catch and return empty string
+		console.error(e);
+		return "";
+	}
+}
+
+function deepMergeInPlace(target, source) {
+	Object.keys(source).forEach((key) => {
+		if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])) {
+			if (!target[key] || typeof target[key] !== "object") {
+				target[key] = {};
+			}
+			deepMergeInPlace(target[key], source[key]);
+		} else if (source[key] !== "") {
+			target[key] = source[key];
+		}
+	});
+	return target;
+}
+
+// Export the reactive state for components to use
+// XXX Do we really need this?
+export const dataStore = {
+	get data() {
+		return translationOverrides.data;
+	},
+	get loading() {
+		return translationOverrides.loading;
+	},
+	get lastFetched() {
+		return translationOverrides.lastFetched;
+	}
+};

--- a/apps/web-client/src/lib/i18n-overrides.ts
+++ b/apps/web-client/src/lib/i18n-overrides.ts
@@ -7,6 +7,8 @@ import { env as publicEnv } from "$env/dynamic/public";
 const PUBLIC_WEBLATE_COMPONENT_URL = publicEnv.PUBLIC_WEBLATE_COMPONENT_URL;
 const PUBLIC_WEBLATE_API_KEY = publicEnv.PUBLIC_WEBLATE_API_KEY;
 const LOCAL_STORAGE_KEY = "weblate_translation_overrides";
+const OVERRIDES_MAXAGE = 60;
+export const TRANSLATION_OVERRIDES_ENABLED = !!PUBLIC_WEBLATE_COMPONENT_URL;
 
 /* -------------------------------------------------------------------------- */
 /*                               Helper types                                 */
@@ -48,36 +50,27 @@ function persisted<T>(key: string, initial: T) {
 	return store;
 }
 
-export const translationOverridesStore = persisted<TranslationOverridesState>(
-	LOCAL_STORAGE_KEY,
-	{
-		overrides: {},
-		lastFetched: null,
-		loading: false
-	}
-);
+export const translationOverridesStore = persisted<TranslationOverridesState>(LOCAL_STORAGE_KEY, {
+	overrides: {},
+	lastFetched: null,
+	loading: false
+});
 
 /* -------------------------------------------------------------------------- */
 /*                         Public fetch/update function                       */
 /* -------------------------------------------------------------------------- */
 
-export async function updateTranslationOverrides(
-	opts: { notOlderThanSecs?: number } = {}
-): Promise<TranslationOverridesState> {
+export async function updateTranslationOverrides(opts: { notOlderThanSecs?: number } = {}): Promise<TranslationOverridesState> {
+	if (!TRANSLATION_OVERRIDES_ENABLED) return;
 	const current: TranslationOverridesState = get(translationOverridesStore);
 
-	const freshnessSecs = opts.notOlderThanSecs ?? 3600;
+	const freshnessSecs = opts.notOlderThanSecs ?? OVERRIDES_MAXAGE;
 
 	/* ---------- Use cached value if still fresh ---------- */
-	if (
-		current.lastFetched &&
-		Date.now() - current.lastFetched < freshnessSecs * 1_000
-	) {
+	if (current.lastFetched && Date.now() - current.lastFetched < freshnessSecs * 1_000) {
 		applyOverridesToLoadedLocales(current.overrides);
 		return current;
 	}
-
-	if (!PUBLIC_WEBLATE_COMPONENT_URL) return current;
 
 	translationOverridesStore.update((s) => ({ ...s, loading: true }));
 
@@ -98,8 +91,8 @@ export async function updateTranslationOverrides(
 			if (res.ok) {
 				newOverrides[language] = await res.json();
 			}
-		} catch {
-			/* ignore individual-language failures */
+		} catch (error) {
+			console.error(error);
 		}
 	}
 
@@ -130,9 +123,7 @@ function getLanguageUrl(baseUrl: string, language: string) {
 		const urlWithSlash = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 		const url = new URL(urlWithSlash);
 		if (!url.pathname.startsWith("/projects/")) return "";
-		const newPath =
-			url.pathname.replace("/projects/", "/api/translations/") +
-			`${language}/file/`;
+		const newPath = url.pathname.replace("/projects/", "/api/translations/") + `${language}/file/`;
 		return new URL(newPath, url.origin).href;
 	} catch {
 		return "";
@@ -142,11 +133,7 @@ function getLanguageUrl(baseUrl: string, language: string) {
 function deepMergeInPlace(target: any, source: any): any {
 	if (!target || !source) return target;
 	Object.keys(source).forEach((key) => {
-		if (
-			source[key] &&
-			typeof source[key] === "object" &&
-			!Array.isArray(source[key])
-		) {
+		if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])) {
 			if (!target[key] || typeof target[key] !== "object") {
 				target[key] = {};
 			}

--- a/apps/web-client/src/lib/i18n-overrides.ts
+++ b/apps/web-client/src/lib/i18n-overrides.ts
@@ -1,5 +1,6 @@
 import { loadedLocales } from "@librocco/shared/i18n-util";
 import { writable } from "svelte/store";
+import { browser } from "$app/environment";
 
 import { env as publicEnv } from "$env/dynamic/public";
 
@@ -7,73 +8,146 @@ const PUBLIC_WEBLATE_COMPONENT_URL = publicEnv.PUBLIC_WEBLATE_COMPONENT_URL;
 const PUBLIC_WEBLATE_API_KEY = publicEnv.PUBLIC_WEBLATE_API_KEY;
 const LOCAL_STORAGE_KEY = "weblate_translation_overrides";
 
-// TODO: update the rest of the code to use translationOverridesStore correctly
-export const translationOverridesStore = writable({
-	loading: true,
-	lastFetched: null as Date | null
-});
+/* -------------------------------------------------------------------------- */
+/*                               Helper types                                 */
+/* -------------------------------------------------------------------------- */
 
-console.log(PUBLIC_WEBLATE_COMPONENT_URL);
-// The function to fetch and update the data
-export async function updateTranslationOverrides() {
-	if (!PUBLIC_WEBLATE_COMPONENT_URL) {
-		return;
+type TranslationOverridesState = {
+	/** Per-language overrides merged into loadedLocales */
+	overrides: Record<string, unknown>;
+	/** Epoch-ms timestamp of the last successful fetch */
+	lastFetched: number | null;
+	/** Network request in flight */
+	loading: boolean;
+};
+
+/* -------------------------------------------------------------------------- */
+/*                           Persisted Svelte store                           */
+/* -------------------------------------------------------------------------- */
+
+function persisted<T>(key: string, initial: T) {
+	const store = writable(initial, (set) => {
+		if (!browser) return;
+
+		try {
+			const json = localStorage.getItem(key);
+			if (json) set(JSON.parse(json));
+		} catch {
+			/* corrupted value – ignore */
+		}
+
+		const unsub = store.subscribe((value) => {
+			try {
+				localStorage.setItem(key, JSON.stringify(value));
+			} catch {
+				/* quota / serialisation errors – ignore */
+			}
+		});
+		return unsub;
+	});
+	return store;
+}
+
+export const translationOverridesStore = persisted<TranslationOverridesState>(
+	LOCAL_STORAGE_KEY,
+	{
+		overrides: {},
+		lastFetched: null,
+		loading: false
 	}
-	console.log("Inside update");
+);
+
+/* -------------------------------------------------------------------------- */
+/*                         Public fetch/update function                       */
+/* -------------------------------------------------------------------------- */
+
+export async function updateTranslationOverrides(
+	opts: { notOlderThanSecs?: number } = {}
+): Promise<TranslationOverridesState> {
+	let current: TranslationOverridesState;
+	translationOverridesStore.subscribe((v) => (current = v))(); // immediate & unsubscribe
+
+	const freshnessSecs = opts.notOlderThanSecs ?? 3600;
+
+	/* ---------- Use cached value if still fresh ---------- */
+	if (
+		current.lastFetched &&
+		Date.now() - current.lastFetched < freshnessSecs * 1_000
+	) {
+		applyOverridesToLoadedLocales(current.overrides);
+		return current;
+	}
+
+	if (!PUBLIC_WEBLATE_COMPONENT_URL) return current;
+
+	translationOverridesStore.update((s) => ({ ...s, loading: true }));
+
+	/* ------------------------ Fetch ----------------------- */
+	const newOverrides: Record<string, unknown> = {};
 
 	for (const language of Object.keys(loadedLocales)) {
-		console.log("Loading language", language);
 		const url = getLanguageUrl(PUBLIC_WEBLATE_COMPONENT_URL, language);
-		if (!url) {
-			console.error(`Invalid URL for language ${language}`);
-			continue;
-		}
+		if (!url) continue;
 
 		try {
 			const headers: Record<string, string> = {};
 			if (PUBLIC_WEBLATE_API_KEY) {
 				headers["Authorization"] = `Token ${PUBLIC_WEBLATE_API_KEY}`;
 			}
-			const response = await fetch(url, {
-				headers
-			});
 
-			if (response.ok) {
-				const downloadedTranslations = await response.json();
-				deepMergeInPlace(loadedLocales[language], downloadedTranslations);
-			} else {
-				console.error(`Failed to fetch translations for ${language}: ${response.statusText}`);
+			const res = await fetch(url, { headers });
+			if (res.ok) {
+				newOverrides[language] = await res.json();
 			}
-		} catch (error) {
-			console.error(`Error fetching translations for ${language}:`, error);
+		} catch {
+			/* ignore individual-language failures */
 		}
+	}
+
+	applyOverridesToLoadedLocales(newOverrides);
+
+	const newState: TranslationOverridesState = {
+		overrides: newOverrides,
+		lastFetched: Date.now(),
+		loading: false
+	};
+	translationOverridesStore.set(newState);
+	return newState;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                Internals                                   */
+/* -------------------------------------------------------------------------- */
+
+function applyOverridesToLoadedLocales(overrides: Record<string, unknown>) {
+	for (const [lang, data] of Object.entries(overrides)) {
+		if (!loadedLocales[lang]) continue;
+		deepMergeInPlace(loadedLocales[lang], data);
 	}
 }
 
 function getLanguageUrl(baseUrl: string, language: string) {
-	/* Takes a weblate component URL like https://weblate.codemyriad.io/projects/librocco/web-client/
-	   and a language like `it`. It returns a URL to download the updated translations, like
-	   https://weblate.codemyriad.io/api/translations/librocco/web-client/it/file/
-	*/
 	try {
-		// Ensure trailing slash for base URL for proper path joining
 		const urlWithSlash = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 		const url = new URL(urlWithSlash);
-		if (!url.pathname.startsWith("/projects/")) {
-			return "";
-		}
-		const newPath = url.pathname.replace("/projects/", "/api/translations/") + `${language}/file/`;
+		if (!url.pathname.startsWith("/projects/")) return "";
+		const newPath =
+			url.pathname.replace("/projects/", "/api/translations/") +
+			`${language}/file/`;
 		return new URL(newPath, url.origin).href;
-	} catch (e) {
-		// Invalid URL will throw, so catch and return empty string
-		console.error(e);
+	} catch {
 		return "";
 	}
 }
 
-function deepMergeInPlace(target, source) {
+function deepMergeInPlace(target: any, source: any): any {
+	if (!target || !source) return target;
 	Object.keys(source).forEach((key) => {
-		if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])) {
+		if (
+			source[key] &&
+			typeof source[key] === "object" &&
+			!Array.isArray(source[key])
+		) {
 			if (!target[key] || typeof target[key] !== "object") {
 				target[key] = {};
 			}
@@ -84,17 +158,3 @@ function deepMergeInPlace(target, source) {
 	});
 	return target;
 }
-
-// Export the reactive state for components to use
-// XXX Do we really need this?
-export const dataStore = {
-	get data() {
-		return translationOverrides.data;
-	},
-	get loading() {
-		return translationOverrides.loading;
-	},
-	get lastFetched() {
-		return translationOverrides.lastFetched;
-	}
-};

--- a/apps/web-client/src/routes/+layout.ts
+++ b/apps/web-client/src/routes/+layout.ts
@@ -21,6 +21,7 @@ import { DEFAULT_LOCALE, IS_E2E } from "$lib/constants";
 import { newPluginsInterface } from "$lib/plugins";
 import { getDB } from "$lib/db/cr-sqlite";
 import { ErrDBCorrupted, ErrDBSchemaMismatch } from "$lib/db/cr-sqlite/db";
+import { updateTranslationOverrides } from "$lib/i18n-overrides";
 
 // Paths which are valid (shouldn't return 404, but don't have any content and should get redirected to the default route "/#/stock/")
 const redirectPaths = ["", "/", "/#", "/#/"].map((path) => `${base}${path}`);
@@ -41,6 +42,7 @@ export const load: LayoutLoad = async ({ url }) => {
 	}
 
 	await loadLocaleAsync(locale);
+	await updateTranslationOverrides();
 	setLocale(locale);
 
 	const plugins = newPluginsInterface();

--- a/apps/web-client/vitest.config.ts
+++ b/apps/web-client/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
 		include: [
 			"src/lib/db/cr-sqlite/__tests__/**/*.{test,spec}.{js,ts}",
 			"src/lib/db/__tests__/**/*.{test,spec}.{js,ts}",
-			"src/lib/utils/__tests__/**/*.{test,spec}.{js,ts}"
+			"src/lib/utils/__tests__/**/*.{test,spec}.{js,ts}",
+			"src/lib/__tests__/**/*.{test,spec}.{js,ts}"
 		],
 		browser: {
 			enabled: true,

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -784,7 +784,8 @@ const table_components = {
 const misc_components = {
 	extension_banner: {
 		book_data_extension: "Book Data Extension",
-		remote_db: "Remote DB"
+		remote_db: "Remote DB",
+		reload_translations_override: "Reload translations overrides"
 	},
 	page_layout: {
 		stock: "Stock",

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -1711,7 +1711,7 @@ type RootTranslation = {
 			 */
 			reconcile: string
 			/**
-			 * V​i​e​w​ ​R​e​c​o​n​c​i​l​i​a​t​i​o​n
+			 * R​e​c​o​n​c​i​l​i​a​t​i​o​n
 			 */
 			view_reconciliation: string
 		}
@@ -2020,6 +2020,10 @@ type RootTranslation = {
 			 * R​e​m​o​t​e​ ​D​B
 			 */
 			remote_db: string
+			/**
+			 * R​e​l​o​a​d​ ​t​r​a​n​s​l​a​t​i​o​n​s​ ​o​v​e​r​r​i​d​e​s
+			 */
+			reload_translations_override: string
 		}
 		page_layout: {
 			/**
@@ -4339,7 +4343,7 @@ export type TranslationFunctions = {
 			 */
 			reconcile: () => LocalizedString
 			/**
-			 * View Reconciliation
+			 * Reconciliation
 			 */
 			view_reconciliation: () => LocalizedString
 		}
@@ -4648,6 +4652,10 @@ export type TranslationFunctions = {
 			 * Remote DB
 			 */
 			remote_db: () => LocalizedString
+			/**
+			 * Reload translations overrides
+			 */
+			reload_translations_override: () => LocalizedString
 		}
 		page_layout: {
 			/**


### PR DESCRIPTION
This PR adds code that is enabled by providing the environment variable `PUBLIC_WEBLATE_COMPONENT_URL` (and possibly `PUBLIC_WEBLATE_API_KEY`) at build time.

When `PUBLIC_WEBLATE_COMPONENT_URL` is defined:

* translation overrides are loaded, persisted and activated on each navigation event (in the root layout's load function)
* translation overrides won't be loaded again unless they're more than 60 seconds old or there's no persisted version
* a new button will show up in the bottom notification area [in hindsight I should have put this in the language menu]


In the CI those variables will be set only for branches containing the `weblate` substring (like this one!).

You can test this on https://test.libroc.co/feature/weblate-translations-preview/#/stock/