### PR TITLE
Replace bunny with Cloudflare

### DIFF
--- a/.github/workflow.templates/on-push.yml
+++ b/.github/workflow.templates/on-push.yml
@@ -7,6 +7,8 @@
 #@ load("rush.lib.yml", "rush_build")
 #@ load("test-job.lib.yml", "test_job")
 #@ load("build-crsqlite.lib.yml", "build_crsqlite")
+#@ load("r2.lib.yml", "install_and_configure_rclone")
+#@ load("r2.lib.yml", "upload_to_r2")
 
 name: Checks
 
@@ -138,7 +140,7 @@ jobs:
         run: rush check-workspace-projects
 
   deploy-preview:
-    name: Deploy preview web-client app to bunny cdn
+    name: Deploy preview web-client app to R2
     runs-on: ubuntu-latest
     needs: build-cr-sqlite
     steps:
@@ -169,23 +171,8 @@ jobs:
           SENTRY_URL: https://sentry.libroc.co
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
-      - name: Install lftp
-        run: |
-          sudo apt-get update
-          sudo apt-get install lftp
-      - name: Copy built app to bunny storage zone
-        run: |
-          lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-          set ftp:ssl-allow no
-          set mirror:parallel-transfer-count 10
-          mirror -R apps/web-client/build/ ${{ github.head_ref || github.ref_name }}
-          EOF
-        env:
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-      - name: Purge bunny cache
-        run: 'curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"'
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+      -  #@ install_and_configure_rclone()
+      -  #@ upload_to_r2("apps/web-client/build/", "${{ github.head_ref || github.ref_name }}/")
       - name: Output link to deployed app
         run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
   e2e-merge-report:
@@ -208,28 +195,8 @@ jobs:
       - name: Merge to HTML report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
-      - name: Install lftp
-        run: |
-          sudo apt-get update
-          sudo apt-get install lftp
-
-      - name: Upload merged report to Bunny storage
-        run: |
-          lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-          set ftp:ssl-allow no
-          set mirror:parallel-transfer-count 10
-          mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
-          EOF
-        env:
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-
-      - name: Purge Bunny cache
-        run: |
-          curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
-               --header "content-type: application/json" \
-               --header "AccessKey: $BUNNY_API_KEY"
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+      -  #@ install_and_configure_rclone()
+      -  #@ upload_to_r2("playwright-report/", "${{ github.head_ref || github.ref_name }}/tests/")
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -242,7 +209,7 @@ jobs:
         run: echo "Merged e2e report https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests/index.html" | tee -a $GITHUB_STEP_SUMMARY
 
   deploy-demo:
-    name: Deploy demo web-client app to bunny cdn
+    name: Deploy demo web-client app to R2
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/production-demo'
     needs:
@@ -280,22 +247,7 @@ jobs:
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
           PUBLIC_IS_DEMO: "true"
           PUBLIC_DEMO_DB_URL: "https://librocco.codemyriad.io/demo_db.sqlite3"
-      - name: Install lftp
-        run: |
-          sudo apt-get update
-          sudo apt-get install lftp
-      - name: Copy built app to bunny storage zone
-        run: |
-          lftp -u demo-librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-          set ftp:ssl-allow no
-          set mirror:parallel-transfer-count 10
-          mirror -R apps/web-client/build/ demo
-          EOF
-        env:
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_DEMO_STORAGE_PASSWORD }}
-      - name: Purge bunny cache
-        run: 'curl --request POST --url https://api.bunny.net/pullzone/4610509/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"'
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+      -  #@ install_and_configure_rclone()
+      -  #@ upload_to_r2("apps/web-client/build/", "demo/")
       - name: Output link to deployed demo app
         run: echo You can view the demo app on https://libroc.co/demo | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflow.templates/r2.lib.yml
+++ b/.github/workflow.templates/r2.lib.yml
@@ -1,0 +1,30 @@
+#@ def install_and_configure_rclone():
+name: Install and configure rclone for R2
+run: |
+  wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
+  unzip -q rclone-v1.71.1-linux-amd64.zip
+  sudo mv rclone-v1.71.1-linux-amd64/rclone /usr/local/bin/rclone
+  sudo chmod +x /usr/local/bin/rclone
+  rm -rf rclone-v1.71.1-linux-amd64.zip rclone-v1.71.1-linux-amd64
+
+  mkdir -p ~/.config/rclone
+  cat > ~/.config/rclone/rclone.conf <<EOF
+  [r2]
+  type = s3
+  provider = Cloudflare
+  access_key_id = ${CLOUDFLARE_ACCESS_KEY_ID}
+  secret_access_key = ${CLOUDFLARE_SECRET_ACCESS_KEY}
+  endpoint = ${CLOUDFLARE_BUCKET_URL}
+  acl = public-read
+  no_check_bucket = true
+  EOF
+env:
+  CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+  CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+  CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
+#@ end
+
+#@ def upload_to_r2(source, destination):
+name: #@ "Upload to R2: {} -> {}".format(source, destination)
+run: #@ "rclone copy {} r2:librocco-ci/{}".format(source, destination)
+#@ end

--- a/.github/workflow.templates/vfs-benchmark.yml
+++ b/.github/workflow.templates/vfs-benchmark.yml
@@ -6,6 +6,8 @@
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
 #@ load("build-crsqlite.lib.yml", "build_crsqlite")
+#@ load("r2.lib.yml", "install_and_configure_rclone")
+#@ load("r2.lib.yml", "upload_to_r2")
 
 name: Checks
 
@@ -102,28 +104,8 @@ jobs:
       - name: Merge to HTML report
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
-      - name: Install lftp
-        run: |
-          sudo apt-get update
-          sudo apt-get install lftp
-
-      - name: Upload merged report to Bunny storage
-        run: |
-          lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-          set ftp:ssl-allow no
-          set mirror:parallel-transfer-count 10
-          mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
-          EOF
-        env:
-          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-
-      - name: Purge Bunny cache
-        run: |
-          curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
-               --header "content-type: application/json" \
-               --header "AccessKey: $BUNNY_API_KEY"
-        env:
-          BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+      -  #@ install_and_configure_rclone()
+      -  #@ upload_to_r2("playwright-report/", "${{ github.head_ref || github.ref_name }}/tests/")
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -413,7 +413,7 @@ jobs:
     - name: Check for unlisted artifacts in 'apps' and 'pkg' folders
       run: rush check-workspace-projects
   deploy-preview:
-    name: Deploy preview web-client app to bunny cdn
+    name: Deploy preview web-client app to R2
     runs-on: ubuntu-latest
     needs: build-cr-sqlite
     steps:
@@ -466,23 +466,31 @@ jobs:
         SENTRY_URL: https://sentry.libroc.co
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
-    - name: Install lftp
+    - name: Install and configure rclone for R2
       run: |
-        sudo apt-get update
-        sudo apt-get install lftp
-    - name: Copy built app to bunny storage zone
-      run: |
-        lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-        set ftp:ssl-allow no
-        set mirror:parallel-transfer-count 10
-        mirror -R apps/web-client/build/ ${{ github.head_ref || github.ref_name }}
+        wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
+        unzip -q rclone-v1.71.1-linux-amd64.zip
+        sudo mv rclone-v1.71.1-linux-amd64/rclone /usr/local/bin/rclone
+        sudo chmod +x /usr/local/bin/rclone
+        rm -rf rclone-v1.71.1-linux-amd64.zip rclone-v1.71.1-linux-amd64
+
+        mkdir -p ~/.config/rclone
+        cat > ~/.config/rclone/rclone.conf <<EOF
+        [r2]
+        type = s3
+        provider = Cloudflare
+        access_key_id = ${CLOUDFLARE_ACCESS_KEY_ID}
+        secret_access_key = ${CLOUDFLARE_SECRET_ACCESS_KEY}
+        endpoint = ${CLOUDFLARE_BUCKET_URL}
+        acl = public-read
+        no_check_bucket = true
         EOF
       env:
-        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-    - name: Purge bunny cache
-      run: 'curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"'
-      env:
-        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+        CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+        CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
+    - name: 'Upload to R2: apps/web-client/build/ -> ${{ github.head_ref || github.ref_name }}/'
+      run: rclone copy apps/web-client/build/ r2:librocco-ci/${{ github.head_ref || github.ref_name }}/
     - name: Output link to deployed app
       run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
   e2e-merge-report:
@@ -507,26 +515,31 @@ jobs:
         merge-multiple: true
     - name: Merge to HTML report
       run: npx playwright merge-reports --reporter html ./all-blob-reports
-    - name: Install lftp
+    - name: Install and configure rclone for R2
       run: |
-        sudo apt-get update
-        sudo apt-get install lftp
-    - name: Upload merged report to Bunny storage
-      run: |
-        lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-        set ftp:ssl-allow no
-        set mirror:parallel-transfer-count 10
-        mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
+        wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
+        unzip -q rclone-v1.71.1-linux-amd64.zip
+        sudo mv rclone-v1.71.1-linux-amd64/rclone /usr/local/bin/rclone
+        sudo chmod +x /usr/local/bin/rclone
+        rm -rf rclone-v1.71.1-linux-amd64.zip rclone-v1.71.1-linux-amd64
+
+        mkdir -p ~/.config/rclone
+        cat > ~/.config/rclone/rclone.conf <<EOF
+        [r2]
+        type = s3
+        provider = Cloudflare
+        access_key_id = ${CLOUDFLARE_ACCESS_KEY_ID}
+        secret_access_key = ${CLOUDFLARE_SECRET_ACCESS_KEY}
+        endpoint = ${CLOUDFLARE_BUCKET_URL}
+        acl = public-read
+        no_check_bucket = true
         EOF
       env:
-        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-    - name: Purge Bunny cache
-      run: |
-        curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
-             --header "content-type: application/json" \
-             --header "AccessKey: $BUNNY_API_KEY"
-      env:
-        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+        CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+        CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
+    - name: 'Upload to R2: playwright-report/ -> ${{ github.head_ref || github.ref_name }}/tests/'
+      run: rclone copy playwright-report/ r2:librocco-ci/${{ github.head_ref || github.ref_name }}/tests/
     - uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -536,7 +549,7 @@ jobs:
     - name: Output link to report
       run: echo "Merged e2e report https://test.libroc.co/${{ github.head_ref || github.ref_name }}/tests/index.html" | tee -a $GITHUB_STEP_SUMMARY
   deploy-demo:
-    name: Deploy demo web-client app to bunny cdn
+    name: Deploy demo web-client app to R2
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/production-demo'
     needs:
@@ -595,22 +608,30 @@ jobs:
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
         PUBLIC_IS_DEMO: "true"
         PUBLIC_DEMO_DB_URL: https://librocco.codemyriad.io/demo_db.sqlite3
-    - name: Install lftp
+    - name: Install and configure rclone for R2
       run: |
-        sudo apt-get update
-        sudo apt-get install lftp
-    - name: Copy built app to bunny storage zone
-      run: |
-        lftp -u demo-librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-        set ftp:ssl-allow no
-        set mirror:parallel-transfer-count 10
-        mirror -R apps/web-client/build/ demo
+        wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
+        unzip -q rclone-v1.71.1-linux-amd64.zip
+        sudo mv rclone-v1.71.1-linux-amd64/rclone /usr/local/bin/rclone
+        sudo chmod +x /usr/local/bin/rclone
+        rm -rf rclone-v1.71.1-linux-amd64.zip rclone-v1.71.1-linux-amd64
+
+        mkdir -p ~/.config/rclone
+        cat > ~/.config/rclone/rclone.conf <<EOF
+        [r2]
+        type = s3
+        provider = Cloudflare
+        access_key_id = ${CLOUDFLARE_ACCESS_KEY_ID}
+        secret_access_key = ${CLOUDFLARE_SECRET_ACCESS_KEY}
+        endpoint = ${CLOUDFLARE_BUCKET_URL}
+        acl = public-read
+        no_check_bucket = true
         EOF
       env:
-        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_DEMO_STORAGE_PASSWORD }}
-    - name: Purge bunny cache
-      run: 'curl --request POST --url https://api.bunny.net/pullzone/4610509/purgeCache --header "content-type: application/json" --header "AccessKey: $BUNNY_API_KEY"'
-      env:
-        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+        CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+        CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
+    - name: 'Upload to R2: apps/web-client/build/ -> demo/'
+      run: rclone copy apps/web-client/build/ r2:librocco-ci/demo/
     - name: Output link to deployed demo app
       run: echo You can view the demo app on https://libroc.co/demo | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/vfs-benchmark.yml
+++ b/.github/workflows/vfs-benchmark.yml
@@ -179,26 +179,31 @@ jobs:
         merge-multiple: true
     - name: Merge to HTML report
       run: npx playwright merge-reports --reporter html ./all-blob-reports
-    - name: Install lftp
+    - name: Install and configure rclone for R2
       run: |
-        sudo apt-get update
-        sudo apt-get install lftp
-    - name: Upload merged report to Bunny storage
-      run: |
-        lftp -u librocco,"${BUNNY_STORAGE_PASSWORD}" storage.bunnycdn.com <<EOF
-        set ftp:ssl-allow no
-        set mirror:parallel-transfer-count 10
-        mirror -R playwright-report/ ${{ github.head_ref || github.ref_name }}/tests
+        wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
+        unzip -q rclone-v1.71.1-linux-amd64.zip
+        sudo mv rclone-v1.71.1-linux-amd64/rclone /usr/local/bin/rclone
+        sudo chmod +x /usr/local/bin/rclone
+        rm -rf rclone-v1.71.1-linux-amd64.zip rclone-v1.71.1-linux-amd64
+
+        mkdir -p ~/.config/rclone
+        cat > ~/.config/rclone/rclone.conf <<EOF
+        [r2]
+        type = s3
+        provider = Cloudflare
+        access_key_id = ${CLOUDFLARE_ACCESS_KEY_ID}
+        secret_access_key = ${CLOUDFLARE_SECRET_ACCESS_KEY}
+        endpoint = ${CLOUDFLARE_BUCKET_URL}
+        acl = public-read
+        no_check_bucket = true
         EOF
       env:
-        BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_PREVIEW_STORAGE_PASSWORD }}
-    - name: Purge Bunny cache
-      run: |
-        curl --request POST --url https://api.bunny.net/pullzone/1306302/purgeCache \
-             --header "content-type: application/json" \
-             --header "AccessKey: $BUNNY_API_KEY"
-      env:
-        BUNNY_API_KEY: ${{ secrets.BUNNY_API_KEY }}
+        CLOUDFLARE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}
+        CLOUDFLARE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}
+        CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
+    - name: 'Upload to R2: playwright-report/ -> ${{ github.head_ref || github.ref_name }}/tests/'
+      run: rclone copy playwright-report/ r2:librocco-ci/${{ github.head_ref || github.ref_name }}/tests/
     - uses: actions/upload-artifact@v4
       if: always()
       with:


### PR DESCRIPTION
The Bunny CDN is great, but their storage has a performance problem when uploading many files. It was taking 10 minutes and more for something that should be no more than one.

This PR retires the Bunny CDN deployment.https://test.libroc.co/ already points to Cloudflare. I will merge this so we get a `/main` soon.