### PR TITLE
small fix: account for undefined vfs when starting a sync worker:

### DIFF
--- a/apps/web-client/src/lib/workers/WorkerInterface.ts
+++ b/apps/web-client/src/lib/workers/WorkerInterface.ts
@@ -48,6 +48,11 @@ export default class WorkerInterface extends WI {
 	}
 
 	start(vfs: VFSWhitelist) {
+		if (!vfs) {
+			console.warn("[worker] No VFS specified, noop -- worker not started");
+			return;
+		}
+
 		this._sendMessage({
 			_type: "start",
 			payload: { vfs }


### PR DESCRIPTION
* 'dbCtx.vfs' -> 'dbCtx?.vfs' guard in 'onMount' block
* update sync worker to noop with warning if vfs undefined

In case of predictable error:
- DB corrupted
- DB version mismatch
the `dbCtx` won't be defined (so `dbCtx.vfs` throws an error)

Apply the fixes mentioned at the top of the file to tackle that

**NOTE:** quite safe, merging as soon as green 
