### PR TITLE
Fix/skip lfs in ci

### DIFF
--- a/.github/workflow.templates/github.lib.yml
+++ b/.github/workflow.templates/github.lib.yml
@@ -3,7 +3,7 @@ name: Checkout repository and submodules
 uses: actions/checkout@v4
 with:
   submodules: "recursive"
-  lfs: true
+  lfs: false
   #@ if deep!=None:
   fetch-depth: 0  #! Enables full clone, with all history
   #@ end

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -26,20 +26,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
+          lfs: false
           fetch-depth: 0 #! We need all the history to check artifact date
-      - name: Compute desired compiled artifact version
-        run: ./scripts/compute_artefacts_version.sh #! This will inform the cache to load the correct artefacts
-      - name: Cache cr-sqlite artefacts
-        uses: actions/cache@v4
-        with:
-          path: 3rd-party/artefacts
-          key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
       - name: Test if artefacts are stale
         id: ts
         shell: bash
-        #! The script will output either `rebuild=yes` or `rebuild=no` on stdout
-        run: scripts/compare_artefacts_version.sh >> "$GITHUB_OUTPUT"
+        #! TEMP fix: always output 'yes' (not using git lfs atm so we're forcing the build of artefacts at each run)
+        run: echo "rebuild=yes" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         if: steps.ts.outputs.rebuild == 'yes'
         with:

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -121,9 +121,9 @@ jobs:
           retention-days: 2
 
   lint-and-typecheck:
-    needs: build-cr-sqlite
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     permissions:
       id-token: write
       contents: read
@@ -133,6 +133,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      -  #@ load_artefacts()
+      -  #@ load_cached_artefacts()
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_install()
@@ -147,6 +149,7 @@ jobs:
   check-i18n-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     permissions:
       id-token: write
       contents: read
@@ -156,6 +159,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      -  #@ load_artefacts()
+      -  #@ load_cached_artefacts()
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_install()
@@ -166,11 +171,14 @@ jobs:
   perform-monorepo-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     steps:
       -  #@ checkout()
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      -  #@ load_artefacts()
+      -  #@ load_cached_artefacts()
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_install()

--- a/.github/workflows/ci-debug.yml
+++ b/.github/workflows/ci-debug.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -274,9 +274,9 @@ jobs:
         path: apps/e2e/blob-report
         retention-days: 2
   lint-and-typecheck:
-    needs: build-cr-sqlite
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     permissions:
       id-token: write
       contents: read
@@ -290,6 +290,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
+    - uses: actions/download-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts
+      if: ${{ !cancelled() && needs.build-cr-sqlite.outputs.rebuild == 'yes' }}
+    - name: Load cached cr-sqlite artefacts
+      uses: actions/cache/restore@v4
+      with:
+        path: 3rd-party/artefacts
+        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
     - name: Cache node modules
       uses: actions/cache@v4
       with:
@@ -313,6 +323,7 @@ jobs:
   check-i18n-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     permissions:
       id-token: write
       contents: read
@@ -326,6 +337,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
+    - uses: actions/download-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts
+      if: ${{ !cancelled() && needs.build-cr-sqlite.outputs.rebuild == 'yes' }}
+    - name: Load cached cr-sqlite artefacts
+      uses: actions/cache/restore@v4
+      with:
+        path: 3rd-party/artefacts
+        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
     - name: Cache node modules
       uses: actions/cache@v4
       with:
@@ -346,6 +367,7 @@ jobs:
   perform-monorepo-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: build-cr-sqlite
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v4
@@ -355,6 +377,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
+    - uses: actions/download-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts
+      if: ${{ !cancelled() && needs.build-cr-sqlite.outputs.rebuild == 'yes' }}
+    - name: Load cached cr-sqlite artefacts
+      uses: actions/cache/restore@v4
+      with:
+        path: 3rd-party/artefacts
+        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
     - name: Cache node modules
       uses: actions/cache@v4
       with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -15,19 +15,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
         fetch-depth: 0
-    - name: Compute desired compiled artifact version
-      run: ./scripts/compute_artefacts_version.sh
-    - name: Cache cr-sqlite artefacts
-      uses: actions/cache@v4
-      with:
-        path: 3rd-party/artefacts
-        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
     - name: Test if artefacts are stale
       id: ts
       shell: bash
-      run: scripts/compare_artefacts_version.sh >> "$GITHUB_OUTPUT"
+      run: echo "rebuild=yes" >> "$GITHUB_OUTPUT"
     - uses: actions/setup-node@v4
       if: steps.ts.outputs.rebuild == 'yes'
       with:
@@ -80,7 +73,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -134,7 +127,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -181,7 +174,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -235,7 +228,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -293,7 +286,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -329,7 +322,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -358,7 +351,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -388,7 +381,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
@@ -462,7 +455,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        lfs: true
+        lfs: false
     - uses: actions/setup-node@v4
       with:
         node-version: "20"


### PR DESCRIPTION
TEMP fix for issue with `git lfs`: **Don't use git lfs at all!**

**NOTE:** CI is excruciatingly slow **on each run**, but at least it works

This quick fix makes the `build-cr-sqlite` job run **at every CI run**

There are, of course, possible improvements, e.g.:
- utilise `make` to build `3rd-party/artefacts` (if there don't do anything, if not, build them)
- cache the artefacts based on `js` submodule hash (will get restored before the `make` step, so make won't do anything...unless they need to be rebuilt)

However, this is another unit of work, the goal of this was to make the CI work and not block us completely
