### PR TITLE
run build-cr-sqlite on playwright-matrix as well:

### DIFF
--- a/.github/workflow.templates/build-crsqlite.lib.yml
+++ b/.github/workflow.templates/build-crsqlite.lib.yml
@@ -1,0 +1,60 @@
+#@ def build_crsqlite():
+runs-on: ubuntu-latest
+permissions:
+  contents: write
+outputs:
+  rebuild: ${{ steps.ts.outputs.rebuild }}
+steps:
+  - uses: actions/checkout@v4
+    with:
+      submodules: recursive
+      lfs: false
+      fetch-depth: 0 #! We need all the history to check artifact date
+  - name: Test if artefacts are stale
+    id: ts
+    shell: bash
+    #! TEMP fix: always output 'yes' (not using git lfs atm so we're forcing the build of artefacts at each run)
+    run: echo "rebuild=yes" >> "$GITHUB_OUTPUT"
+  - uses: actions/setup-node@v4
+    if: steps.ts.outputs.rebuild == 'yes'
+    with:
+      node-version: "20"
+  - name: Install Rust 1.85.0
+    if: steps.ts.outputs.rebuild == 'yes'
+    #! I was getting this:
+    #! error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+    #! and for now I decided to downgrade rust instead of upgrading wasm-bindgen
+    uses: actions-rs/toolchain@v1
+    with:
+      toolchain: 1.85.0
+      override: true
+  - name: install wasm-pack
+    if: steps.ts.outputs.rebuild == 'yes'
+    run: cargo install wasm-pack
+  - name: install pnpm
+    if: steps.ts.outputs.rebuild == 'yes'
+    run: npm install -g 'pnpm@<9'
+  - name: Build cr-sqlite
+    if: steps.ts.outputs.rebuild == 'yes'
+    run: ./scripts/build_vlcn.sh
+  - name: Check that the build went fine
+    #! Let's leave this without an `if`: it won't hurt and might help debugging
+    run: git status; ls -l 3rd-party/artefacts/
+  - name: upload to later jobs
+    if: steps.ts.outputs.rebuild == 'yes'
+    uses: actions/upload-artifact@v4
+    with:
+      name: built-vlcn-artefacts
+      path: 3rd-party/artefacts/
+  - name: Mark cached version
+    run: cp 3rd-party/artefacts_version.txt 3rd-party/artefacts/version-cached.txt
+  - name: Commit updated assets
+    if: github.ref == 'refs/heads/compile-assets'
+    run: bash scripts/commit-artefacts.sh
+  - name: Push changes
+    if: github.ref == 'refs/heads/compile-assets'
+    uses: ad-m/github-push-action@master
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      branch: compile-assets
+#@ end

--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -6,6 +6,7 @@
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
 #@ load("test-job.lib.yml", "test_job")
+#@ load("build-crsqlite.lib.yml", "build_crsqlite")
 
 name: Checks
 
@@ -16,65 +17,7 @@ name: Checks
       - "wip/**"
 
 jobs:
-  build-cr-sqlite:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      rebuild: ${{ steps.ts.outputs.rebuild }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          lfs: false
-          fetch-depth: 0 #! We need all the history to check artifact date
-      - name: Test if artefacts are stale
-        id: ts
-        shell: bash
-        #! TEMP fix: always output 'yes' (not using git lfs atm so we're forcing the build of artefacts at each run)
-        run: echo "rebuild=yes" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v4
-        if: steps.ts.outputs.rebuild == 'yes'
-        with:
-          node-version: "20"
-      - name: Install Rust 1.85.0
-        if: steps.ts.outputs.rebuild == 'yes'
-        #! I was getting this:
-        #! error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
-        #! and for now I decided to downgrade rust instead of upgrading wasm-bindgen
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.85.0
-          override: true
-      - name: install wasm-pack
-        if: steps.ts.outputs.rebuild == 'yes'
-        run: cargo install wasm-pack
-      - name: install pnpm
-        if: steps.ts.outputs.rebuild == 'yes'
-        run: npm install -g 'pnpm@<9'
-      - name: Build cr-sqlite
-        if: steps.ts.outputs.rebuild == 'yes'
-        run: ./scripts/build_vlcn.sh
-      - name: Check that the build went fine
-        #! Let's leave this without an `if`: it won't hurt and might help debugging
-        run: git status; ls -l 3rd-party/artefacts/
-      - name: upload to later jobs
-        if: steps.ts.outputs.rebuild == 'yes'
-        uses: actions/upload-artifact@v4
-        with:
-          name: built-vlcn-artefacts
-          path: 3rd-party/artefacts/
-      - name: Mark cached version
-        run: cp 3rd-party/artefacts_version.txt 3rd-party/artefacts/version-cached.txt
-      - name: Commit updated assets
-        if: github.ref == 'refs/heads/compile-assets'
-        run: bash scripts/commit-artefacts.sh
-      - name: Push changes
-        if: github.ref == 'refs/heads/compile-assets'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: compile-assets
+  build-cr-sqlite: #@ build_crsqlite()
 
   js-search-test: #@ test_job("JS-Search Tests", "pkg/js-search", "jest-junit")
 

--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -1,8 +1,11 @@
 #@ load("github.lib.yml", "checkout")
+#@ load("github.lib.yml", "load_artefacts")
 #@ load("cache.lib.yml", "cache_node")
+#@ load("cache.lib.yml", "load_cached_artefacts")
 #@ load("rush.lib.yml", "rush_add_path")
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
+#@ load("build-crsqlite.lib.yml", "build_crsqlite")
 
 name: PlaywrightMatrix
 
@@ -15,9 +18,12 @@ name: PlaywrightMatrix
     - cron: "30 5 * * 1,3"
 
 jobs:
+  build-cr-sqlite: #@ build_crsqlite()
+
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: build-cr-sqlite
     strategy:
       fail-fast: false
       matrix:
@@ -28,6 +34,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      -  #@ load_artefacts()
+      -  #@ load_cached_artefacts()
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_install()

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -6,9 +6,64 @@ name: PlaywrightMatrix
   schedule:
   - cron: 30 5 * * 1,3
 jobs:
+  build-cr-sqlite:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      rebuild: ${{ steps.ts.outputs.rebuild }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: false
+        fetch-depth: 0
+    - name: Test if artefacts are stale
+      id: ts
+      shell: bash
+      run: echo "rebuild=yes" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-node@v4
+      if: steps.ts.outputs.rebuild == 'yes'
+      with:
+        node-version: "20"
+    - name: Install Rust 1.85.0
+      if: steps.ts.outputs.rebuild == 'yes'
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.85.0
+        override: true
+    - name: install wasm-pack
+      if: steps.ts.outputs.rebuild == 'yes'
+      run: cargo install wasm-pack
+    - name: install pnpm
+      if: steps.ts.outputs.rebuild == 'yes'
+      run: npm install -g 'pnpm@<9'
+    - name: Build cr-sqlite
+      if: steps.ts.outputs.rebuild == 'yes'
+      run: ./scripts/build_vlcn.sh
+    - name: Check that the build went fine
+      run: git status; ls -l 3rd-party/artefacts/
+    - name: upload to later jobs
+      if: steps.ts.outputs.rebuild == 'yes'
+      uses: actions/upload-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts/
+    - name: Mark cached version
+      run: cp 3rd-party/artefacts_version.txt 3rd-party/artefacts/version-cached.txt
+    - name: Commit updated assets
+      if: github.ref == 'refs/heads/compile-assets'
+      run: bash scripts/commit-artefacts.sh
+    - name: Push changes
+      if: github.ref == 'refs/heads/compile-assets'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: compile-assets
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: build-cr-sqlite
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +90,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: "20"
+    - uses: actions/download-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts
+      if: ${{ !cancelled() && needs.build-cr-sqlite.outputs.rebuild == 'yes' }}
+    - name: Load cached cr-sqlite artefacts
+      uses: actions/cache/restore@v4
+      with:
+        path: 3rd-party/artefacts
+        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
     - name: Cache node modules
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
* extract build_crsqlite as its own workflow template
* run build_crqlite before playwright matrix jobs

