### PR TITLE
move the submodules to stable wa-sqlite fix:

### DIFF
--- a/3rd-party/artefacts/.gitattributes
+++ b/3rd-party/artefacts/.gitattributes
@@ -7,4 +7,3 @@ vlcn.io-ws-server-0.2.2.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-wa-sqlite-0.22.0.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-ws-client-0.2.0.tgz filter=lfs diff=lfs merge=lfs -text
 vlcn.io-xplat-api-0.15.0.tgz filter=lfs diff=lfs merge=lfs -text
-sqlite-version-3.50.1.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/scripts/build_vlcn.sh
+++ b/scripts/build_vlcn.sh
@@ -8,9 +8,6 @@ TRD_PARTY="$SCRIPT_DIR/../3rd-party"
 VLCN_ROOT="$TRD_PARTY/js"
 ARTEFACTS_DIR="$TRD_PARTY/artefacts"
 
-SQLITE_VERSION="version-3.50.1"
-export SQLITE_SRC_TARBALL="$ARTEFACTS_DIR/sqlite-$SQLITE_VERSION.tar.gz"
-
 cd $SCRIPT_DIR/..
 
 # 2. Check if npx is installed


### PR DESCRIPTION
* point wa-sqlite to the latest commit (incl. fix to the broken SQLite download link)
* no additional tarball passing build process
* remove the tarball from git lfs tracked files

Undoes #1081 (with officially supported approach)
