### PR TITLE
Sort warehouse displayNames by length first then by displayName

### DIFF
--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -180,13 +180,20 @@ test("should continue the naming sequence from the highest sequenced warehouse n
 
 	// Verify final warehouse names
 	await page.getByRole("link", { name: "Manage inventory" }).click();
+	// assert for warehouses > 10
+	await dbHandle.evaluate(upsertWarehouse, { id: 10, displayName: "New Warehouse (10)" });
+	await dashboard.getByRole("button", { name: "New warehouse" }).first().click();
+	await header.title().assert("New Warehouse (11)");
+	await page.getByRole("link", { name: "Manage inventory" }).click();
 
 	await warehouseList.assertElements([
 		{ name: "Warehouse 1" },
 		{ name: "Warehouse 2" },
 		{ name: "Warehouse 3" },
 		{ name: "Warehouse 4" },
-		{ name: "New Warehouse" }
+		{ name: "New Warehouse" },
+		{ name: "New Warehouse (10)" },
+		{ name: "New Warehouse (11)" }
 	]);
 });
 

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -38,12 +38,12 @@ const getSeqName = async (db: TXAsync): Promise<string> => {
 	const sequenceQuery = `
 			SELECT display_name AS displayName FROM warehouse
 			WHERE displayName LIKE 'New Warehouse%'
-			ORDER BY displayName DESC
+			ORDER BY LENGTH(displayName) DESC, displayName DESC
 			LIMIT 1;
 		`;
 	const result = await db.execO<{ displayName?: string }>(sequenceQuery);
 	const displayName = result[0]?.displayName;
-
+	console.log({ displayName });
 	if (!displayName) {
 		return "New Warehouse";
 	}
@@ -53,7 +53,7 @@ const getSeqName = async (db: TXAsync): Promise<string> => {
 	}
 
 	const maxSequence = Number(displayName.replace("New Warehouse", "").replace("(", "").replace(")", "").trim()) + 1;
-
+	console.log({ maxSequence });
 	return `New Warehouse (${maxSequence})`;
 };
 


### PR DESCRIPTION
- names containing larger numbers need to be identified as being greater than those with smaller numbers, so getSeqName needs to sort warehouse displayNames by length first then by displayName
- include warehouse name > 10 in test case