### PR TITLE
Set `ensureConsistentVersions` to `true` and align all dependencies versions across packages in the monorepo

### DIFF
--- a/apps/e2e/helpers/cr-sqlite.ts
+++ b/apps/e2e/helpers/cr-sqlite.ts
@@ -43,7 +43,8 @@ export function getDbHandle(page: Page) {
 			} else {
 				// Creating a separate function, as we want to run the listener only once and then remove it
 				const finalise = () => {
-					window.removeEventListener("db_ready", finalise), res();
+					window.removeEventListener("db_ready", finalise);
+					res();
 				};
 				window.addEventListener("db_ready", finalise);
 			}

--- a/apps/e2e/helpers/db.ts
+++ b/apps/e2e/helpers/db.ts
@@ -26,7 +26,8 @@ export function getDbHandle(page: Page) {
 			} else {
 				// Creating a separate function, as we want to run the listener only once and then remove it
 				const finalise = () => {
-					window.removeEventListener("db_ready", finalise), res();
+					window.removeEventListener("db_ready", finalise);
+					res();
 				};
 				window.addEventListener("db_ready", finalise);
 			}

--- a/apps/e2e/helpers/fixtures.ts
+++ b/apps/e2e/helpers/fixtures.ts
@@ -494,5 +494,5 @@ export const testOrders = testBase.extend<OrderTestFixture>({
  *
  */
 export const depends = (x: any) => {
-	x; // This does nothing
+	void x; // This does nothing
 };

--- a/apps/web-client/src/lib/plugins/types.ts
+++ b/apps/web-client/src/lib/plugins/types.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import { Observable } from "rxjs";
 
 import type { BookData } from "@librocco/shared";
 
 // #region plugins
-export type LibroccoPlugin<T extends {}> = {
+export type LibroccoPlugin<T extends object> = {
 	/**
 	 * Registers a new implementation of the plugin. It's idempotent in case of the same implementation being registered multiple times (will register only once).
 	 */

--- a/pkg/shared/src/StockMap.ts
+++ b/pkg/shared/src/StockMap.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import { filter, map } from "./generators";
 import { VolumeStock } from "./types";
 import { asc, composeCompare } from "./utils";

--- a/pkg/shared/src/plugins.ts
+++ b/pkg/shared/src/plugins.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import type { BookData } from "./types";
 import { BehaviorSubject, Observable, from } from "rxjs";
 
 // #region types
-export type LibroccoPlugin<T extends {}> = {
+export type LibroccoPlugin<T extends object> = {
 	/**
 	 * Registers a new implementation of the plugin. It's idempotent in case of the same implementation being registered multiple times (will register only once).
 	 */

--- a/pkg/shared/src/types.ts
+++ b/pkg/shared/src/types.ts
@@ -1,7 +1,6 @@
 // #region misc
 export type VolumeStockKind = "book" | "custom";
 
-/* eslint-disable @typescript-eslint/ban-types */
 /**
  * A union of entries found in note and warehouse's `entries` (`"custom"` variant should only be found in outbond notes).
  * The union can be descriminated over the `__kind` property.

--- a/plugins/book-data-extension/src/plugin/listeners.ts
+++ b/plugins/book-data-extension/src/plugin/listeners.ts
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import { Result } from "../types";
 
 import { addEventListener, removeEventListener } from "./window-helpers";
 
-type MessageData<T = {}> = { message: string } & T;
+type MessageData<T = object> = { message: string } & T;
 
 /**
  * A helper function used to create the response listener - listening to a message from the extension. The timeout


### PR DESCRIPTION
Upgrades dependencies and enforces version consistency across the monorepo:

  - Zod: 3.25.0 → 3.25.76 (fixes typing issues)
  - @vlcn.io/crsqlite: 0.16.1 → 0.16.3 (prevents the need to compile in the CI)
  - TypeScript: ^5.5.0 → ^5.7.3
  - Various tooling: prettier, eslint parsers, vite, vitest

  Adds version consistency enforcement and updates CI workflows to use rush install instead of rush update. Fixes typing problems introduced by zod upgrade.

[Claude's analysis of the zod problem is interesting](https://gist.github.com/silviot/31763e2a45331805d495e492ef50353b): it deems the inclusion of both zod 3 and for into 3.25.x as the root cause of our problems, I believe.
