### PR TITLE
add AGENTS.md to the root of the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,6 @@
 - **Rush managed**: Node 20, pnpm 8.7.0, projects in `apps/`, `pkg/`, `plugins/`
 - **Workspace deps**: Use `"workspace:*"` for local package dependencies
 - **Add deps**: `rush add -p <package>` (+ `--dev` for devDeps) from package dir, then `rush update`
+
+## Caveats
+- Github actions in `.github/workflows` are generated from `.github/workflow.templates` and built running `.github/build-workflows.sh`


### PR DESCRIPTION
I've added AGENTS.md to the root of the repo. It works in the same way as CLAUDE.md (I reckon) and I think all agentic IDE / apps could be configured to use it as base (for the repo).

This is the OpenCode convention (AGENTS.md, not CLAUDE.md, cursor rules, etc.), but I think the name `AGENTS` is the most ambiguous, so I propose we use it as the standard.

Finally, this should be very gentle content: containing only FACTS about the repo, not very opinionated, so I'll merge it as soon as CI greenlights it.