### PR TITLE
fix artifact name conflicts in playwright-matrix e2e

### DIFF
--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -41,6 +41,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.dummy1 }}-${{ matrix.dummy2 }}
           path: apps/e2e/test-results
           retention-days: 30

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -59,6 +59,6 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: playwright-test-results
+        name: playwright-test-results-${{ matrix.dummy1 }}-${{ matrix.dummy2 }}
         path: apps/e2e/test-results
         retention-days: 30


### PR DESCRIPTION
This wasn't an issue so far (idk why), but it fixes it:

Upload artifact@v4 job would fail in playwright CI as reports have the same artifact name, [see here](https://github.com/librocco/librocco/actions/runs/17127133644/job/48610034150)
