### PR TITLE
rush caching 1st pass: prevent unnecessary reinstalls:

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -7,10 +7,24 @@ const fs = require('fs');
 
 module.exports = {
 	hooks: {
-		// running this so that we don't have absolute paths in the lockfile when updating the local .tar deps
+		// Running this so that we don't have absolute paths in the lockfile when updating the local .tar deps
+		//
+		// We have the following scenario:
+		// - package.json imports specify versions (latest) for vlcn.io packages (e.g. in web-client)
+		// - vlcn.io packages depend on eachother internally -- overriding specifiers in our packages (setting to file:...)
+		//   doesn't override interdependencies (leading to multiple versions of same package being used)
+		// - we specify 'globalOverrides' in 'common/config/rush/pnpm-config.json' to override deps (at resolution time) to use
+		//   tarballs in '3rd-party/artefacts'
+		// - with overrides in place Rush and pnpm (whichever) resolve the absolute path (which is variable depending on each dev's fs layout), e.g.:
+		//   - specifier: "file:/Users/<user-name>/dev-workspace/librocco/3rd-party/..." (resolved absolute path)
+		//   - version: "file:../../3rd-party/..." (pnpm globalOverride - relative to each package root, e.g. apps/web-client)
+		// - when Rush sees the mismatch (above) it triggers shrinkwrap invalidtion - resulting in slow and unnecessary `rush update` on each call
+		// - we perform the hack to (manually) override the specifier so that the requested version (specifier) matches the installed version
 		afterAllResolved: (lockfile, context) => {
-			const artefactsRelPath = '../../../3rd-party/artefacts'
-			const tarballFiles = new Set(fs.readdirSync(path.join(__dirname, artefactsRelPath)).filter(file => file.endsWith('.tgz')))
+			const artefactsPath = path.join(__dirname, '..', '..', '..', '3rd-party/artefacts')
+			const tarballFiles = new Set(fs.readdirSync(artefactsPath).filter(file => file.endsWith('.tgz')))
+
+			const artefactsPathOverride = '../../3rd-party/artefacts'
 
 			context.log("tarball files:")
 			for (const file of tarballFiles) {
@@ -27,14 +41,15 @@ module.exports = {
 
 					const basename = path.basename(specifier);
 
-					const relativePath = `file:${path.join(artefactsRelPath, basename)}`
+					const pathOverride = path.join(artefactsPathOverride, basename)
+					const specifierOverride = `file:${pathOverride}`
 
 					if (tarballFiles.has(basename)) {
 						const _old = specifier
-						const _new = relativePath
+						const _new = specifierOverride
 
 						context.log(`replacing specifier ${_old} -> ${_new}`);
-						importer.specifiers[depName] = relativePath
+						importer.specifiers[depName] = _new
 					}
 				}
 			}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         specifier: ~6.19.1
         version: 6.19.1(eslint@8.57.1)(typescript@5.9.2)
       '@vlcn.io/crsqlite-wasm':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
       eslint:
         specifier: ^8.13.0
@@ -64,7 +64,7 @@ importers:
   ../../apps/sync-server:
     dependencies:
       '@vlcn.io/ws-server':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
       better-sqlite3:
         specifier: ~11.4.0
@@ -104,28 +104,28 @@ importers:
         specifier: ~9.34.0
         version: 9.34.0(@sveltejs/kit@2.27.0)(svelte@5.37.3)(vite@6.0.15)
       '@vlcn.io/crsqlite':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.1.tgz
       '@vlcn.io/crsqlite-wasm':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz
       '@vlcn.io/rx-tbl':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz
       '@vlcn.io/wa-sqlite':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz
       '@vlcn.io/ws-browserdb':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz
       '@vlcn.io/ws-client':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz
       '@vlcn.io/ws-common':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-ws-common-0.2.0.tgz
       '@vlcn.io/xplat-api':
-        specifier: file:../../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
+        specifier: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
         version: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz
       comlink:
         specifier: ~4.4.2
@@ -503,7 +503,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.15(@types/node@16.18.126)
+        version: 6.0.15(tsx@4.19.4)
 
   ../../plugins/open-library-api:
     devDependencies:
@@ -533,7 +533,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: ~6.0.11
-        version: 6.0.15(@types/node@16.18.126)
+        version: 6.0.15(tsx@4.19.4)
 
 packages:
 
@@ -3717,6 +3717,23 @@ packages:
       vite: 6.0.15(tsx@4.19.4)
     dev: true
 
+  /@vitest/mocker@3.0.9(vite@6.0.15):
+    resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.0.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      vite: 6.0.15(@types/node@16.18.126)
+    dev: true
+
   /@vitest/pretty-format@2.0.5:
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
     dependencies:
@@ -3780,7 +3797,7 @@ packages:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@vitest/browser@3.0.9)(@vitest/ui@3.0.9)(tsx@4.19.4)
+      vitest: 3.0.9(@vitest/ui@3.0.9)(tsx@4.20.3)
     dev: true
 
   /@vitest/utils@2.0.5:
@@ -8900,7 +8917,7 @@ packages:
     dependencies:
       '@types/node': 16.18.126
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -8965,7 +8982,7 @@ packages:
     dependencies:
       '@vitest/browser': 3.0.9(playwright@1.50.1)(typescript@5.9.2)(vite@6.0.15)(vitest@3.0.9)
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -9029,7 +9046,7 @@ packages:
         optional: true
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(msw@2.10.4)(vite@6.0.15)
+      '@vitest/mocker': 3.0.9(vite@6.0.15)
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0dae482324f8c10abf94f4bcce3fa5bff42024d3",
+  "pnpmShrinkwrapHash": "a6ccdd98b9de5e7a0089a89564211728850cf6d2",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
* fix .pnpmfile.js specifier overrides (for vlcn.io) packages: '../../../3rd-party/...' -> '../../3rd-party/...'
* this results in 3rd-party tarballs having:
  - relative paths as both specifier and version (in pnpm lock)
  - matching specifier and version -> doesn't trigger shrinkwrap invalidation
  - if files (tarballs) are changed (rebuilt) will be reinstalled on `rush update`

Why this is useful: previously Rush would go into full installation whenever we ran it (even though nothing updated) as it thought the `@vlcn.io/*` deps changed (different specifier and version in `pnpm-lock.json`).

This prevents unnecessary reinstalls, whilst keeping the up-to-date installations (in case we update `3rd-party/artefacts/*` it will reinstall the particular dep as it figures that out using file hash/timestamp -- I don't know the exact plumbing, I've manually verified it works).

This should be paired with more intelligent (incremental) rebuild of `3rd-party/artefacts/*` so that files don't get changed (rebuilt) if not necessary, but this is a TODO I'm working on in a separate branch.