### PR TITLE
Refactor: implement automatic migration and splash screen error handling

### DIFF
--- a/apps/web-client/src/app.html
+++ b/apps/web-client/src/app.html
@@ -40,6 +40,11 @@
 				animation: draw 2s ease-in-out infinite alternate;
 			}
 
+			#app-splash.error path {
+				stroke: #dc2626;
+				stroke-dashoffset: 0;
+			}
+
 			@keyframes draw {
 				from {
 					stroke-dashoffset: 3800;
@@ -63,6 +68,36 @@
 				line-height: 1.2;
 			}
 
+			#app-splash.error h1 {
+				color: #dc2626;
+			}
+
+			#app-splash .error-details {
+				font-size: 0.75rem;
+				opacity: 0.5;
+				margin-top: 0.5rem;
+				max-width: 300px;
+				word-break: break-word;
+			}
+			#app-splash .action-btn {
+				margin-top: 1.5rem;
+				padding: 0.75rem 1.5rem;
+				background: #1a1a1a;
+				opacity: 40;
+				color: white;
+				outline: 1px solid #eee;
+				border-radius: 0.5rem;
+				font-size: 0.9rem;
+				font-weight: 500;
+				cursor: pointer;
+				transition: background 0.15s;
+			}
+
+			#app-splash .action-btn:hover {
+				outline: 2px solid #eee;
+				font-weight: 600;
+			}
+
 			@media (prefers-color-scheme: dark) {
 				#app-splash {
 					background: #1a1a1a;
@@ -70,6 +105,12 @@
 				}
 				#app-splash path {
 					stroke: #eee;
+				}
+				#app-splash.error path {
+					stroke: #f87171;
+				}
+				#app-splash.error h1 {
+					color: #f87171;
 				}
 			}
 			#app-splash.bye {
@@ -94,10 +135,99 @@
 				/>
 			</svg>
 			<div>
-				<h1>Librocco is loading. Hang tight!</h1>
-				<h2>Or hang loose – your choice.</h2>
+				<h1 id="splash-title">Librocco is loading. Hang tight!</h1>
+				<h2 id="splash-subtitle">Or hang loose – your choice.</h2>
+				<p id="splash-error" class="error-details" style="display: none"></p>
+				<button id="splash-action" class="action-btn" style="display: none">Reset Database</button>
 			</div>
 		</div>
+		<script>
+			// Static message map for each initialization phase
+			const splashMessages = {
+				// The idle state is typed above in the HTML as it should be visible immediately on load
+				idle: { title: "", subtitle: "" },
+				loading: { title: "Initialising the database", subtitle: "Waking the workers and heating the coffee..." },
+				migrating: {
+					title: "Migrating the database",
+					subtitle: "Updating to the latest version..."
+				},
+				error: {
+					title: "Migration Error",
+					subtitle:
+						"There was a problem updating the database. Click Reset Database below to continue. Your data will be re-synced from the server."
+				}
+			};
+
+			// Callback for init-store to notify phase changes
+			window.__dbInitUpdate = function (phase, error) {
+				const splash = document.getElementById("app-splash");
+				const title = document.getElementById("splash-title");
+				const subtitle = document.getElementById("splash-subtitle");
+				const errorEl = document.getElementById("splash-error");
+				const actionBtn = document.getElementById("splash-action");
+
+				const msg = splashMessages[phase] || splashMessages.idle;
+				title.textContent = msg.title;
+				subtitle.textContent = msg.subtitle;
+
+				if (phase === "error") {
+					splash.classList.add("error");
+					if (error && error.message) {
+						errorEl.textContent = error.message;
+						errorEl.style.display = "block";
+					}
+					actionBtn.style.display = "inline-block";
+				} else if (phase === "ready") {
+					splash.classList.add("bye");
+					splash.addEventListener("animationend", function () {
+						splash.remove();
+					});
+				} else {
+					splash.classList.remove("error");
+					errorEl.style.display = "none";
+					actionBtn.style.display = "none";
+				}
+			};
+
+			// OPFS nuke function - deletes the database files and reloads
+			async function nukeDatabase() {
+				const nukeBtn = document.getElementById("splash-action");
+				nukeBtn.disabled = true;
+				nukeBtn.textContent = "Resetting...";
+
+				try {
+					// Get database name from localStorage (default: "dev")
+					const dbname = localStorage.getItem("librocco-current-db") || "dev";
+
+					// Get OPFS root directory
+					const root = await navigator.storage.getDirectory();
+
+					// Helper to safely remove a file if it exists
+					async function removeIfExists(name) {
+						try {
+							await root.removeEntry(name);
+						} catch (e) {
+							// File doesn't exist or can't be removed - that's ok
+						}
+					}
+
+					// Remove the database files
+					await removeIfExists(dbname);
+					await removeIfExists(dbname + "-wal");
+					await removeIfExists(dbname + "-journal");
+
+					// Reload the page to reinitialize
+					window.location.reload();
+				} catch (e) {
+					console.error("Failed to nuke database:", e);
+					nukeBtn.textContent = "Reset Failed";
+					nukeBtn.disabled = false;
+				}
+			}
+
+			// Wire up button handlers
+			document.getElementById("splash-action").onclick = nukeDatabase;
+		</script>
 		<div style="height: 100%">%sveltekit.body%</div>
 	</body>
 </html>

--- a/apps/web-client/src/lib/db/index.ts
+++ b/apps/web-client/src/lib/db/index.ts
@@ -6,6 +6,7 @@ import { DEMO_DB_NAME, IS_DEMO } from "$lib/constants";
 
 import type { SyncConfig } from "./sync";
 export * from "./sync";
+export * from "./init-store";
 
 // NOTE: we're purposefully casting the demo dbid to writable:
 // - for type simplicity - for most intents and purposes we'll have the selection available (production)

--- a/apps/web-client/src/lib/db/init-store.ts
+++ b/apps/web-client/src/lib/db/init-store.ts
@@ -1,0 +1,57 @@
+import { writable, get } from "svelte/store";
+import { browser } from "$app/environment";
+
+/**
+ * Phases of DB initialization:
+ * - idle: Not started
+ * - loading: Loading DB/WASM
+ * - migrating: Running auto-migration
+ * - ready: DB ready for use
+ * - error: Unrecoverable error (requires nuke)
+ */
+export type InitPhase = "idle" | "loading" | "migrating" | "ready" | "error";
+
+export type InitState = {
+	phase: InitPhase;
+	error: Error | null;
+};
+
+const initialState: InitState = {
+	phase: "idle",
+	error: null
+};
+
+/**
+ * Store tracking DB initialization state.
+ * Used to communicate progress to the splash screen and control sync startup.
+ */
+function createInitStore() {
+	const { subscribe, set } = writable<InitState>(initialState);
+
+	return {
+		subscribe,
+
+		/**
+		 * Set the current initialization phase.
+		 * Notifies the splash screen via window callback.
+		 */
+		setPhase: (phase: InitPhase, error?: Error) => {
+			set({ phase, error: error || null });
+
+			// Notify splash screen in app.html
+			if (browser) {
+				(window as any).__dbInitUpdate?.(phase, error);
+			}
+		},
+
+		/** Reset to idle state */
+		reset: () => {
+			set(initialState);
+		},
+
+		/** Get current state synchronously */
+		get: () => get({ subscribe })
+	};
+}
+
+export const initStore = createInitStore();

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import "$lib/main.css";
 	import "./global.css";
 
-	import { onDestroy, onMount } from "svelte";
+	import { onMount } from "svelte";
 	import { get, writable } from "svelte/store";
 	import { fade, fly } from "svelte/transition";
 
@@ -17,16 +17,16 @@
 
 	import type { LayoutData } from "./$types";
 
-	import { DEFAULT_VFS, DEMO_DB_NAME, DEMO_DB_URL, IS_DEBUG, IS_DEMO, IS_E2E } from "$lib/constants";
+	import { DEMO_DB_NAME, DEMO_DB_URL, IS_DEBUG, IS_DEMO, IS_E2E } from "$lib/constants";
 
 	import { Sidebar } from "$lib/components";
 
 	import SyncWorker from "$lib/workers/sync-worker.ts?worker";
 	import WorkerInterface from "$lib/workers/WorkerInterface";
 
-	import { sync, syncConfig, syncActive, dbid, syncProgressStore } from "$lib/db";
-	import { clearDb, getDB, schemaName, schemaContent, dbCache, isEmptyDB } from "$lib/db/cr-sqlite/db";
-	import { ErrDBSchemaMismatch, ErrDemoDBNotInitialised } from "$lib/db/cr-sqlite/errors";
+	import { sync, syncConfig, syncActive, dbid, syncProgressStore, initStore } from "$lib/db";
+	import { clearDb, dbCache } from "$lib/db/cr-sqlite/db";
+	import { ErrDemoDBNotInitialised } from "$lib/db/cr-sqlite/errors";
 	import * as migrations from "$lib/db/cr-sqlite/debug/migrations";
 	import * as books from "$lib/db/cr-sqlite/books";
 	import * as customers from "$lib/db/cr-sqlite/customers";
@@ -46,7 +46,6 @@
 	import { progressBar } from "$lib/actions";
 
 	import { appPath } from "$lib/paths";
-	import type { VFSWhitelist } from "$lib/db/cr-sqlite/core";
 
 	export let data: LayoutData;
 
@@ -112,74 +111,67 @@
 		sync.stop();
 	}
 
-	let disposer: () => void;
-
-	onMount(() => {
-		const splash = document.getElementById("app-splash");
-		if (splash) {
-			splash.classList.add("bye");
-			splash.addEventListener("animationend", () => splash.remove());
-		}
-	});
-
-	onMount(() => {
-		// Control the invalidation of the stock cache in central spot
-		// On every 'book_transaction' change, we run 'maybeInvalidate', which, in turn checks for relevant changes
-		// between the last cached value and the current one and invalidates the cache if needed
-		disposer = dbCtx?.rx?.onRange(["book_transaction"], () => stockCache.maybeInvalidate(dbCtx.db));
-	});
-
 	// Sync
 	const { progress: syncProgress } = syncProgressStore;
 
 	onMount(() => {
-		// We currently don't support the sync in demo mode
-		if (IS_DEMO) return;
-
-		// This helps us in e2e to know when the page is interactive, otherwise Playwright will start too early
+		// This helps us in e2e to know when the page is interactive
 		document.body.setAttribute("hydrated", "true");
 
 		if (IS_E2E || IS_DEBUG) {
 			window["timeLogger"] = timeLogger;
 		}
+		// Control the invalidation of the stock cache
+		// On every 'book_transaction' change, we run 'maybeInvalidate', which checks for relevant changes
+		// between the last cached value and the current one and invalidates the cache if needed
+		const disposer = dbCtx?.rx?.onRange(["book_transaction"], () => stockCache.maybeInvalidate(dbCtx.db));
 
-		// Start the sync worker
-		//
-		// Init worker and sync interface
-		const wkr = new WorkerInterface(new SyncWorker());
-		// NOTE: It's ok if dbCtx (and, by extension the vfs) is not defined -- this is handled elsewhere
-		// calls to wkr.start(vfs) without vfs provided are noop
-		const vfs = dbCtx?.vfs;
+		// 3. Sync setup (not supported in demo mode)
+		// Only start sync when DB is ready
 
-		wkr.start(vfs);
-		sync.init(wkr);
+		let preventUnloadHandler: ((e: BeforeUnloadEvent) => void) | null = null;
 
-		// Start the sync is it should be active.
-		if ($syncActive) {
-			sync.sync($syncConfig, { invalidateAll });
-		}
+		const initUnsubscribe = initStore.subscribe((state) => {
+			if (state.phase !== "ready") return;
 
-		// Start the sync progress store (listen to sync events)
-		syncProgressStore.start(wkr);
+			// DB is ready, start sync worker
+			const wkr = new WorkerInterface(new SyncWorker());
+			const vfs = dbCtx?.vfs;
 
-		// Prevent user from navigating away if sync is in progress (this would result in an invalid DB state)
-		const preventUnloadIfSyncing = (e: BeforeUnloadEvent) => {
-			if (get(syncProgress).active) {
-				e.preventDefault();
-				e.returnValue = "";
+			wkr.start(vfs);
+			sync.init(wkr);
+
+			// Start the sync if it should be active
+			if ($syncActive) {
+				sync.sync($syncConfig, { invalidateAll });
 			}
+
+			// Start the sync progress store (listen to sync events)
+			syncProgressStore.start(wkr);
+
+			// Prevent user from navigating away if sync is in progress
+			preventUnloadHandler = (e: BeforeUnloadEvent) => {
+				if (get(syncProgress).active) {
+					e.preventDefault();
+					e.returnValue = "";
+				}
+			};
+			window.addEventListener("beforeunload", preventUnloadHandler);
+		});
+
+		// Cleanup function
+		return () => {
+			// Stop the sync (if active)
+			sync.stop();
+			syncProgressStore.stop();
+
+			availabilitySubscription?.unsubscribe();
+			initUnsubscribe?.();
+			disposer?.();
+
+			// Run all cleanup functions
+			window.removeEventListener("beforeunload", preventUnloadHandler);
 		};
-		window.addEventListener("beforeunload", preventUnloadIfSyncing);
-	});
-
-	onDestroy(() => {
-		// Stop the sync (if active)
-		sync.stop(); // Safe and idempotent
-		syncProgressStore.stop(); // Safe and idempotent
-
-		availabilitySubscription?.unsubscribe();
-
-		disposer?.();
 	});
 
 	const {
@@ -264,21 +256,6 @@
 
 		// Reload the window - to avoid a huge number of issues related to
 		// having to account for DB not being available, but becoming available within the same lifetime
-		window.location.reload();
-	};
-
-	const automigrateDB = async () => {
-		// We need to retrieve the DB directly, as the broken DB won't be passed down from the load function
-		const vfs = (window.localStorage.getItem("vfs") as VFSWhitelist) || DEFAULT_VFS;
-		const db = await getDB($dbid, vfs);
-
-		console.log("automigrating db to latest versin....");
-		await db.automigrateTo(schemaName, schemaContent);
-		console.log("automigration done");
-
-		// Reload the window - to avoid a huge number of issues related to
-		// having to account for DB not being available, but becoming available within the same lifetime
-		// NOTE: commented out so we can observe the errors before navigating away, TODO: uncomment when stable
 		window.location.reload();
 	};
 
@@ -400,7 +377,8 @@
 	</div>
 {/if}
 
-{#if $errorDialogOpen}
+{#if $errorDialogOpen && error instanceof ErrDemoDBNotInitialised}
+	<!-- Demo DB initialization dialog - only shown in demo mode when DB needs to be fetched -->
 	<div use:melt={$errorDialogPortalled}>
 		<div use:melt={$errorDialogOverlay} class="fixed inset-0 z-[100] bg-black/50" transition:fade|global={{ duration: 150 }}></div>
 
@@ -410,69 +388,28 @@
 			use:melt={$errorDialogContent}
 		>
 			<div class="modal-box overflow-clip rounded-lg md:shadow-2xl">
-				{#if error instanceof ErrDemoDBNotInitialised}
-					<h2 use:melt={$errorDialogTitle} class="mb-4 text-xl font-semibold leading-7 text-gray-900">
-						{tLayout.error_dialog.demo_db_not_initialised.title()}
-					</h2>
+				<h2 use:melt={$errorDialogTitle} class="mb-4 text-xl font-semibold leading-7 text-gray-900">
+					{tLayout.error_dialog.demo_db_not_initialised.title()}
+				</h2>
 
-					<p class="mb-4 text-sm leading-6 text-gray-600" use:melt={$errorDialogDescription}>
-						<span class="mb-2 block">
-							{tLayout.error_dialog.demo_db_not_initialised.call_to_action()}
-						</span>
-						<span class="mb-2 block">
-							{tLayout.error_dialog.demo_db_not_initialised.description()}
-						</span>
-					</p>
+				<p class="mb-4 text-sm leading-6 text-gray-600" use:melt={$errorDialogDescription}>
+					<span class="mb-2 block">
+						{tLayout.error_dialog.demo_db_not_initialised.call_to_action()}
+					</span>
+					<span class="mb-2 block">
+						{tLayout.error_dialog.demo_db_not_initialised.description()}
+					</span>
+				</p>
 
-					<div class="mb-8 h-3 w-full overflow-hidden rounded">
-						<div use:progressBar={demoFetchProgress} class="h-full bg-cyan-300"></div>
-					</div>
+				<div class="mb-8 h-3 w-full overflow-hidden rounded">
+					<div use:progressBar={demoFetchProgress} class="h-full bg-cyan-300"></div>
+				</div>
 
-					<div class="w-full text-end">
-						<button on:click={handleFetchDemoDB} type="button" class="btn-secondary btn">
-							{tLayout.error_dialog.demo_db_not_initialised.button()}
-						</button>
-					</div>
-				{:else if error instanceof ErrDBSchemaMismatch}
-					<h2 use:melt={$errorDialogTitle} class="mb-4 text-xl font-semibold leading-7 text-gray-900">
-						{tLayout.error_dialog.schema_mismatch.title()}
-					</h2>
-
-					<p class="mb-4 text-sm leading-6 text-gray-600" use:melt={$errorDialogDescription}>
-						<span class="mb-2 block">
-							{tLayout.error_dialog.schema_mismatch.description()}
-						</span>
-						<span class="ml-4 block">
-							{tLayout.error_dialog.schema_mismatch.latest_version({ wantVersion: (error as ErrDBSchemaMismatch).wantVersion })}
-						</span>
-						<span class="ml-4 block">
-							{tLayout.error_dialog.schema_mismatch.your_version({ gotVersion: (error as ErrDBSchemaMismatch).gotVersion })}
-						</span>
-					</p>
-
-					<div class="w-full text-end">
-						<button on:click={automigrateDB} type="button" class="btn-secondary btn">
-							{tLayout.error_dialog.schema_mismatch.button()}
-						</button>
-					</div>
-				{:else}
-					<h2 use:melt={$errorDialogTitle} class="mb-4 text-xl font-semibold leading-7 text-gray-900">
-						{tLayout.error_dialog.corrupted.title()}
-					</h2>
-
-					<p class="mb-2 text-sm leading-6 text-gray-600" use:melt={$errorDialogDescription}>
-						<span class="mb-2 block">{tLayout.error_dialog.corrupted.description()}</span>
-						<span class="mb-4 block">
-							{tLayout.error_dialog.corrupted.note()}
-						</span>
-					</p>
-
-					<div class="w-full text-end">
-						<button on:click={nukeDB} type="button" class="btn-secondary btn">
-							{tLayout.error_dialog.corrupted.button()}
-						</button>
-					</div>
-				{/if}
+				<div class="w-full text-end">
+					<button on:click={handleFetchDemoDB} type="button" class="btn-secondary btn">
+						{tLayout.error_dialog.demo_db_not_initialised.button()}
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This work is not as thorough as I would have liked it to be - it does not include tests - but I wanted to submit something before the end of the week.

- Remove schema mismatch and DB corrupted dialogs from root layout.svelte
- Implement automatic migration in checkAndInitializeDB() when there is a schema mismatch. We will only ask the user to intervene if there is a problem.
- Add an "init-store" to track DB initialization phases (idle, loading, migrating, ready, error)
- Update app.html splash screen to display loading states and provide inline OPFS database reset functionality for when an error occurs
- Prevent sync from starting until DB initialization and migration are complete

Todos:
- Tests. It shouldn't be too much work with the sync server setup/spec that already exists
- Localise loading messages in the app.html
- Investigate multi-tab behaviour
