### PR TITLE
Fix: relax mime type check in check-pr safety script

### DIFF
--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -46,7 +46,7 @@ for f in "${added_files[@]}"; do
   fi
 
   mime=$(file -b --mime -- "$f")
-  if [[ "$mime" != text/* ]]; then
+  if ! grep -Eq '^(text/|application/(javascript|json))' <<< "$mime"; then    
     echo "❌ binary/blob file detected: $f ($mime)"
     BINARY_DETECTED=1
   fi


### PR DESCRIPTION
Fixes the check-pr script which is failing across the board on the mime type check `!= text/*`. It now allows `application/javascript|json`.

Fixes #1060 