### PR TITLE
Refactor/e2e table helpers

### DIFF
--- a/apps/e2e/helpers/types.ts
+++ b/apps/e2e/helpers/types.ts
@@ -230,7 +230,16 @@ export type HistoryRowInterface = DashboardNode<{
 	assertFields(row: Partial<DisplayRow>, opts?: AssertRowFieldsOpts): Promise<void>;
 }>;
 
-export interface InventoryWarehouseNameField extends AssertedLocator<string>, Asserter<string>, Setter<string>, Locator {
+export type IWarehouseName = {
+	name: string;
+	forced: boolean;
+};
+
+export interface InventoryWarehouseNameField
+	extends AssertedLocator<string | IWarehouseName>,
+		Asserter<string | IWarehouseName>,
+		Setter<string | IWarehouseName>,
+		Locator {
 	assertOptions(options: string[], opts?: WaitForOpts): Promise<void>;
 }
 

--- a/apps/e2e/helpers/types.ts
+++ b/apps/e2e/helpers/types.ts
@@ -230,29 +230,29 @@ export type HistoryRowInterface = DashboardNode<{
 	assertFields(row: Partial<DisplayRow>, opts?: AssertRowFieldsOpts): Promise<void>;
 }>;
 
-export interface InventoryWarehouseNameField extends AsserterSetter<string>, Locator {
+export interface InventoryWarehouseNameField extends AssertedLocator<string>, Asserter<string>, Setter<string>, Locator {
 	assertOptions(options: string[], opts?: WaitForOpts): Promise<void>;
 }
 
 export interface InventoryFieldLookup {
-	isbn: Asserter<string>;
-	title: Asserter<string>;
-	authors: Asserter<string>;
-	quantity: AsserterSetter<number>;
-	year: Asserter<string>;
-	publisher: Asserter<string>;
-	price: Asserter<number | string | IBookPrice>;
+	isbn: Asserter<string> & AssertedLocator<string>;
+	title: Asserter<string> & AssertedLocator<string>;
+	authors: Asserter<string> & AssertedLocator<string>;
+	quantity: Asserter<number> & Setter<number> & AssertedLocator<number>;
+	year: Asserter<string> & AssertedLocator<string>;
+	publisher: Asserter<string> & AssertedLocator<string>;
+	price: Asserter<number | string | IBookPrice> & AssertedLocator<number | string | IBookPrice>;
 	warehouseName: InventoryWarehouseNameField;
-	editedBy: Asserter<string>;
-	outOfPrint: Asserter<boolean>;
-	category: Asserter<string>;
-	type: Asserter<string>;
+	editedBy: Asserter<string> & AssertedLocator<string>;
+	outOfPrint: Asserter<boolean> & AssertedLocator<boolean>;
+	category: Asserter<string> & AssertedLocator<string>;
+	type: Asserter<string> & AssertedLocator<string>;
 }
 export interface HistoryFieldLookup {
 	isbn: Asserter<string>;
 	title: Asserter<string>;
 	authors: Asserter<string>;
-	quantity: AsserterSetter<number>;
+	quantity: Asserter<number> & Setter<number>;
 	warehouseName: Asserter<string>;
 	noteName: Locator & Asserter<string>;
 	committedAt: Asserter<string | Date>;
@@ -311,11 +311,30 @@ export interface Asserter<T> {
 	assert(value: T, opts?: WaitForOpts): Promise<void>;
 }
 
-interface Setter<T> {
-	set: (value: T) => Promise<void>;
+export interface AssertedLocator<T> {
+	/**
+	 * Createa s locator with assertion information (some expected value or text),
+	 * this should be used within a `.filter()` method to construct a composite matcher (locator)
+	 * for a row as a whole, e.g.:
+	 * ```ts`
+	 *  // matching a row with:
+	 *  // - isbn: "123456789"
+	 *  // - title: "Some Book Title"
+	 *  const row = table.row(0)
+	 *  const matcher = row
+	 *    .filter({ has: row.field("isbn").assertedLocator(page, "123456789") })
+	 *    .filter({ has: row.field("title").assertedLocator(page, "Some Book Title") })
+	 * ```
+	 * @param {Page} page - Playwright page instance -- this is used as nested locators (within filter)
+	 *   are already relative to the container.filter(...) element, and as such should be chained off of page interface (not the container)
+	 * @param {T} value - The expected value to assert against the locator.
+	 */
+	assertedLocator(page: Page, value: T): Locator;
 }
 
-type AsserterSetter<T> = Asserter<T> & Setter<T>;
+export interface Setter<T> {
+	set: (value: T) => Promise<void>;
+}
 
 export interface FieldConstructor<L extends Record<string, any>, K extends keyof L> {
 	(parent: DashboardNode, view: TableView): L[K];

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/BookQuantityFormCell.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/BookQuantityFormCell.svelte
@@ -10,6 +10,7 @@
 		name="quantity"
 		id="quantity"
 		value={quantity}
+		data-value={quantity}
 		class="border-base w-full rounded border bg-transparent px-2 py-1.5 text-center focus:border-primary focus:ring-0"
 		type="number"
 		min="1"


### PR DESCRIPTION
This aims to reduce an aspect of flakiness of e2e tests (related to inventory table).

The main idea is to, instead of using highly asynchronous matching, match whole rows.

The former code would expand to something like this:
```ts
// Match row
const row = page.locator("table").locator("row") // Just an example
await Promise.all([
  expect(row.nth(0).locator(`[data-property="isbn"]`)).toHaveText("1234567890") // assertion 1
  expect(row.nth(0).locator(`[data-property="warehouseName"]`)).toHaveText("Warehouse 1") // assertion 2
  expect(row.nth(1).locator(`[data-property="isbn"]`)).toHaveText("0987654321") // assertion 3
  expect(row.nth(1).locator(`[data-property="warehouseName"]`)).toHaveText("Warehouse 1") // assertion 4
])
```

Now all of those assertions are dispatched asynchronously, allowing for something like this:
- have a row: `{ isbn: "0987654321", warehouseName: "Warehouse 1"  }`
- before the next row is added assertion 2 had (already) passed
- add a row `{ isbn: "1234567890", warehouseName: "Warehouse 2" }` 
- this moves the row 1 one below and adds row 2 on top of it resulting in rows:
  - `{ isbn: "1234567890", warehouseName: "Warehouse 2" }` 
  - `{ isbn: "0987654321", warehouseName: "Warehouse 1"  }`
- by assertions 1, 3 and 4 this is valid, while it should fail assertion 2, it had already been resolved

All of this results in flakiness. The solution here is to match whole rows, like so:
```ts
// Match row
const row = page.locator("table").locator("row") // Just an example

await row.nth(0)
  .filter({ has page.locator(`[data-property="isbn"]`, { hasText: "1234567890" }) })
  .filter({ has page.locator(`[data-property="warehouseName"]`, { hasText: "Warehouse 1" }) })
  .waitFor()

await row.nth(1)
  .filter({ has page.locator(`[data-property="isbn"]`, { hasText: "0987654321" }) })
  .filter({ has page.locator(`[data-property="warehouseName"]`, { hasText: "Warehouse 1" }) })
  .waitFor()
```

Now if we replay the example above:
- the 1st row wouldn't get matched before it has isbn "12345678990" (and not at all since the combination of "1234567890" and warehousName "Warehouse 1" never appear together - thus reducing the flakiness.

**WARNING:** This PR finds some errors in e2e tests (previously flaky) and makes them permanent, resulting in red CI. Do we want to merge it now, or with the fix?


