### PR TITLE
clean up DB types:

### DIFF
--- a/3rd-party/artefacts/.gitattributes
+++ b/3rd-party/artefacts/.gitattributes
@@ -6,3 +6,4 @@ vlcn.io-ws-common-0.2.0.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-ws-server-0.2.2.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-wa-sqlite-0.22.0.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-ws-client-0.2.0.tgz filter=lfs diff=lfs merge=lfs -text
+vlcn.io-xplat-api-0.15.0.tgz filter=lfs diff=lfs merge=lfs -text

--- a/3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
+++ b/3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07b17a78846c8bb374554ebfecd4720573838f90eaaa4793d66eb7256e6b03c4
-size 753096
+oid sha256:d4d7c50e9c7efbedfd374b7f7a74b35d2dc8dd4f2c53040ba69c8106e534e316
+size 767750

--- a/3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
+++ b/3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f8a02775c5ca20f9c542c2c55899e9f7265bcec78c7472b8de312c7bcd0c6e
-size 1220602
+oid sha256:f3f94b3fe74096ab2ba1cd7db5ea61227d02735d803cd3775ff411a5036a4ff1
+size 1686083

--- a/3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
+++ b/3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc8f3f2d33c79b1a5612204148afa6454a68df1721f387cf5e8947d95da1f676
-size 5736
+oid sha256:de59e55e2201769d21a7fd8e1454ef2c1ca70a4919c3ca9c1a81131160310f51
+size 5400

--- a/3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
+++ b/3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66accf48a3e05afa3ee9446a050a8c904e6a79700bdb32465def72ee1c3ca283
+oid sha256:032fa671c925df33d5a77805faf473b5ddbb32e470289d737ac211514cfa5037
 size 34879

--- a/3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
+++ b/3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69ed17ae5bb65615e69e161f07b56ab58d16cc627119876ebfb1a787c6c70e50
+size 4402

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -34,6 +34,7 @@
 		"@vlcn.io/ws-client": "0.2.0",
 		"@vlcn.io/ws-common": "0.2.0",
 		"@vlcn.io/ws-server": "0.2.2",
+		"@vlcn.io/xplat-api": "0.15.0",
 		"lucide-svelte": "^0.475.0",
 		"export-to-csv": "~1.3.0",
 		"rxjs": "~7.8.0",

--- a/apps/web-client/src/lib/controllers/HistoryPage.svelte
+++ b/apps/web-client/src/lib/controllers/HistoryPage.svelte
@@ -10,7 +10,7 @@
 
 	import type { HistoryView } from "@librocco/shared";
 
-	import type { DB } from "$lib/db/cr-sqlite/types";
+	import type { DBAsync } from "$lib/db/cr-sqlite/types";
 	import type { PluginsInterface } from "$lib/plugins";
 
 	$: tabs = [
@@ -41,7 +41,7 @@
 	];
 
 	export let view: HistoryView;
-	export let db: DB;
+	export let db: DBAsync;
 	export let plugins: PluginsInterface;
 </script>
 

--- a/apps/web-client/src/lib/controllers/InventoryManagementPage.svelte
+++ b/apps/web-client/src/lib/controllers/InventoryManagementPage.svelte
@@ -10,7 +10,7 @@
 	import { Page } from "$lib/controllers";
 	import { appHash } from "$lib/paths";
 
-	import type { DB } from "$lib/db/cr-sqlite/types";
+	import type { DBAsync } from "$lib/db/cr-sqlite/types";
 	import type { PluginsInterface } from "$lib/plugins";
 
 	$: ({ page_headings: tPage } = $LL);
@@ -30,7 +30,7 @@
 
 	$: activeTab = tabs.find(({ href }) => $page.url.hash.startsWith(href));
 
-	export let db: DB;
+	export let db: DBAsync;
 	export let plugins: PluginsInterface;
 
 	export let handleCreateWarehouse = () => Promise.resolve();

--- a/apps/web-client/src/lib/controllers/Page.svelte
+++ b/apps/web-client/src/lib/controllers/Page.svelte
@@ -8,9 +8,9 @@
 	import { PageLayout, ExtensionStatusBanner } from "$lib/components";
 
 	import type { WebClientView } from "@librocco/shared";
-	import type { DB } from "$lib/db/cr-sqlite/types";
+	import type { DBAsync } from "$lib/db/cr-sqlite/types";
 
-	export let db: DB;
+	export let db: DBAsync;
 	export let plugins: PluginsInterface;
 
 	export let view: WebClientView;

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { type DB, type Customer, OrderLineStatus } from "../types";
+import { type Customer, OrderLineStatus } from "../types";
 
 import { getRandomDb } from "./lib";
 
@@ -729,7 +729,7 @@ describe("Stress tests", () => {
 		for (let i = 0; i < howMany; i++) {
 			// NOTE: this was wrapped in a transaction, but 'addBooksToCustomer'
 			// already runs inside a transaction (internally)
-			await addBooksToCustomer(db as DB, 1, [
+			await addBooksToCustomer(db, 1, [
 				"9780000000000",
 				"9780000000001",
 				"9780000000002",

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/lib.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/lib.ts
@@ -1,10 +1,11 @@
+import type { DBAsync, TXAsync } from "$lib/db/cr-sqlite/types";
+
 import { getDB, initializeDB, getChanges, applyChanges, getSiteId, getPeerDBVersion } from "../db";
 import { upsertCustomer, addBooksToCustomer } from "../customers";
 import { upsertBook } from "../books";
-import { type DB } from "../types";
 import { upsertSupplier, associatePublisher } from "../suppliers";
 
-export const getRandomDb = async (): Promise<DB> => {
+export const getRandomDb = async (): Promise<DBAsync> => {
 	// Each test run will use a different db
 	// birthday paradox chance of collision for 1k runs is 0.5%)
 	const randomTestRunId = Math.floor(Math.random() * 100000000);
@@ -13,7 +14,7 @@ export const getRandomDb = async (): Promise<DB> => {
 	return db;
 };
 
-export const getRandomDbs = async (): Promise<DB[]> => {
+export const getRandomDbs = async (): Promise<DBAsync[]> => {
 	const randomTestRunId = Math.floor(Math.random() * 100000000);
 	const db1 = await getDB("testdb1" + randomTestRunId);
 	const db2 = await getDB("testdb2" + randomTestRunId);
@@ -22,12 +23,12 @@ export const getRandomDbs = async (): Promise<DB[]> => {
 	return [db1, db2];
 };
 
-export const syncDBs = async (source: DB, destination: DB) => {
+export const syncDBs = async (source: TXAsync, destination: TXAsync) => {
 	const sourceDBVersion = await getPeerDBVersion(source, await getSiteId(destination));
 	await applyChanges(destination, await getChanges(source, sourceDBVersion));
 };
 
-export const createCustomerOrders = async (db: DB) => {
+export const createCustomerOrders = async (db: DBAsync) => {
 	// Add three books
 	await upsertBook(db, { isbn: "1", publisher: "MathsAndPhysicsPub", title: "Physics", price: 7 });
 	await upsertBook(db, { isbn: "2", publisher: "ChemPub", title: "Chemistry", price: 13 });

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import type { DB, OutOfStockTransaction } from "../types";
+import type { TXAsync, OutOfStockTransaction } from "../types";
 
 import { getRandomDb } from "./lib";
 import { NoWarehouseSelectedError, OutOfStockError } from "../errors";
@@ -1175,7 +1175,7 @@ describe("Book transactions", async () => {
 		/* This should be trivial, but I had some weird behaviour around this so here's a test testing that cr-sqlite extension doesn't block that. */
 
 		// A helper to avoid flakiness due to temporal sorting - sorts by warehouseId
-		const _getNoteEntries = (db: DB, noteId: number) =>
+		const _getNoteEntries = (db: TXAsync, noteId: number) =>
 			getNoteEntries(db, noteId).then((r) => r.sort((a, b) => a.warehouseId - b.warehouseId));
 
 		const db = await getRandomDb();

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { type DB } from "../types";
+import { type DBAsync } from "../types";
 
 import { getRandomDb } from "./lib";
 
@@ -28,7 +28,7 @@ const books = [book1, book2];
 const supplier1 = { id: 1, name: "Alphabet Books LTD" };
 const supplier2 = { id: 2, name: "Xanax Books LTD" };
 
-let db: DB;
+let db: DBAsync;
 
 beforeEach(async () => {
 	db = await getRandomDb();

--- a/apps/web-client/src/lib/db/cr-sqlite/books.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/books.ts
@@ -20,7 +20,7 @@
 
 import { type BookData } from "@librocco/shared";
 
-import { type DB } from "./types";
+import { type TXAsync } from "./types";
 
 import { timed } from "$lib/utils/timer";
 
@@ -34,7 +34,7 @@ import { timed } from "$lib/utils/timer";
  * @throws {Error} If ISBN is not provided
  * @see apps/e2e/helpers/cr-sqlite.ts:upsertBook whe you make any updates
  */
-async function _upsertBook(db: DB, book: BookData) {
+async function _upsertBook(db: TXAsync, book: BookData) {
 	if (!book.isbn) {
 		throw new Error("Book must have an ISBN");
 	}
@@ -75,7 +75,7 @@ async function _upsertBook(db: DB, book: BookData) {
 	);
 }
 
-async function _getMultipleBookData(db: DB, ...isbns: string[]): Promise<Array<Required<BookData> & { updatedAt: Date | null }>> {
+async function _getMultipleBookData(db: TXAsync, ...isbns: string[]): Promise<Array<Required<BookData> & { updatedAt: Date | null }>> {
 	// Supporting this case as there might be a request for empty entries list (as this depends on warehouse/note entries)
 	if (!isbns.length) {
 		return [];
@@ -109,7 +109,7 @@ async function _getMultipleBookData(db: DB, ...isbns: string[]): Promise<Array<R
 	return res.map(processRawBookRes);
 }
 
-async function _getBookData(db: DB, isbn: string): Promise<Required<BookData> & { updatedAt: Date | null }> {
+async function _getBookData(db: TXAsync, isbn: string): Promise<Required<BookData> & { updatedAt: Date | null }> {
 	const [res] = await db.execO<RawBookRes>(
 		`SELECT
 				isbn,
@@ -132,7 +132,7 @@ async function _getBookData(db: DB, isbn: string): Promise<Required<BookData> & 
 	return processRawBookRes(res);
 }
 
-async function _getPublisherList(db: DB): Promise<string[]> {
+async function _getPublisherList(db: TXAsync): Promise<string[]> {
 	const res = await db.execO<{ publisher: string }>(`SELECT DISTINCT publisher FROM book`);
 	return res.map(({ publisher }) => publisher);
 }
@@ -143,7 +143,7 @@ type SearchBooksParams = {
 	order?: "asc" | "desc";
 };
 async function _searchBooks(
-	db: DB,
+	db: TXAsync,
 	{ searchString, orderBy, order = "asc" }: SearchBooksParams = {}
 ): Promise<Array<Required<BookData> & { updatedAt: Date | null }>> {
 	const filterClauses = [];

--- a/apps/web-client/src/lib/db/cr-sqlite/core/index.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/index.ts
@@ -1,0 +1,1 @@
+export type * from "./types";

--- a/apps/web-client/src/lib/db/cr-sqlite/core/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/types.ts
@@ -1,0 +1,8 @@
+import type { TXAsync as _TXAsync } from "@vlcn.io/xplat-api";
+export type { DBAsync } from "@vlcn.io/xplat-api";
+
+/**
+ * A TXAsync type without the `tx.tx` method - we're using this adjusted type to ensure that functions
+ * that call to `db.tx` don't accept `TXAsync` as `db` (ensuring we don't nest transactions).
+ */
+export type TXAsync = Omit<_TXAsync, "tx">;

--- a/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
@@ -2,7 +2,7 @@ import { cryb64 } from "@vlcn.io/ws-common";
 
 import { zip } from "@librocco/shared";
 
-import type { DB } from "../types";
+import type { TXAsync } from "../types";
 import { getDB } from "../db";
 
 function firstPick<T>(data: any[]): T | undefined {
@@ -77,7 +77,7 @@ const logger = newLogger();
  *
  * IMPORTANT NOTE: This is for debug purposes only and should NEVER be used in production as (unlike the original) it doesn't wrap everything into a transaction
  */
-export async function jsAutomigrateTo(db: DB, schemaName: string, schemaContent: string): Promise<"noop" | "apply" | "migrate"> {
+export async function jsAutomigrateTo(db: TXAsync, schemaName: string, schemaContent: string): Promise<"noop" | "apply" | "migrate"> {
 	const l = logger.extend("jsAutomigrateTo");
 	l.start({ db, schemaName, schemaContent });
 
@@ -130,7 +130,7 @@ export async function jsAutomigrateTo(db: DB, schemaName: string, schemaContent:
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L31
  */
-export async function crsql_automigrate(db: DB, schema: string, cleanup_stmt: string): Promise<void> {
+export async function crsql_automigrate(db: TXAsync, schema: string, cleanup_stmt: string): Promise<void> {
 	const l = logger.extend("crsql_automigrate");
 	l.start({ db, schema, cleanup_stmt });
 
@@ -146,11 +146,11 @@ export async function crsql_automigrate(db: DB, schema: string, cleanup_stmt: st
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L55
  */
-export async function automigrate_impl(db: DB, schema: string, cleanup_stmt: string) {
+export async function automigrate_impl(db: TXAsync, schema: string, cleanup_stmt: string) {
 	const l = logger.extend("automigrate_impl");
 	l.start({ db, schema, cleanup_stmt });
 
-	const cleanup = (mem_db: DB) => mem_db.exec(cleanup_stmt);
+	const cleanup = (mem_db: TXAsync) => mem_db.exec(cleanup_stmt);
 
 	const local_db = db;
 	const desired_schema = schema;
@@ -207,7 +207,7 @@ export async function automigrate_impl(db: DB, schema: string, cleanup_stmt: str
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L106
  */
-export async function migrate_to(local_db: DB, mem_db: DB) {
+export async function migrate_to(local_db: TXAsync, mem_db: TXAsync) {
 	const l = logger.extend("migrate_to");
 	l.start({ local_db, mem_db });
 
@@ -263,7 +263,7 @@ export function strip_crr_statements(schema: string) {
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L169
  */
-export async function drop_tables(local_db: DB, tables: string[]) {
+export async function drop_tables(local_db: TXAsync, tables: string[]) {
 	const l = logger.extend("drop_tables");
 	l.start({ local_db, tables });
 
@@ -277,7 +277,7 @@ export async function drop_tables(local_db: DB, tables: string[]) {
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L181
  */
-export async function maybe_modify_table(local_db: DB, table: string, mem_db: DB) {
+export async function maybe_modify_table(local_db: TXAsync, table: string, mem_db: TXAsync) {
 	const l = logger.extend("maybe_modify_table");
 	l.start({ local_db, table, mem_db });
 
@@ -319,7 +319,7 @@ export async function maybe_modify_table(local_db: DB, table: string, mem_db: DB
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/is_crr.rs#L10
  */
-export async function is_crr(local_db: DB, table: string) {
+export async function is_crr(local_db: TXAsync, table: string) {
 	const l = logger.extend("is_crr");
 	l.start({ local_db, table });
 
@@ -332,7 +332,7 @@ export async function is_crr(local_db: DB, table: string) {
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L236
  */
-export async function drop_columns(local_db: DB, table: string, columns: string[]) {
+export async function drop_columns(local_db: TXAsync, table: string, columns: string[]) {
 	const l = logger.extend("drop_columns");
 	l.start({ local_db, table, columns });
 
@@ -352,7 +352,7 @@ export async function drop_columns(local_db: DB, table: string, columns: string[
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L256
  */
-export async function add_columns(local_db: DB, table: string, columns: string[], mem_db: DB) {
+export async function add_columns(local_db: TXAsync, table: string, columns: string[], mem_db: TXAsync) {
 	const l = logger.extend("add_columns");
 	l.start({ local_db, table, columns, mem_db });
 
@@ -386,7 +386,7 @@ export async function add_columns(local_db: DB, table: string, columns: string[]
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L301
  */
-export async function add_column(local_db: DB, table: string, name: string, col_type: string, notnull: number, dflt_val: unknown) {
+export async function add_column(local_db: TXAsync, table: string, name: string, col_type: string, notnull: number, dflt_val: unknown) {
 	const l = logger.extend("add_column");
 	l.start({ local_db, table, name, col_type, notnull, dflt_val });
 
@@ -400,7 +400,7 @@ export async function add_column(local_db: DB, table: string, name: string, col_
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L328
  */
-export async function maybe_update_indices(local_db: DB, table: string, mem_db: DB) {
+export async function maybe_update_indices(local_db: TXAsync, table: string, mem_db: TXAsync) {
 	const l = logger.extend("maybe_update_indices");
 	l.start({ local_db, table, mem_db });
 
@@ -437,7 +437,7 @@ export async function maybe_update_indices(local_db: DB, table: string, mem_db: 
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L374
  */
-export async function drop_indices(local_db: DB, dropped: string[]) {
+export async function drop_indices(local_db: TXAsync, dropped: string[]) {
 	const l = logger.extend("drop_indices");
 	l.start({ local_db, dropped });
 
@@ -466,7 +466,7 @@ export async function drop_indices(local_db: DB, dropped: string[]) {
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L396
  *
  */
-export async function maybe_recreate_index(local_db: DB, table: string, idx: string, mem_db: DB) {
+export async function maybe_recreate_index(local_db: TXAsync, table: string, idx: string, mem_db: TXAsync) {
 	const l = logger.extend("maybe_recreate_index");
 	l.start({ local_db, table, idx, mem_db });
 
@@ -514,7 +514,7 @@ export async function maybe_recreate_index(local_db: DB, table: string, idx: str
 /**
  * @see https://github.com/vlcn-io/cr-sqlite/blob/891fe9e0190dd20917f807d739c809e1bc32f6a3/core/rs/core/src/automigrate.rs#L447
  */
-export async function recreate_index(local_db: DB, idx: string) {
+export async function recreate_index(local_db: TXAsync, idx: string) {
 	const l = logger.extend("recreate_index");
 	l.start({ local_db, idx });
 

--- a/apps/web-client/src/lib/db/cr-sqlite/history.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/history.ts
@@ -15,7 +15,7 @@
  * - warehouse table: Location names and discounts
  */
 
-import type { DB, PastNoteItem, PastTransactionItem, NoteType } from "./types";
+import type { TXAsync, PastNoteItem, PastTransactionItem, NoteType } from "./types";
 
 import { timed } from "$lib/utils/timer";
 
@@ -28,7 +28,7 @@ import { timed } from "$lib/utils/timer";
  * @param {string} date - Date to query in YYYY-MM-DD format
  * @returns {Promise<PastNoteItem[]>} Committed notes
  */
-async function _getPastNotes(db: DB, date: string): Promise<PastNoteItem[]> {
+async function _getPastNotes(db: TXAsync, date: string): Promise<PastNoteItem[]> {
 	const query = `
             SELECT
                 n.id,
@@ -89,7 +89,7 @@ type Params = {
  * @param {Params} params - Query filters
  * @returns {Promise<PastTransactionItem[]>} Historical transactions
  */
-async function _getPastTransactions(db: DB, params: Params): Promise<PastTransactionItem[]> {
+async function _getPastTransactions(db: TXAsync, params: Params): Promise<PastTransactionItem[]> {
 	const { isbn, warehouseId, startDate, endDate, noteType } = params;
 	const conditions = [];
 	const values = [];

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -35,7 +35,8 @@
  */
 
 import type {
-	DB,
+	DBAsync,
+	TXAsync,
 	InboundNoteListItem,
 	VolumeStock,
 	NoteEntriesItem,
@@ -52,7 +53,7 @@ import { NoWarehouseSelectedError, OutOfStockError } from "./errors";
 
 import { getStock } from "./stock";
 
-async function _getNoteIdSeq(db: DB) {
+async function _getNoteIdSeq(db: TXAsync) {
 	const query = `SELECT COALESCE(MAX(id), 0) + 1 AS nextId FROM note;`;
 	const [result] = await db.execO<{ nextId: number }>(query);
 	return result.nextId;
@@ -62,11 +63,11 @@ async function _getNoteIdSeq(db: DB) {
  * Generates a sequential display name for a new note.
  * Format follows: "New Note", "New Note (2)", "New Note (3)", etc.
  *
- * @param {DB | TXAsync} db - Database connection
+ * @param {TXAsync} db - Database connection
  * @param {"inbound" | "outbound"} kind - Type of note being created
  * @returns {Promise<string>} Next available sequential name
  */
-const getSeqName = async (db: DB, kind: "inbound" | "outbound") => {
+const getSeqName = async (db: TXAsync, kind: "inbound" | "outbound"): Promise<string> => {
 	const sequenceQuery = `
 			SELECT display_name AS displayName FROM note
 			WHERE displayName LIKE 'New ${kind === "inbound" ? "Purchase" : "Sale"}%'
@@ -100,7 +101,7 @@ const getSeqName = async (db: DB, kind: "inbound" | "outbound") => {
  * @param {number} noteId - Unique identifier for the new note
  * @returns {Promise<void>} Resolves when note is created
  */
-export function createInboundNote(db: DB, warehouseId: number, noteId: number): Promise<void> {
+export function createInboundNote(db: DBAsync, warehouseId: number, noteId: number): Promise<void> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, warehouse_id, updated_at) VALUES (?, ?, ?, ?)";
 
@@ -118,7 +119,7 @@ export function createInboundNote(db: DB, warehouseId: number, noteId: number): 
  * @param {number} noteId - Unique identifier for the new note
  * @returns {Promise<void>} Resolves when note is created
  */
-export function createOutboundNote(db: DB, noteId: number): Promise<void> {
+export function createOutboundNote(db: DBAsync, noteId: number): Promise<void> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, updated_at) VALUES (?, ?, ?)";
 
@@ -135,7 +136,7 @@ export function createOutboundNote(db: DB, noteId: number): Promise<void> {
  * @param {DB} db - Database connection
  * @returns {Promise<InboundNoteListItem[]>} Array of inbound notes
  */
-async function _getActiveInboundNotes(db: DB): Promise<InboundNoteListItem[]> {
+async function _getActiveInboundNotes(db: TXAsync): Promise<InboundNoteListItem[]> {
 	const query = `
 		SELECT
 			note.id,
@@ -164,7 +165,7 @@ async function _getActiveInboundNotes(db: DB): Promise<InboundNoteListItem[]> {
  * @param {DB} db - Database connection
  * @returns {Promise<OutboundNoteListItem[]>} Array of outbound notes
  */
-async function _getActiveOutboundNotes(db: DB): Promise<OutboundNoteListItem[]> {
+async function _getActiveOutboundNotes(db: TXAsync): Promise<OutboundNoteListItem[]> {
 	const query = `
 		SELECT
 			note.id,
@@ -212,7 +213,7 @@ type GetNoteResponse = {
  * @param {number} id - ID of note to retrieve
  * @returns {Promise<GetNoteResponse | undefined>} Note details
  */
-async function _getNoteById(db: DB, id: number): Promise<GetNoteResponse | undefined> {
+async function _getNoteById(db: TXAsync, id: number): Promise<GetNoteResponse | undefined> {
 	const query = `
 		SELECT
 			note.id,
@@ -272,7 +273,7 @@ async function _getNoteById(db: DB, id: number): Promise<GetNoteResponse | undef
  * @param {number} [payload.defaultWarehouse] - New default warehouse ID for outbound notes
  * @returns {Promise<void>} Resolves when note is updated
  */
-async function _updateNote(db: DB, id: number, payload: { displayName?: string; defaultWarehouse?: number }): Promise<void> {
+async function _updateNote(db: TXAsync, id: number, payload: { displayName?: string; defaultWarehouse?: number }): Promise<void> {
 	const note = await getNoteById(db, id);
 	if (note?.committed) {
 		console.warn("Trying to update a committed note: this is a noop, but probably indicates a bug in the calling code.");
@@ -322,7 +323,7 @@ async function _updateNote(db: DB, id: number, payload: { displayName?: string; 
  * @param {number} noteId - ID of note to check
  * @returns {Promise<OutOfStockTransaction[]>} Array of transactions that would result in negative stock
  */
-async function _getOutOfStockEntries(db: DB, noteId: number): Promise<OutOfStockTransaction[]> {
+async function _getOutOfStockEntries(db: TXAsync, noteId: number): Promise<OutOfStockTransaction[]> {
 	const entries = (await getNoteEntries(db, noteId)) as Required<NoteEntriesItem>[];
 	const stock = await getStock(db, { entries }).then((x) => new Map(x.map((e) => [[e.isbn, e.warehouseId].join("-"), e])));
 
@@ -352,7 +353,7 @@ async function _getOutOfStockEntries(db: DB, noteId: number): Promise<OutOfStock
  * @param {number} id - ID of note to check
  * @returns {Promise<VolumeStock[]>} Array of transactions missing warehouse assignments
  */
-async function _getNoWarehouseEntries(db: DB, id: number): Promise<VolumeStock[]> {
+async function _getNoWarehouseEntries(db: TXAsync, id: number): Promise<VolumeStock[]> {
 	const query = `
 		SELECT
 			isbn,
@@ -382,7 +383,7 @@ async function _getNoWarehouseEntries(db: DB, id: number): Promise<VolumeStock[]
  * @throws {OutOfStockError} If outbound note requests more books than available
  * @returns {Promise<void>} Resolves when note is committed
  */
-async function _commitNote(db: DB, id: number, { force = false }: { force?: boolean } = {}): Promise<void> {
+async function _commitNote(db: DBAsync, id: number, { force = false }: { force?: boolean } = {}): Promise<void> {
 	const note = await getNoteById(db, id);
 	if (note?.committed) {
 		console.warn("Trying to commit a note that is already committed: this is a noop, but probably indicates a bug in the calling code.");
@@ -421,7 +422,7 @@ async function _commitNote(db: DB, id: number, { force = false }: { force?: bool
  * @param {number} id - ID of note to delete
  * @returns {Promise<void>} Resolves when note is deleted
  */
-async function _deleteNote(db: DB, id: number): Promise<void> {
+async function _deleteNote(db: TXAsync, id: number): Promise<void> {
 	const note = await getNoteById(db, id);
 	if (note?.committed) {
 		console.warn("Trying to delete a committed note: this is a noop, but probably indicates a bug in the calling code.");
@@ -440,7 +441,7 @@ async function _deleteNote(db: DB, id: number): Promise<void> {
  * @param {VolumeStock} volume - Book data containing ISBN, warehouseId and quantity
  * @returns {Promise<void>} Resolves when volumes are added
  */
-async function _addVolumesToNote(db: DB, noteId: number, volume: VolumeStock): Promise<void> {
+async function _addVolumesToNote(db: DBAsync, noteId: number, volume: VolumeStock): Promise<void> {
 	const note = await getNoteById(db, noteId);
 	if (note?.committed) {
 		console.warn("Cannot add volumes to a committed note.");
@@ -475,7 +476,7 @@ async function _addVolumesToNote(db: DB, noteId: number, volume: VolumeStock): P
  * @param {number} id - ID of note to get entries for
  * @returns {Promise<NoteEntriesItem[]>} Array of note entries with book details (title, price, etc)
  */
-async function _getNoteEntries(db: DB, id: number): Promise<NoteEntriesItem[]> {
+async function _getNoteEntries(db: TXAsync, id: number): Promise<NoteEntriesItem[]> {
 	const query = `
 		SELECT
 			bt.isbn,
@@ -545,7 +546,7 @@ async function _getNoteEntries(db: DB, id: number): Promise<NoteEntriesItem[]> {
  * @returns {Promise<void>} Resolves when transaction is updated
  */
 async function _updateNoteTxn(
-	db: DB,
+	db: DBAsync,
 	noteId: number,
 	curr: { isbn: string; warehouseId: number },
 	next: { warehouseId: number; quantity: number }
@@ -604,7 +605,7 @@ async function _updateNoteTxn(
  * @param {number} match.warehouseId - Warehouse ID
  * @returns {Promise<void>} Resolves when transaction is removed
  */
-async function _removeNoteTxn(db: DB, noteId: number, match: { isbn: string; warehouseId: number }): Promise<void> {
+async function _removeNoteTxn(db: DBAsync, noteId: number, match: { isbn: string; warehouseId: number }): Promise<void> {
 	const note = await getNoteById(db, noteId);
 	if (note?.committed) {
 		console.warn("Cannot delete transactions of a committed note.");
@@ -632,7 +633,7 @@ async function _removeNoteTxn(db: DB, noteId: number, match: { isbn: string; war
  * @param {number} payload.price - Item price
  * @returns {Promise<void>} Resolves when item is added/updated
  */
-async function _upsertNoteCustomItem(db: DB, noteId: number, payload: NoteCustomItem): Promise<void> {
+async function _upsertNoteCustomItem(db: DBAsync, noteId: number, payload: NoteCustomItem): Promise<void> {
 	const note = await getNoteById(db, noteId);
 	if (note?.committed) {
 		console.warn("Cannot upsert custom items to a committed note.");
@@ -669,7 +670,7 @@ async function _upsertNoteCustomItem(db: DB, noteId: number, payload: NoteCustom
  * @param {number} noteId - ID of note to get items for
  * @returns {Promise<Array<{id: number, title: string, price: number}>>} Array of custom items
  */
-async function _getNoteCustomItems(db: DB, noteId: number): Promise<NoteCustomItem[]> {
+async function _getNoteCustomItems(db: TXAsync, noteId: number): Promise<NoteCustomItem[]> {
 	const query = `
 		SELECT id, title, COALESCE(price, 0) AS price, updated_at
 		FROM custom_item
@@ -691,7 +692,7 @@ async function _getNoteCustomItems(db: DB, noteId: number): Promise<NoteCustomIt
  * @param {number} itemId - ID of custom item to remove
  * @returns {Promise<void>} Resolves when item is removed
  */
-async function _removeNoteCustomItem(db: DB, noteId: number, itemId: number): Promise<void> {
+async function _removeNoteCustomItem(db: DBAsync, noteId: number, itemId: number): Promise<void> {
 	const note = await getNoteById(db, noteId);
 	if (note?.committed) {
 		console.warn("Cannot remove custom items from a committed note.");
@@ -713,7 +714,7 @@ async function _removeNoteCustomItem(db: DB, noteId: number, itemId: number): Pr
  * @returns {Promise<ReceiptData>} Receipt data including items and timestamp
  * @throws {Error} If note doesn't exist
  */
-async function _getReceiptForNote(db: DB, noteId: number): Promise<ReceiptData> {
+async function _getReceiptForNote(db: TXAsync, noteId: number): Promise<ReceiptData> {
 	const note = await getNoteById(db, noteId);
 	if (!note) {
 		throw new Error("Note not found");
@@ -772,7 +773,7 @@ async function _getReceiptForNote(db: DB, noteId: number): Promise<ReceiptData> 
  * @param {VolumeStock[]} volumes - Array of book quantity adjustments
  * @returns {Promise<void>} Resolves when note is created and committed
  */
-async function _createAndCommitReconciliationNote(db: DB, id: number, volumes: VolumeStock[]): Promise<void> {
+async function _createAndCommitReconciliationNote(db: DBAsync, id: number, volumes: VolumeStock[]): Promise<void> {
 	const timestamp = Date.now();
 	const displayName = `Reconciliation note: ${new Date(timestamp).toISOString()}`;
 

--- a/apps/web-client/src/lib/db/cr-sqlite/stock.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/stock.ts
@@ -18,7 +18,7 @@
  * - book table: Contains book metadata
  */
 
-import type { DB, GetStockResponseItem } from "./types";
+import type { TXAsync, GetStockResponseItem } from "./types";
 
 import { timed } from "$lib/utils/timer";
 
@@ -52,7 +52,7 @@ type GetStockParams = {
  *   - Book metadata: title, price, year, authors, etc
  */
 async function _getStock(
-	db: DB,
+	db: TXAsync,
 	{ searchString = "", entries = [], isbns = [], warehouseId }: GetStockParams = {}
 ): Promise<GetStockResponseItem[]> {
 	const filterClauses = [];

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -1,9 +1,6 @@
-/**
- * This is a placeholder as we're not using the generic DB, this might change as we add schema, but trying to keep this as a single source of truth
- */
-import type { DB as _DB } from "@vlcn.io/crsqlite-wasm";
-
 import type { BookData } from "@librocco/shared";
+
+export type { DBAsync, TXAsync } from "./core";
 
 /**
  * Order tables only show a slice of book data => our order lines only need to return relevant cols
@@ -299,10 +296,6 @@ export type GetStockResponseItem = {
 	outOfPrint: boolean;
 	category: string;
 };
-
-/** The type of the DB object passed to sqlite DB.tx transaction callback */
-export type TXAsync = Parameters<Parameters<_DB["tx"]>[0]>[0];
-export type DB = _DB | TXAsync;
 
 /** The transaction returned (thrown) by outbound note commit check - if certin txn will result in negative stock */
 export interface OutOfStockTransaction extends VolumeStock {

--- a/apps/web-client/svelte.config.js
+++ b/apps/web-client/svelte.config.js
@@ -30,7 +30,8 @@ function alias_vlcn_dev() {
 		"@vlcn.io/ws-client/worker.js": "../../3rd-party/js/packages/ws-client/dist/worker/worker.js",
 		"@vlcn.io/ws-client": "../../3rd-party/js/packages/ws-client/dist",
 		"@vlcn.io/ws-common": "../../3rd-party/js/packages/ws-common/dist",
-		"@vlcn.io/ws-server": "../../3rd-party/js/packages/ws-server/dist"
+		"@vlcn.io/ws-server": "../../3rd-party/js/packages/ws-server/dist",
+		"@vlcn.io/xplat-api": "../../3rd-party/js/packages/xplat-api/dist/xplat-api.js"
 	};
 
 	console.log("using submodules: aliasing vlcn.io packages to respective submodules:");

--- a/apps/web-client/vitest.config.ts
+++ b/apps/web-client/vitest.config.ts
@@ -25,7 +25,8 @@ function alias_vlcn_dev() {
 		"@vlcn.io/ws-client/worker.js": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist/worker/worker.js"),
 		"@vlcn.io/ws-client": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist"),
 		"@vlcn.io/ws-common": path.resolve(__dirname, "../../3rd-party/js/packages/ws-common/dist"),
-		"@vlcn.io/ws-server": path.resolve(__dirname, "../../3rd-party/js/packages/ws-server/dist")
+		"@vlcn.io/ws-server": path.resolve(__dirname, "../../3rd-party/js/packages/ws-server/dist"),
+		"@vlcn.io/xplat-api": path.resolve(__dirname, "../../3rd-party/js/packages/xplat-api/dist/xplat-api.js")
 	};
 
 	console.log("submodule test: aliasing vlcn.io packages to respective submodules:");

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -157,11 +157,12 @@
     "@vlcn.io/crsqlite": "file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz",
     "@vlcn.io/crsqlite-wasm": "file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz",
     "@vlcn.io/rx-tbl": "file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz",
+    "@vlcn.io/wa-sqlite": "file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz",
     "@vlcn.io/ws-browserdb": "file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz",
     "@vlcn.io/ws-client": "file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz",
     "@vlcn.io/ws-common": "file:../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz",
     "@vlcn.io/ws-server": "file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz",
-    "@vlcn.io/wa-sqlite": "file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz"
+    "@vlcn.io/xplat-api": "file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz"
   },
 
   /**

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,11 +8,12 @@ overrides:
   '@vlcn.io/crsqlite': file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz
   '@vlcn.io/crsqlite-wasm': file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
   '@vlcn.io/rx-tbl': file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz
+  '@vlcn.io/wa-sqlite': file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
   '@vlcn.io/ws-browserdb': file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
   '@vlcn.io/ws-client': file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz
   '@vlcn.io/ws-common': file:../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz
   '@vlcn.io/ws-server': file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
-  '@vlcn.io/wa-sqlite': file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
+  '@vlcn.io/xplat-api': file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
 
 importers:
 
@@ -86,6 +87,9 @@ importers:
       '@vlcn.io/ws-server':
         specifier: file:../../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
+      '@vlcn.io/xplat-api':
+        specifier: file:../../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
+        version: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
       export-to-csv:
         specifier: ~1.3.0
         version: 1.3.0
@@ -356,7 +360,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ~6.0.11
-        version: 6.0.15(@types/node@16.18.126)
+        version: 6.0.15(tsx@4.19.4)
 
   ../../pkg/scaffold:
     dependencies:
@@ -543,7 +547,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ~6.0.11
-        version: 6.0.15(@types/node@16.18.126)
+        version: 6.0.15(tsx@4.19.4)
 
   ../../plugins/open-library-api:
     devDependencies:
@@ -573,7 +577,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ~6.0.11
-        version: 6.0.15(@types/node@16.18.126)
+        version: 6.0.15(tsx@4.19.4)
 
 packages:
 
@@ -5247,6 +5251,23 @@ packages:
       vite: 6.0.15(tsx@4.19.4)
     dev: true
 
+  /@vitest/mocker@3.0.9(vite@6.0.15):
+    resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      vite: 6.0.15(tsx@4.20.3)
+    dev: true
+
   /@vitest/pretty-format@2.0.5:
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
     dependencies:
@@ -5310,7 +5331,7 @@ packages:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@vitest/browser@3.0.9)(@vitest/ui@3.0.9)(tsx@4.19.4)
+      vitest: 3.0.9(@vitest/ui@3.0.9)(tsx@4.20.3)
     dev: true
 
   /@vitest/utils@2.0.5:
@@ -5343,11 +5364,6 @@ packages:
     dependencies:
       winston: 3.17.0
     dev: false
-
-  /@vlcn.io/xplat-api@0.15.0:
-    resolution: {integrity: sha512-2/aE7VgI3EbIO5EcJGrskAJuCa2pteY1rWNWfhovFKMERe9NhJdlDMIB1I31X0sN/WC2DnF30RqcdTXNfYyzhQ==}
-    dependencies:
-      comlink: 4.4.2
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -13046,7 +13062,7 @@ packages:
     dependencies:
       '@types/node': 16.18.126
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -13111,7 +13127,7 @@ packages:
     dependencies:
       '@vitest/browser': 3.0.9(playwright@1.50.1)(typescript@5.8.3)(vite@6.0.15)(vitest@3.0.9)
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -13175,7 +13191,7 @@ packages:
         optional: true
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -13611,12 +13627,12 @@ packages:
     dev: false
 
   file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz:
-    resolution: {integrity: sha512-ub5aKNz3CaHBfqldIlL0fu9I8M7tF3yx+0FF5l4WA97MzQfbfvqK5PaJlMD49HanNNR518GJ/KNpqIS8RsAOuw==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz}
+    resolution: {integrity: sha512-JFskUyV/aqHypW7kaFcXMmmnifrcUk/Fq7VR35kznEnN/u59888tK3pzhiR4qw4zqMM1tKiB0ZWkmZ8G6k7hCw==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz}
     name: '@vlcn.io/crsqlite-wasm'
     version: 0.16.0
     dependencies:
       '@vlcn.io/wa-sqlite': file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
-      '@vlcn.io/xplat-api': 0.15.0
+      '@vlcn.io/xplat-api': file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
       async-mutex: 0.4.1
 
   file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz:
@@ -13624,16 +13640,16 @@ packages:
     name: '@vlcn.io/rx-tbl'
     version: 0.15.0
     dependencies:
-      '@vlcn.io/xplat-api': 0.15.0
+      '@vlcn.io/xplat-api': file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
     dev: false
 
   file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz:
-    resolution: {integrity: sha512-6SwOK8TnDctAPioh5EGwV74epILqI8rRyz7j/U6e7ZRG6ob1qqHjpXkm3hT51fSLG5qXWs94A/VnIta73041sw==, tarball: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz}
+    resolution: {integrity: sha512-mxe0c3EN3+RWhb9L3Inki30cqNxuJRVXlicm9fG2GkHzlpB7qbOm0kyo8Im2W1w1cMYQzg70noRLJykS1rk1WQ==, tarball: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz}
     name: '@vlcn.io/wa-sqlite'
     version: 0.22.0
 
   file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz:
-    resolution: {integrity: sha512-T8xd50vqQRDGoAP6nG+dRBroq27cdp/sod8m/ZrjMAeE4o3Q34wsecN0y9cCqWNsVbhC2TGJeZgM03zHPcu13Q==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz}
+    resolution: {integrity: sha512-P4YYb9EvzQi87BHPplzWnpcmZMq+lQL6AruozNM5leZ1ETWNdntJ+mUm4MD3+ZHdcdb0EPRvwGclv0QkLNyOag==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz}
     name: '@vlcn.io/ws-browserdb'
     version: 0.2.0
     dependencies:
@@ -13642,7 +13658,7 @@ packages:
       '@vlcn.io/rx-tbl': file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz
       '@vlcn.io/ws-client': file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz
       '@vlcn.io/ws-common': file:../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz
-      '@vlcn.io/xplat-api': 0.15.0
+      '@vlcn.io/xplat-api': file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
     dev: false
 
   file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz:
@@ -13663,7 +13679,7 @@ packages:
     dev: false
 
   file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz:
-    resolution: {integrity: sha512-4zmFuykl3vyZ5x3kGWaQj+t0eLHPnPAUtf/gPrSAKI91a0xRq+W5xBQEVQng50djElgoNBvwGLxfA7HuP6Hl/A==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz}
+    resolution: {integrity: sha512-1F9kqzCe/cAoLc9HJvicIyj28ButkqG4wHuMLdO6EWnis3NtBZnlpQQEbeNLk2gza+LmJ7flOKW1ZFQiW5UsEw==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz}
     name: '@vlcn.io/ws-server'
     version: 0.2.2
     dependencies:
@@ -13680,3 +13696,10 @@ packages:
       - bufferutil
       - utf-8-validate
     dev: false
+
+  file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz:
+    resolution: {integrity: sha512-rdJShMovT3ymtOFcdFZOR0PZZliClXjSZPEFge3QMDdPkN2ZuXYOtGCsuSLMkK/7M/U8uAmZtb8akTPCEjesIg==, tarball: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz}
+    name: '@vlcn.io/xplat-api'
+    version: 0.15.0
+    dependencies:
+      comlink: 4.4.2

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "744c5127c7cc66a2c1a587ad6aefe50013b22f27",
+  "pnpmShrinkwrapHash": "6c1d4e92a6fcd4bd5cf152d30ddcf9da31c2b720",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/scripts/build_vlcn.sh
+++ b/scripts/build_vlcn.sh
@@ -51,6 +51,7 @@ process_package "$VLCN_ROOT/packages/ws-common"
 process_package "$VLCN_ROOT/packages/ws-browserdb"
 process_package "$VLCN_ROOT/packages/ws-server"
 process_package "$VLCN_ROOT/packages/rx-tbl"
+process_package "$VLCN_ROOT/packages/xplat-api"
 process_package "$VLCN_ROOT/deps/cr-sqlite/core"
 process_package "$VLCN_ROOT/deps/wa-sqlite"
 echo '::endgroup::'


### PR DESCRIPTION
* replace 'DB' type with 'DBAsync' and 'TXAsync' interfaces
* make sure the DB operations using 'db.tx' don't accept 'TXAsync' as 'db' type (to avoid nested transactions)

This is part of merging vfs-selection experiment work bit by bit: 
- instead of using ambiguous `DB = _DB | TXAsync`, where `_DB` is a class (implementing `DBAsync`) from `crsqlite-wasm` we're using `DBAsync`
- `DBAsync` is the interface including all relevant methods of `_DB` (without unnecessary details)
- `TXAsync` is the object passed to tx callback:  `txDB` in `(DBAsync).tx(txDB => { ... })`
- slight alteration is made to `TXAsync` we use, omitting the `tx` method (`type TXAsync = Omit<_TXAsync, "tx">`), this is done so that functions running a transaction (internally) can't accept `TXAsync` as parameter (only `DBAsync`) - this ensures we're not nesting transactions
- the folder structure is set up exactly in the way as the upcoming (bit-by-bit) vfs selection effort, laying the groundwork
