### PR TITLE
Create note and warehouse with empty state after deletion

### DIFF
--- a/apps/e2e/helpers/entityList.ts
+++ b/apps/e2e/helpers/entityList.ts
@@ -33,7 +33,8 @@ export function getEntityList(_parent: DashboardNode, view: EntityListView): Ent
 			);
 		}
 
-		if (numBooks) await locator.getByText(`${numBooks} books`).waitFor();
+		if (numBooks === 1) await locator.getByText(`${numBooks} book`).waitFor();
+		if (numBooks > 1) await locator.getByText(`${numBooks} books`).waitFor();
 		if (discount) await locator.getByText(`${discount}% discount`).waitFor();
 		if (totalCoverPrice) await locator.getByText(`Total cover price: ${totalCoverPrice.toFixed(2)}`).waitFor();
 		if (totalDiscountedPrice) await locator.getByText(`Total discounted price: ${totalDiscountedPrice.toFixed(2)}`).waitFor();

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -924,7 +924,7 @@ test("should auto-assign to the available warehouse after a warehouse with stock
 	await entries.assertRows([{ isbn, quantity: 1, warehouseName: "Warehouse 2" }]);
 });
 
-test("should not show transaction after the assigned warehouse is deleted", async ({ page }) => {
+test("should show transaction with no assigned warehouse after the assigned warehouse is deleted", async ({ page }) => {
 	// Setup: Create a transaction and assign it to a warehouse.
 	const dbHandle = await getDbHandle(page);
 	const isbn = "1234567890";
@@ -940,8 +940,8 @@ test("should not show transaction after the assigned warehouse is deleted", asyn
 	// Action: Delete the assigned warehouse.
 	await dbHandle.evaluate(deleteWarehouse, 1);
 
-	// Assertion: Verify the transaction row now does not exist
-	await entries.assertRows([]);
+	// Assertion: Verify the transaction row now has no wh
+	await entries.assertRows([{ isbn, quantity: 1, warehouseName: "" }]);
 });
 
 test("should reset default warehouse selector when the selected warehouse is deleted", async ({ page }) => {

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -926,7 +926,7 @@ test("should auto-assign to the available warehouse after a warehouse with stock
 	await entries.assertRows([{ isbn, quantity: 1, warehouseName: "Warehouse 2" }]);
 });
 
-test("should show no warehouse selected after the assigned warehouse is deleted", async ({ page }) => {
+test("should not show transaction after the assigned warehouse is deleted", async ({ page }) => {
 	// Setup: Create a transaction and assign it to a warehouse.
 	const dbHandle = await getDbHandle(page);
 	const isbn = "1234567890";
@@ -942,8 +942,8 @@ test("should show no warehouse selected after the assigned warehouse is deleted"
 	// Action: Delete the assigned warehouse.
 	await dbHandle.evaluate(deleteWarehouse, 1);
 
-	// Assertion: Verify the transaction row now shows no warehouse selected.
-	await entries.assertRows([{ isbn, quantity: 1, warehouseName: "" }]);
+	// Assertion: Verify the transaction row now does not exist
+	await entries.assertRows([]);
 });
 
 test("should reset default warehouse selector when the selected warehouse is deleted", async ({ page }) => {

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -515,8 +515,7 @@ test(`should check validity of the transactions and commit the note on 'commit'
 	await entries.row(0).field("warehouseName").click({ force: true });
 
 	const dropdown = page.getByTestId("dropdown-menu");
-	await dropdown.locator("button", { hasText: "Force withdrawal" }).waitFor();
-	await dropdown.locator("button", { hasText: "Force withdrawal" }).click({ force: true });
+	await dropdown.getByRole("button", { name: "Force withdrawal" }).click();
 	const forceWithdrawalDialog = page.getByRole("dialog");
 	await forceWithdrawalDialog.locator("#warehouse-force-withdrawal").selectOption({ label: "Warehouse 2" });
 	await forceWithdrawalDialog.getByRole("button", { name: "Confirm" }).click();

--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -512,10 +512,9 @@ test(`should check validity of the transactions and commit the note on 'commit'
 		{ isbn: "11111111", quantity: 3, warehouseName: "Warehouse 1" }
 	]);
 
-	await entries.row(0).field("warehouseName").click({ force: true });
+	await page.getByTestId("dropdown-control").nth(1).click();
 
-	const dropdown = page.getByTestId("dropdown-menu");
-	await dropdown.getByRole("button", { name: "Force withdrawal" }).click();
+	await page.getByRole("button", { name: "Force withdrawal" }).click();
 	const forceWithdrawalDialog = page.getByRole("dialog");
 	await forceWithdrawalDialog.locator("#warehouse-force-withdrawal").selectOption({ label: "Warehouse 2" });
 	await forceWithdrawalDialog.getByRole("button", { name: "Confirm" }).click();

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -84,6 +84,40 @@ test("should delete the warehouse on delete button click (after confirming the p
 	await content.entityList("warehouse-list").assertElements([{ name: "Warehouse 2" }]);
 });
 
+test("should not carry over state from a deleted warehose into a new one", async ({ page }) => {
+	const dashboard = getDashboard(page);
+	const content = dashboard.content();
+	const dbHandle = await getDbHandle(page);
+	const warehouseList = content.entityList("warehouse-list");
+
+	// Create a warehouse and add books to it
+	await dbHandle.evaluate(upsertWarehouse, { id: 1, displayName: "Warehouse 1" });
+	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1 });
+	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "1111111111", quantity: 5, warehouseId: 1 }] as const);
+	await dbHandle.evaluate(commitNote, 1);
+
+	await warehouseList.assertElements([{ name: "Warehouse 1", numBooks: 5 }]);
+
+	// Delete the warehouse
+	await warehouseList.item(0).dropdown().delete();
+	const dialog = dashboard.dialog();
+	await dialog.getByLabel("Confirm by typing warehouse name").fill("warehouse_1");
+	await dialog.confirm();
+	await dialog.waitFor({ state: "detached" });
+
+	// Verify it's gone
+	await warehouseList.assertElement(null, 0);
+
+	// Create a new warehouse
+	await dashboard.getByRole("button", { name: "New warehouse" }).first().click();
+
+	// Navigate back to the list to check the new warehouse
+	await page.getByRole("link", { name: "Manage inventory" }).click();
+	await warehouseList.waitFor();
+
+	// Verify the new warehouse is empty
+	await warehouseList.assertElements([{ name: "New Warehouse", numBooks: 0 }]);
+});
 test("warehouse page: should display breadcrumbs leading back to warehouse page", async ({ page }) => {
 	const dashboard = getDashboard(page);
 

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -111,6 +111,9 @@ test("should not carry over state from a deleted warehose into a new one", async
 	// Create a new warehouse
 	await dashboard.getByRole("button", { name: "New warehouse" }).first().click();
 
+	// check stock is empty
+	await content.table("warehouse").assertRows([]);
+
 	// Navigate back to the list to check the new warehouse
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 	await warehouseList.waitFor();

--- a/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
@@ -1,21 +1,69 @@
 <script lang="ts">
+	import { fade } from "svelte/transition";
+	import { expoInOut } from "svelte/easing";
+	import X from "$lucide/x";
 	import Save from "$lucide/save";
-	import { createEventDispatcher } from "svelte";
 
-	const dispatch = createEventDispatcher<{ cancel: void; confirm: void }>();
+	import { melt } from "@melt-ui/svelte";
+	import type { Dialog } from "@melt-ui/svelte";
+	import { clickOutside } from "$lib/actions";
+
+	export let title: string;
+	export let description: string;
+	export let dialog: Dialog;
+
+	export let onConfirm: () => void;
+	export let onCancel: () => void;
 
 	export let labels: Partial<Record<"cancel" | "confirm", string>> = {};
+
+	const {
+		elements: { portalled, overlay, content, title: titleStore, description: desciptionStore, close },
+		states: { open }
+	} = dialog;
 </script>
 
-<div class="stretch flex w-full gap-x-4 p-6">
-	<div class="basis-fit">
-		<button on:click={() => dispatch("cancel")} class="btn-secondary btn-outline btn-lg btn" type="button">{labels.cancel}</button>
-	</div>
+{#if $open}
+	<div use:melt={$portalled}>
+		<div
+			class="fixed inset-0 z-[200] h-full w-full overflow-y-auto bg-[#000000]/50"
+			transition:fade={{ duration: 250, easing: expoInOut }}
+			use:melt={$overlay}
+		></div>
+		<div
+			class="fixed left-1/2 top-1/2 z-[200] max-h-screen w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto px-4 md:max-w-lg md:px-0"
+			transition:fade={{ duration: 250, easing: expoInOut }}
+			use:melt={$content}
+			use:clickOutside={onCancel}
+		>
+			<div class="modal-box overflow-clip rounded-lg md:shadow-2xl">
+				<div class="flex w-full flex-col justify-between pr-16">
+					{#if title}
+						<div class="prose">
+							<h3 use:melt={$titleStore}>
+								{title}
+							</h3>
+						</div>
+					{/if}
+				</div>
 
-	<div class="grow">
-		<button on:click={() => dispatch("confirm")} class="btn-primary btn-lg btn w-full">
-			<Save aria-hidden="true" focusable="false" size={20} />
-			{labels.confirm}
-		</button>
+				<p class="w-full p-6" use:melt={$desciptionStore}>{description}</p>
+				<button use:melt={$close} on:click={onCancel} class="btn-ghost btn-outline btn-sm btn absolute right-8 top-4" aria-label="Close">
+					<X size={16} />
+				</button>
+
+				<div class="stretch flex w-full gap-x-4 p-6">
+					<div class="basis-fit">
+						<button on:click={onCancel} class="btn-secondary btn-outline btn-lg btn" type="button">{labels.cancel}</button>
+					</div>
+					<div class="grow">
+						<button on:click={onConfirm} class="btn-primary btn-lg btn w-full">
+							<Save aria-hidden="true" focusable="false" size={20} />
+							{labels.confirm}
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
-</div>
+{/if}

--- a/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/ConfirmDialog.svelte
@@ -4,25 +4,8 @@
 
 	const dispatch = createEventDispatcher<{ cancel: void; confirm: void }>();
 
-	export let heading = "";
-	export let description = "";
-
 	export let labels: Partial<Record<"cancel" | "confirm", string>> = {};
 </script>
-
-<div class="flex w-full flex-col justify-between gap-y-6 p-6">
-	{#if heading}
-		<div class="prose">
-			<h3>
-				{heading}
-			</h3>
-		</div>
-	{/if}
-
-	<div class="form-fields w-full"></div>
-</div>
-
-<p class="w-full px-6 pb-6">{description}</p>
 
 <div class="stretch flex w-full gap-x-4 p-6">
 	<div class="basis-fit">

--- a/apps/web-client/src/lib/components/Dialogs/ForceWithdrawalDialog.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/ForceWithdrawalDialog.svelte
@@ -38,7 +38,7 @@
 		</h3>
 		<p>{tOutbound.force_withdrawal_dialog.description()}</p>
 
-		<div class="stretch flex w-full flex-col gap-y-6">
+		<div id="warehouse-force-withdrawal-container" class="stretch flex w-full flex-col gap-y-6">
 			<select id="warehouse-force-withdrawal" bind:value={selectedId} class="select-bordered select w-full">
 				<option value={null} disabled selected>{$LL.misc_components.warehouse_select.default_option()}</option>
 				{#each warehouses as { id, displayName }}

--- a/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
+++ b/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
@@ -33,7 +33,7 @@
 			use:clickOutside={() => dispatch("cancel")}
 		>
 			<div class="modal-box overflow-clip rounded-lg md:shadow-2xl">
-				<div class="flex w-full flex-col justify-between gap-y-6 p-6">
+				<div class="flex w-full flex-col justify-between">
 					{#if title}
 						<div class="prose">
 							<h3 use:melt={$titleStore}>

--- a/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
+++ b/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
@@ -5,13 +5,9 @@
 
 	import { melt } from "@melt-ui/svelte";
 	import type { Dialog } from "@melt-ui/svelte";
-	import { clickOutside } from "$lib/actions";
-	import { createEventDispatcher } from "svelte";
 	export let title: string;
 	export let description: string;
 	export let dialog: Dialog;
-
-	const dispatch = createEventDispatcher<{ cancel: void }>();
 
 	const {
 		elements: { portalled, overlay, content, title: titleStore, description: desciptionStore, close },
@@ -30,20 +26,12 @@
 			class="fixed left-1/2 top-1/2 z-[200] max-h-screen w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto px-4 md:max-w-lg md:px-0"
 			transition:fade={{ duration: 250, easing: expoInOut }}
 			use:melt={$content}
-			use:clickOutside={() => dispatch("cancel")}
 		>
 			<div class="modal-box overflow-clip rounded-lg md:shadow-2xl">
-				<div class="flex w-full flex-col justify-between">
-					{#if title}
-						<div class="prose">
-							<h3 use:melt={$titleStore}>
-								{title}
-							</h3>
-						</div>
-					{/if}
-				</div>
+				<p class="sr-only" use:melt={$titleStore}>{title}</p>
 
-				<p class="w-full px-6 pb-6" use:melt={$desciptionStore}>{description}</p>
+				<p class="sr-only" use:melt={$desciptionStore}>{description}</p>
+
 				<button use:melt={$close} class="btn-ghost btn-outline btn-sm btn absolute right-8 top-4" aria-label="Close">
 					<X size={16} />
 				</button>

--- a/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
+++ b/apps/web-client/src/lib/components/Melt/PageCenterDialog.svelte
@@ -5,9 +5,13 @@
 
 	import { melt } from "@melt-ui/svelte";
 	import type { Dialog } from "@melt-ui/svelte";
+	import { clickOutside } from "$lib/actions";
+	import { createEventDispatcher } from "svelte";
 	export let title: string;
 	export let description: string;
 	export let dialog: Dialog;
+
+	const dispatch = createEventDispatcher<{ cancel: void }>();
 
 	const {
 		elements: { portalled, overlay, content, title: titleStore, description: desciptionStore, close },
@@ -26,12 +30,20 @@
 			class="fixed left-1/2 top-1/2 z-[200] max-h-screen w-full translate-x-[-50%] translate-y-[-50%] overflow-y-auto px-4 md:max-w-lg md:px-0"
 			transition:fade={{ duration: 250, easing: expoInOut }}
 			use:melt={$content}
+			use:clickOutside={() => dispatch("cancel")}
 		>
 			<div class="modal-box overflow-clip rounded-lg md:shadow-2xl">
-				<h2 class="sr-only" use:melt={$titleStore}>{title}</h2>
+				<div class="flex w-full flex-col justify-between gap-y-6 p-6">
+					{#if title}
+						<div class="prose">
+							<h3 use:melt={$titleStore}>
+								{title}
+							</h3>
+						</div>
+					{/if}
+				</div>
 
-				<p class="sr-only" use:melt={$desciptionStore}>{description}</p>
-
+				<p class="w-full px-6 pb-6" use:melt={$desciptionStore}>{description}</p>
 				<button use:melt={$close} class="btn-ghost btn-outline btn-sm btn absolute right-8 top-4" aria-label="Close">
 					<X size={16} />
 				</button>

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -422,7 +422,7 @@ async function _commitNote(db: DBAsync, id: number, { force = false }: { force?:
  * @param {number} id - ID of note to delete
  * @returns {Promise<void>} Resolves when note is deleted
  */
-async function _deleteNote(db: TXAsync, id: number): Promise<void> {
+async function _deleteNote(db: DBAsync, id: number): Promise<void> {
 	const note = await getNoteById(db, id);
 	if (note?.committed) {
 		console.warn("Trying to delete a committed note: this is a noop, but probably indicates a bug in the calling code.");

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -427,7 +427,11 @@ async function _deleteNote(db: DB, id: number): Promise<void> {
 		console.warn("Trying to delete a committed note: this is a noop, but probably indicates a bug in the calling code.");
 		return;
 	}
-	return db.exec("DELETE FROM note WHERE id = ?", [id]);
+	return db.tx(async (db) => {
+		await db.exec("DELETE FROM note WHERE id = ?", [id]);
+		await db.exec("DELETE FROM book_transaction WHERE note_id = ?", [id]);
+		await db.exec("DELETE FROM custom_item WHERE note_id = ?", [id]);
+	});
 }
 
 /**

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -166,8 +166,11 @@ async function _getWarehouseById(db: DB, id: number) {
 	return result;
 }
 
-export function deleteWarehouse(db: DB, id: number) {
-	return db.exec("DELETE FROM warehouse WHERE id = ?", [id]);
+export function deleteWarehouse(db: DB, id: number): Promise<void> {
+	return db.tx(async (txDb) => {
+		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
+		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);
+	});
 }
 
 export const getWarehouseIdSeq = timed(_getWarehouseIdSeq);

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -168,6 +168,7 @@ async function _getWarehouseById(db: TXAsync, id: number) {
 
 export function deleteWarehouse(db: DBAsync, id: number): Promise<void> {
 	return db.tx(async (txDb) => {
+		await txDb.exec("DELETE FROM book_transaction WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);
 	});

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -166,7 +166,7 @@ async function _getWarehouseById(db: TXAsync, id: number) {
 	return result;
 }
 
-export function deleteWarehouse(db: TXAsync, id: number): Promise<void> {
+export function deleteWarehouse(db: DBAsync, id: number): Promise<void> {
 	return db.tx(async (txDb) => {
 		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -168,7 +168,11 @@ async function _getWarehouseById(db: TXAsync, id: number) {
 
 export function deleteWarehouse(db: DBAsync, id: number): Promise<void> {
 	return db.tx(async (txDb) => {
-		await txDb.exec("DELETE FROM book_transaction WHERE warehouse_id = ?", [id]);
+		await txDb.exec("DELETE FROM book_transaction WHERE note_id IN (SELECT id FROM note WHERE warehouse_id = ?)", [id]);
+		await txDb.exec(
+			"UPDATE book_transaction SET warehouse_id = 0 WHERE warehouse_id = ? AND note_id IN (SELECT id FROM note WHERE warehouse_id IS NULL)",
+			[id]
+		);
 		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);
 	});

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -24,7 +24,6 @@
 	import { getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
 	import { InventoryManagementPage } from "$lib/controllers";
 	import LL from "@librocco/shared/i18n-svelte";
-	import PageCenterDialog from "$lib/components/Melt/PageCenterDialog.svelte";
 	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
 
 	export let data: PageData;
@@ -155,21 +154,15 @@
 	{/if}
 </InventoryManagementPage>
 
-<PageCenterDialog
+>
+<ConfirmDialog
 	{dialog}
-	on:cancel={() => {
-		open.set(false);
-		noteToDelete = null;
-	}}
 	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
 	title={$LL.common.delete_dialog.description()}
->
-	<ConfirmDialog
-		on:confirm={() => {
-			handleDeleteNote(noteToDelete.id);
-			noteToDelete = null;
-		}}
-		on:cancel={() => open.set(false)}
-		labels={{ confirm: "Confirm", cancel: "Cancel" }}
-	/>
-</PageCenterDialog>
+	onConfirm={() => {
+		handleDeleteNote(noteToDelete.id);
+		noteToDelete = null;
+	}}
+	onCancel={() => open.set(false)}
+	labels={{ confirm: "Confirm", cancel: "Cancel" }}
+/>

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -64,15 +64,13 @@
 
 	const dialog = createDialog({ forceVisible: true, closeOnOutsideClick: false });
 	const {
-		elements: { portalled, overlay, trigger },
+		elements: { trigger },
 		states: { open }
 	} = dialog;
 	const handleDeleteNote = async (id: number) => {
 		open.set(false);
 		await deleteNote(db, id);
 	};
-
-	let dialogContent: DialogContent;
 </script>
 
 <InventoryManagementPage {handleCreateWarehouse} {db} {plugins}>

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { fade } from "svelte/transition";
 	import { invalidate } from "$app/navigation";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
@@ -63,7 +62,7 @@
 		await goto(appPath("warehouses", id));
 	};
 
-	const dialog = createDialog({ forceVisible: true });
+	const dialog = createDialog({ forceVisible: true, closeOnOutsideClick: false });
 	const {
 		elements: { portalled, overlay, trigger },
 		states: { open }
@@ -144,11 +143,6 @@
 								aria-label="Delete note: {note.displayName}"
 								on:m-click={() => {
 									noteToDelete = note;
-									// dialogContent = {
-									// 	onConfirm: handleDeleteNote(note.id),
-									// 	title: $LL.common.delete_dialog.title({ entity: note.displayName }),
-									// 	description: $LL.common.delete_dialog.description()
-									// };
 								}}
 							>
 								<Trash size={18} aria-hidden />
@@ -162,33 +156,22 @@
 		<!-- End entity list contaier -->
 	{/if}
 </InventoryManagementPage>
-<!--
-{#if $open}
-	{@const { onConfirm, title, description } = dialogContent};
 
-	<div use:melt={$portalled}>
-		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }}></div>
-		<div class="fixed left-[50%] top-[50%] z-50 flex max-w-2xl translate-x-[-50%] translate-y-[-50%]">
-			<Dialog {dialog} type="delete" {onConfirm}>
-				<svelte:fragment slot="title">{title}</svelte:fragment>
-				<svelte:fragment slot="description">{description}</svelte:fragment>
-			</Dialog>
-		</div>
-	</div>
-{/if} -->
-
-<PageCenterDialog {dialog} description="" title="">
+<PageCenterDialog
+	{dialog}
+	on:cancel={() => {
+		open.set(false);
+		noteToDelete = null;
+	}}
+	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
+	title={$LL.common.delete_dialog.description()}
+>
 	<ConfirmDialog
 		on:confirm={() => {
 			handleDeleteNote(noteToDelete.id);
 			noteToDelete = null;
 		}}
-		on:cancel={() => {
-			open.set(false);
-			noteToDelete = null;
-		}}
-		heading={$LL.common.delete_dialog.description()}
-		description={$LL.common.delete_dialog.title({ entity: noteToDelete.displayName })}
+		on:cancel={() => open.set(false)}
 		labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	/>
 </PageCenterDialog>

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -66,8 +66,11 @@
 		elements: { trigger },
 		states: { open }
 	} = dialog;
-	const handleDeleteNote = async (id: number) => {
+	const resetDialogState = () => {
 		open.set(false);
+		noteToDelete = null;
+	};
+	const handleDeleteNote = async (id: number) => {
 		await deleteNote(db, id);
 	};
 </script>
@@ -161,8 +164,8 @@
 	title={$LL.common.delete_dialog.description()}
 	onConfirm={() => {
 		handleDeleteNote(noteToDelete.id);
-		noteToDelete = null;
+		resetDialogState();
 	}}
-	onCancel={() => open.set(false)}
+	onCancel={resetDialogState}
 	labels={{ confirm: "Confirm", cancel: "Cancel" }}
 />

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -32,7 +32,7 @@
 	import { invalidate as invalidateStockCache } from "$lib/db/cr-sqlite/stock_cache";
 
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
-	import { deleteWarehouse, getNotes, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
+	import { deleteWarehouse, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
 	import LL from "@librocco/shared/i18n-svelte";
 
 	import type { PageData } from "./$types";

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -29,9 +29,10 @@
 	import PageCenterDialog from "$lib/components/Melt/PageCenterDialog.svelte";
 	import { InventoryManagementPage } from "$lib/controllers";
 	import { defaultDialogConfig } from "$lib/components/Melt";
+	import { invalidate as invalidateStockCache } from "$lib/db/cr-sqlite/stock_cache";
 
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
-	import { deleteWarehouse, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
+	import { deleteWarehouse, getNotes, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
 	import LL from "@librocco/shared/i18n-svelte";
 
 	import type { PageData } from "./$types";
@@ -49,7 +50,7 @@
 	let disposer: () => void;
 	onMount(() => {
 		// Reload when warehouse data changes
-		disposer = data.dbCtx?.rx?.onRange(["warehouse"], () => invalidate("warehouse:list"));
+		disposer = data.dbCtx?.rx?.onRange(["warehouse", "note", "book_transaction"], () => invalidate("warehouse:list"));
 	});
 	onDestroy(() => {
 		// Unsubscribe on unmount
@@ -62,6 +63,7 @@
 	const handleDeleteWarehouse = (id: number) => async () => {
 		await deleteWarehouse(db, id);
 		deleteDialogOpen.set(false);
+		invalidateStockCache();
 	};
 
 	/**

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -536,12 +536,14 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog dialog={nonUniqueIdDialog} title="" description="">
+<PageCenterDialog
+	dialog={nonUniqueIdDialog}
+	title={$LL.customer_orders_page.dialogs.non_unique_id.title()}
+	description={$LL.customer_orders_page.dialogs.non_unique_id.description()}
+>
 	<ConfirmDialog
 		on:confirm={handleConfirmNonUniqueIdDialog}
 		on:cancel={() => nonUniqueIdDialogOpen.set(false)}
-		heading={$LL.customer_orders_page.dialogs.non_unique_id.title()}
-		description={$LL.customer_orders_page.dialogs.non_unique_id.description()}
 		labels={{ confirm: $LL.common.actions.confirm(), cancel: $LL.common.actions.cancel() }}
 	/>
 </PageCenterDialog>

--- a/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/[id]/+page.svelte
@@ -536,14 +536,11 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog
+<ConfirmDialog
 	dialog={nonUniqueIdDialog}
 	title={$LL.customer_orders_page.dialogs.non_unique_id.title()}
 	description={$LL.customer_orders_page.dialogs.non_unique_id.description()}
->
-	<ConfirmDialog
-		on:confirm={handleConfirmNonUniqueIdDialog}
-		on:cancel={() => nonUniqueIdDialogOpen.set(false)}
-		labels={{ confirm: $LL.common.actions.confirm(), cancel: $LL.common.actions.cancel() }}
-	/>
-</PageCenterDialog>
+	onConfirm={handleConfirmNonUniqueIdDialog}
+	onCancel={() => nonUniqueIdDialogOpen.set(false)}
+	labels={{ confirm: $LL.common.actions.confirm(), cancel: $LL.common.actions.cancel() }}
+/>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -365,23 +365,20 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog
+<ConfirmDialog
 	dialog={confirmationDialog}
 	title={t.dialogs.reassign_publisher.title()}
 	description={t.dialogs.reassign_publisher.description({ publisher: confirmationPublisher, supplier: supplier.name })}
->
-	<ConfirmDialog
-		labels={{
-			confirm: "Confirm",
-			cancel: "Cancel"
-		}}
-		on:confirm={() => {
-			handleAssignPublisher(confirmationPublisher)();
-			confirmationDialogOpen.set(false);
-		}}
-		on:cancel={() => confirmationDialogOpen.set(false)}
-	/>
-</PageCenterDialog>
+	labels={{
+		confirm: "Confirm",
+		cancel: "Cancel"
+	}}
+	onConfirm={() => {
+		handleAssignPublisher(confirmationPublisher)();
+		confirmationDialogOpen.set(false);
+	}}
+	onCancel={() => confirmationDialogOpen.set(false)}
+/>
 
 <style global>
 	:global(html) {

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -365,7 +365,11 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog dialog={confirmationDialog} title="" description="">
+<PageCenterDialog
+	dialog={confirmationDialog}
+	title={t.dialogs.reassign_publisher.title()}
+	description={t.dialogs.reassign_publisher.description({ publisher: confirmationPublisher, supplier: supplier.name })}
+>
 	<ConfirmDialog
 		labels={{
 			confirm: "Confirm",
@@ -376,8 +380,6 @@
 			confirmationDialogOpen.set(false);
 		}}
 		on:cancel={() => confirmationDialogOpen.set(false)}
-		heading={t.dialogs.reassign_publisher.title()}
-		description={t.dialogs.reassign_publisher.description({ publisher: confirmationPublisher, supplier: supplier.name })}
 	/>
 </PageCenterDialog>
 

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
@@ -359,12 +359,10 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog dialog={deleteDialog} title="" description="">
+<PageCenterDialog dialog={deleteDialog} title={t.delete_dialog.title()} description={t.delete_dialog.description()}>
 	<ConfirmDialog
 		on:confirm={handleDelete}
 		on:cancel={() => deleteDialogOpen.set(false)}
-		heading={t.delete_dialog.title()}
-		description={t.delete_dialog.description()}
 		labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	/>
 </PageCenterDialog>

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/+page.svelte
@@ -359,10 +359,11 @@
 	/>
 </PageCenterDialog>
 
-<PageCenterDialog dialog={deleteDialog} title={t.delete_dialog.title()} description={t.delete_dialog.description()}>
-	<ConfirmDialog
-		on:confirm={handleDelete}
-		on:cancel={() => deleteDialogOpen.set(false)}
-		labels={{ confirm: "Confirm", cancel: "Cancel" }}
-	/>
-</PageCenterDialog>
+<ConfirmDialog
+	dialog={deleteDialog}
+	title={t.delete_dialog.title()}
+	description={t.delete_dialog.description()}
+	onConfirm={handleDelete}
+	onCancel={() => deleteDialogOpen.set(false)}
+	labels={{ confirm: "Confirm", cancel: "Cancel" }}
+/>

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -166,7 +166,15 @@
 	</div>
 </Page>
 
-<PageCenterDialog {dialog} description="" title="">
+<PageCenterDialog
+	{dialog}
+	on:cancel={() => {
+		open.set(false);
+		noteToDelete = null;
+	}}
+	title={$LL.common.delete_dialog.description()}
+	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
+>
 	<ConfirmDialog
 		on:confirm={() => {
 			handleDeleteNote(noteToDelete.id);
@@ -176,8 +184,6 @@
 			open.set(false);
 			noteToDelete = null;
 		}}
-		heading={$LL.common.delete_dialog.description()}
-		description={$LL.common.delete_dialog.title({ entity: noteToDelete.displayName })}
 		labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	/>
 </PageCenterDialog>

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
-	import { fade } from "svelte/transition";
 	import { invalidate } from "$app/navigation";
 
 	import { createDialog, melt } from "@melt-ui/svelte";
@@ -19,8 +18,6 @@
 
 	import { PlaceholderBox, Dialog } from "$lib/components";
 	import { Page } from "$lib/controllers";
-
-	import { type DialogContent } from "$lib/types";
 
 	import { generateUpdatedAtString } from "$lib/utils/time";
 
@@ -72,7 +69,6 @@
 	} = dialog;
 
 	let noteToDelete = null;
-	let dialogContent: DialogContent | null = null;
 	$: tOutboundPage = $LL.sale_page;
 	$: tPages = $LL.page_headings;
 </script>
@@ -172,8 +168,14 @@
 
 <PageCenterDialog {dialog} description="" title="">
 	<ConfirmDialog
-		on:confirm={() => handleDeleteNote(noteToDelete.id)}
-		on:cancel={() => open.set(false)}
+		on:confirm={() => {
+			handleDeleteNote(noteToDelete.id);
+			noteToDelete = null;
+		}}
+		on:cancel={() => {
+			open.set(false);
+			noteToDelete = null;
+		}}
 		heading={$LL.common.delete_dialog.description()}
 		description={$LL.common.delete_dialog.title({ entity: noteToDelete.displayName })}
 		labels={{ confirm: "Confirm", cancel: "Cancel" }}

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -46,8 +46,12 @@
 	let initialized = false;
 	$: initialized = Boolean(db);
 
-	const handleDeleteNote = async (id: number) => {
+	const resetDialogState = () => {
 		open.set(false);
+		noteToDelete = null;
+	};
+
+	const handleDeleteNote = async (id: number) => {
 		await deleteNote(db, id);
 	};
 
@@ -169,12 +173,9 @@
 	{dialog}
 	onConfirm={() => {
 		handleDeleteNote(noteToDelete.id);
-		noteToDelete = null;
+		resetDialogState();
 	}}
-	onCancel={() => {
-		open.set(false);
-		noteToDelete = null;
-	}}
+	onCancel={resetDialogState}
 	labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	title={$LL.common.delete_dialog.description()}
 	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -27,6 +27,8 @@
 	import { appPath } from "$lib/paths";
 	import { createOutboundNote, deleteNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import LL from "@librocco/shared/i18n-svelte";
+	import PageCenterDialog from "$lib/components/Melt/PageCenterDialog.svelte";
+	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
 
 	export let data: PageData;
 
@@ -48,9 +50,9 @@
 	let initialized = false;
 	$: initialized = Boolean(db);
 
-	const handleDeleteNote = (id: number) => async (closeDialog: () => void) => {
+	const handleDeleteNote = async (id: number) => {
+		open.set(false);
 		await deleteNote(db, id);
-		closeDialog();
 	};
 
 	/**
@@ -63,12 +65,13 @@
 		await goto(appPath("outbound", id));
 	};
 
-	const dialog = createDialog({ forceVisible: true });
+	const dialog = createDialog();
 	const {
 		elements: { portalled, overlay, trigger },
 		states: { open }
 	} = dialog;
 
+	let noteToDelete = null;
 	let dialogContent: DialogContent | null = null;
 	$: tOutboundPage = $LL.sale_page;
 	$: tPages = $LL.page_headings;
@@ -149,11 +152,7 @@
 									class="btn-secondary btn-sm btn"
 									aria-label="Delete note: {note.displayName}"
 									on:m-click={() => {
-										dialogContent = {
-											onConfirm: handleDeleteNote(note.id),
-											title: $LL.common.delete_dialog.title({ entity: note.displayName }),
-											description: $LL.common.delete_dialog.description()
-										};
+										noteToDelete = note;
 									}}
 								>
 									<span aria-hidden="true">
@@ -171,15 +170,12 @@
 	</div>
 </Page>
 
-{#if $open}
-	{@const { onConfirm, title, description } = dialogContent};
-	<div use:melt={$portalled}>
-		<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50" transition:fade|global={{ duration: 100 }}></div>
-		<div class="fixed left-[50%] top-[50%] z-50 translate-x-[-50%] translate-y-[-50%]">
-			<Dialog {dialog} type="delete" {onConfirm}>
-				<svelte:fragment slot="title">{title}</svelte:fragment>
-				<svelte:fragment slot="description">{description}</svelte:fragment>
-			</Dialog>
-		</div>
-	</div>
-{/if}
+<PageCenterDialog {dialog} description="" title="">
+	<ConfirmDialog
+		on:confirm={() => handleDeleteNote(noteToDelete.id)}
+		on:cancel={() => open.set(false)}
+		heading={$LL.common.delete_dialog.description()}
+		description={$LL.common.delete_dialog.title({ entity: noteToDelete.displayName })}
+		labels={{ confirm: "Confirm", cancel: "Cancel" }}
+	/>
+</PageCenterDialog>

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -24,7 +24,6 @@
 	import { appPath } from "$lib/paths";
 	import { createOutboundNote, deleteNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import LL from "@librocco/shared/i18n-svelte";
-	import PageCenterDialog from "$lib/components/Melt/PageCenterDialog.svelte";
 	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
 
 	export let data: PageData;
@@ -166,24 +165,17 @@
 	</div>
 </Page>
 
-<PageCenterDialog
+<ConfirmDialog
 	{dialog}
-	on:cancel={() => {
+	onConfirm={() => {
+		handleDeleteNote(noteToDelete.id);
+		noteToDelete = null;
+	}}
+	onCancel={() => {
 		open.set(false);
 		noteToDelete = null;
 	}}
+	labels={{ confirm: "Confirm", cancel: "Cancel" }}
 	title={$LL.common.delete_dialog.description()}
 	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
->
-	<ConfirmDialog
-		on:confirm={() => {
-			handleDeleteNote(noteToDelete.id);
-			noteToDelete = null;
-		}}
-		on:cancel={() => {
-			open.set(false);
-			noteToDelete = null;
-		}}
-		labels={{ confirm: "Confirm", cancel: "Cancel" }}
-	/>
-</PageCenterDialog>
+/>


### PR DESCRIPTION
- Use PageCenterDialog instead because old dialog caused a blank page to load when trying to navigate to a different page after deleting a note
- I added the bug in the delete note test case but to be honest it wasn't failing in the first place not sure why
- Delete notes associated with deleted warehouses and add test case

Fixes #1038
