### PR TITLE
Allow search by customer id

### DIFF
--- a/apps/web-client/src/routes/orders/customers/+page.svelte
+++ b/apps/web-client/src/routes/orders/customers/+page.svelte
@@ -51,7 +51,8 @@
 	$: filteredOrders = customerOrders.filter((order) => {
 		if (!$search) return true;
 
-		return matchesName($search, order.fullname);
+		// Match by exact customer ID (displayId) or by name
+		return order.displayId === $search || matchesName($search, order.fullname);
 	});
 
 	$: tableStore.set(filteredOrders.slice(0, maxResults));


### PR DESCRIPTION
Fixes #1099 

Adds a simple condition to customer search. We compare the full search term to each customer id, instead of matching on a substring, since we might want to search `4` but don't want entries in the `4000`-`4999` range to show up.