### PR TITLE
Add architecture deep-dive docs for DB init and sync

### DIFF
--- a/docs/architecture/00-overview.md
+++ b/docs/architecture/00-overview.md
@@ -1,0 +1,47 @@
+# Librocco Architecture: The Life of a Page Load
+
+This is a technical deep-dive into how Librocco starts up, stores data, syncs it across devices, and keeps the UI in lockstep with the database. It was written to equip you to tackle two specific problems:
+
+1. **The loading screen takes too long** -- why does the splash screen linger?
+2. **Two browsers showed different books on the same outbound note** -- how can a CRDT-synced app show inconsistent state?
+
+Each document below covers one slice of the system. They reference each other frequently, because the pieces are deeply entangled.
+
+## Documents
+
+| # | Document | What it covers |
+|---|----------|----------------|
+| 1 | [DB Initialization](./01-db-initialization.md) | From splash screen to `AppDbState.Ready`: WASM loading, VFS selection, schema application, integrity checks. **Start here for the slow-loading issue.** |
+| 2 | [Sync](./02-sync.md) | WebSocket sync via a Web Worker, the `SyncTransportController` chunking pipeline, initial sync optimization, and the FSNotify mechanism on the server. |
+| 3 | [Migrations](./03-migrations.md) | Hash-based schema versioning, the JavaScript port of `crsql_automigrate`, and the `begin_alter`/`commit_alter` dance for CRDT tables. |
+| 4 | [Reactivity](./04-reactivity.md) | How `TblRx` subscriptions flow from database writes to Svelte stores, the `notifyAll()` fix for sync-driven changes, and the `RxListenerManager` transfer mechanism. |
+| 5 | [CRDT Conflict Resolution](./05-crdt-conflict-resolution.md) | Last-Write-Wins semantics, the `crsql_changes` virtual table, causal clocks, site IDs, and what can go wrong. **Start here for the inconsistent-note issue.** |
+| 6 | [Diagnosis: Known Issues](./06-known-issues.md) | Detailed analysis of both target issues with root causes, contributing factors, and potential improvements. |
+| 7 | [Sync User Requirements](./07-sync-user-requirements.md) | User-facing sync requirements, gap analysis, and implementation roadmap. **Start here for sync indicator and pending changes tracking.** |
+
+## The 30-Second Picture
+
+```
+Browser Tab
+  +layout.ts -----> initApp()
+                       |
+               +-------+--------+
+               |                 |
+          initializeDb()    initializeSync()
+               |                 |
+         getDBCore()         SyncWorker
+               |             (Web Worker)
+        WASM + VFS load          |
+               |          WebSocket <---> Sync Server
+          schema check                     (chokidar)
+               |                              |
+         AppDbState.Ready             FSNotify -> touchHack
+               |                              |
+          TblRx wired              changeset push/pull
+               |                              |
+          Svelte stores <---- notifyAll() <---+
+               |
+            UI render
+```
+
+Everything below unpacks this diagram.

--- a/docs/architecture/01-db-initialization.md
+++ b/docs/architecture/01-db-initialization.md
@@ -1,0 +1,161 @@
+# DB Initialization: From Splash Screen to Ready
+
+**Relevant issue:** The loading screen takes too long.
+
+This document traces every step from the moment the browser tab opens to the moment the splash screen slides away. Each step is a potential bottleneck.
+
+## The Splash Screen
+
+Before SvelteKit even hydrates, a hand-crafted HTML splash screen is already visible. It lives in raw HTML inside `app.html`:
+
+```
+apps/web-client/src/app.html:130-143
+```
+
+The splash has its own mini state machine driven by a global callback `window.__dbInitUpdate(phase, error)` (line 162). The phases are `idle`, `loading`, `migrating`, `error`, and `ready`. On `ready`, the splash plays a 200ms exit animation and removes itself from the DOM (lines 180-184).
+
+This approach -- a pre-hydration splash -- exists because SvelteKit can't render anything meaningful until JavaScript loads and the database is ready. The splash is the first thing the user sees, and the last thing before the app appears.
+
+## The Initialization Sequence
+
+The entry point is `+layout.ts`:
+
+```
+apps/web-client/src/routes/+layout.ts:59-69
+```
+
+When running in the browser, it calls `initApp(app)`, which delegates to `initAppImpl()` in:
+
+```
+apps/web-client/src/lib/app/init.ts:54-69
+```
+
+The sequence is:
+
+### Step 1: I18n Initialization
+```typescript
+await initializeI18n();  // init.ts:57
+```
+Detects locale, loads translation strings, applies overrides. This is async and involves a `fetch()` if URL-based translation overrides are configured. Normally fast, but it blocks everything else.
+
+### Step 2: Database Initialization
+```typescript
+const vfs = getVFSFromLocalStorage(DEFAULT_VFS);  // init.ts:61
+await initializeDb(app, get(app.config.dbid), vfs);  // init.ts:62
+```
+
+This is where the time goes. Let's unpack it.
+
+### Step 3: Sync Initialization
+```typescript
+await initializeSync(app, vfs);  // init.ts:67
+if (get(syncActive)) await startSync(app, get(dbid), get(syncUrl));  // init.ts:68
+```
+
+Spawns the sync Web Worker and, if sync is enabled, starts the WebSocket connection. See [02-sync.md](./02-sync.md).
+
+## Inside `initializeDb()`
+
+```
+apps/web-client/src/lib/app/db.ts:120-192
+```
+
+### 2a. VFS Selection and WASM Loading
+
+```typescript
+const db = await getDBCore(dbid, vfs);  // db.ts:129
+```
+
+`getDBCore` is actually `getDB` from `db/cr-sqlite/db.ts:26-34`. It inspects the VFS name to decide whether to use the main thread or a worker:
+
+```typescript
+const mainThreadVFS = new Set(["asyncify-idb-batch-atomic", "asyncify-opfs-any-context"]);
+if (mainThreadVFS.has(vfs)) {
+    return getMainThreadDB(dbname, vfs);   // Main thread path
+}
+return getWorkerDB(dbname, vfs);           // Worker thread path
+```
+
+Either path eventually calls `getCrsqliteDB()` in:
+
+```
+apps/web-client/src/lib/db/cr-sqlite/core/init.ts:46-58
+```
+
+This function:
+1. **Loads the WASM module** -- dynamically imports one of three builds (`sync`, `asyncify`, `jspi`) based on the VFS. The VFS-to-build mapping is at `init.ts:31-40`.
+2. **Creates a VFS factory** -- wraps the browser storage API (OPFS or IndexedDB).
+3. **Initializes cr-sqlite** -- calls `createWasmInitializer()` from `@vlcn.io/crsqlite-wasm`, which loads the WASM binary and opens the database file.
+
+**Why this is slow:** WASM binaries are ~1-2MB. On first load, they must be fetched over the network. On subsequent loads, the browser may cache them, but initialization still involves compiling WASM to native code. The OPFS VFS also requires negotiating file system handles with the browser, which can be slow especially if the browser has stale locks from a previous crash.
+
+### 2b. Integrity Check
+
+```typescript
+const [[res]] = await db.execA<[string]>("PRAGMA integrity_check");  // db.ts:132
+```
+
+This runs SQLite's full integrity check on the database. For a large database, this walks every page. It's a linear scan of the entire file. On a 50MB database, this can take noticeable time.
+
+### 2c. Schema Check and Application
+
+```typescript
+const schemaRes = await getSchemaNameAndVersion(db);  // db.ts:140
+```
+
+Queries `crsql_master` for the stored schema name and version hash. Three outcomes:
+
+1. **No schema stored** (fresh DB): Apply the full schema from `$lib/schemas/init` and store the name + version. See [03-migrations.md](./03-migrations.md) for the schema file.
+2. **Schema matches**: Done. Set state to `Ready`.
+3. **Schema mismatch**: Enter the `Migrating` state and run auto-migration. See [03-migrations.md](./03-migrations.md).
+
+### 2d. State Transitions and the Splash
+
+The `AppDb.setState()` method (db.ts:95-116) updates a Svelte writable store. The `+layout.svelte` component subscribes to this store and calls `window.__dbInitUpdate(phase)` to drive the splash screen:
+
+```
+apps/web-client/src/routes/+layout.svelte:54-58
+```
+
+The state machine:
+```
+Null --> Loading --> [Migrating -->] Ready
+  \                                   |
+   +----------> Error <--------------+
+```
+
+When `Ready` is set, two things happen simultaneously:
+- The splash animates out (app.html:180-184)
+- `AppDbRx.invalidate(db)` wires up the reactive subscription system (db.ts:110)
+
+## Where the Time Goes: A Budget
+
+| Step | Typical time | Notes |
+|------|-------------|-------|
+| I18n detection + load | ~50-100ms | Fast unless fetching overrides |
+| WASM fetch (first load) | 500ms-2s | Depends on network; cached after |
+| WASM compilation | 200-500ms | Browser JIT compiles WASM to native |
+| VFS/OPFS handle acquisition | 50-500ms | Can be slow if stale locks exist |
+| `sqlite.open(dbname)` | 50-200ms | Opens file, reads header |
+| `PRAGMA integrity_check` | 100ms-2s | Linear scan of entire database |
+| Schema check | <10ms | Simple query |
+| Auto-migration (if needed) | 200ms-5s | Creates temp DB, diffs, applies |
+| Sync worker spawn | 50-100ms | Parallel with above after Ready |
+| **Total (warm cache, no migration)** | **~0.5-3s** | |
+| **Total (cold cache, with migration)** | **~2-8s** | |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web-client/src/app.html` | Splash screen HTML + state callback |
+| `apps/web-client/src/routes/+layout.ts` | Entry point, calls `initApp()` |
+| `apps/web-client/src/routes/+layout.svelte` | Bridges `AppDbState` to splash callback |
+| `apps/web-client/src/lib/app/init.ts` | `initApp()` / `initAppImpl()` orchestration |
+| `apps/web-client/src/lib/app/db.ts` | `AppDb` class, `initializeDb()`, state machine |
+| `apps/web-client/src/lib/db/cr-sqlite/db.ts` | `getDB()`, schema version, change functions |
+| `apps/web-client/src/lib/db/cr-sqlite/core/init.ts` | WASM loading, VFS factory, `getCrsqliteDB()` |
+
+## Potential Improvements
+
+See [06-known-issues.md](./06-known-issues.md) for a detailed analysis of what could be done to reduce loading time.

--- a/docs/architecture/02-sync.md
+++ b/docs/architecture/02-sync.md
@@ -1,0 +1,213 @@
+# Sync: From Browser to Server and Back
+
+This document covers the full sync pipeline: how changes leave the browser, reach the sync server, and return to other connected clients. It also covers the initial sync optimization and the FSNotify mechanism that caused the bug fixed in PR #1169.
+
+## Architecture Overview
+
+```
+Browser A                           Sync Server                     Browser B
+--------                           -----------                     --------
+                                        |
+Main Thread  <->  Sync Worker  <--> WebSocket <--> chokidar/FS  <->  Sync Worker  <->  Main Thread
+  (UI)           (Web Worker)       (ws-server)    (FSNotify)        (Web Worker)        (UI)
+                     |                  |                                |
+              SyncTransport         dbCache                      SyncTransport
+              Controller           (in-memory)                    Controller
+                     |                  |                                |
+              ChangesProcessor     touchHack                    ChangesProcessor
+```
+
+## The Sync Worker
+
+The sync worker runs in a dedicated Web Worker thread. It's defined in:
+
+```
+apps/web-client/src/lib/workers/sync-worker.ts
+```
+
+### Initialization (lines 63-104)
+
+When the main thread sends a `"start"` message, the worker:
+
+1. **Resolves WASM artefacts** for the given VFS (line 65)
+2. **Creates a `dbProvider`** -- a factory that, given a database name, loads the WASM module, creates the VFS, initializes cr-sqlite, and opens the database (lines 76-90)
+3. **Wraps the transport provider** with `SyncTransportController` for chunking and progress tracking (lines 94-97)
+4. **Calls `start(config)`** from `@vlcn.io/ws-client` to begin the sync loop (line 100)
+5. **Sends `"ready"`** back to the main thread (line 103) -- without this, the main thread hangs forever waiting for `initPromise`
+
+The critical detail: the sync worker creates its **own** database connection. It doesn't share the main thread's connection. The two connections share the same underlying file (via OPFS or IDB), but they are independent SQLite instances.
+
+### Worker Communication
+
+The `WorkerInterface` class (main thread side) manages bidirectional messaging:
+
+```
+apps/web-client/src/lib/workers/WorkerInterface.ts
+```
+
+**Outbound messages** (main -> worker):
+- `start`: Initialize with VFS config
+- `startSync` / `stopSync`: Begin or end syncing a specific database (inherited from `@vlcn.io/ws-client`)
+
+**Inbound messages** (worker -> main):
+- `changesReceived`: A batch of changes arrived from the server
+- `changesProcessed`: A batch finished applying
+- `progress`: Sync progress update (nProcessed/nTotal)
+- `ready`: Worker initialized
+- `connection.open` / `connection.close`: WebSocket state
+
+## The SyncTransportController
+
+```
+apps/web-client/src/lib/workers/sync-transport-control.ts:129-213
+```
+
+This is a decorator around the raw `Transport` from `@vlcn.io/ws-client`. It adds two things:
+
+### 1. Chunking via `ChangesProcessor`
+
+When a large batch of changes arrives (e.g., during initial sync), applying them all at once would block the worker thread. The `ChangesProcessor` (lines 70-127) breaks them into chunks of `MAX_SYNC_CHUNK_SIZE = 1024` changes:
+
+```typescript
+enqueue({ _tag, sender, changes, since }: Changes) {
+    for (const chunk of chunks(changes, this.#maxChunkSize)) {
+        this.#queue.push({ _tag, sender, changes: chunk, since });
+    }
+    if (!this.#running) {
+        this.#running = true;
+        this._processQueue();
+    }
+}
+```
+
+Each chunk is processed sequentially via `_processQueue()` (lines 86-104). The `onChunk` callback triggers the actual application of changes to the local database.
+
+### 2. Progress Tracking
+
+The `SyncEventEmitter` (lines 9-36) broadcasts progress to the main thread. The main thread uses this to show the sync dialog (see `+layout.svelte:103-104`).
+
+### 3. Connection Monitoring
+
+The `ConnectionEventEmitter` (lines 38-57) tracks WebSocket open/close events. The main thread uses `WorkerInterface.isConnected` to show connectivity status.
+
+## How Changes Flow
+
+### Outbound (local change -> server)
+
+1. User modifies data (e.g., adds a book to a note)
+2. The modification writes to the local SQLite database via cr-sqlite
+3. cr-sqlite automatically records the change in `crsql_changes` with the local `site_id`
+4. The `@vlcn.io/ws-client` library detects new local changes and calls `transport.sendChanges()`
+5. The `SyncTransportController` passes this through to the underlying WebSocket transport
+6. The server receives the changeset and applies it to its copy of the database
+
+### Inbound (server change -> local)
+
+1. The server detects a change (via another client's push, or via FSNotify -- see below)
+2. The server sends changesets over WebSocket to all connected clients
+3. `transport.onChangesReceived` fires in the sync worker
+4. `SyncTransportController._onChangesReceived()` enqueues the changes (line 183-185)
+5. `ChangesProcessor` chunks and processes them sequentially
+6. Each chunk is applied to the worker's database connection via `INSERT INTO crsql_changes`
+7. After processing, `changesReceived` event is posted to the main thread
+8. The main thread's `onChangesReceived` handler calls `app.db.rx.notifyAll()` to update the UI
+
+That last step -- `notifyAll()` -- is the recent fix from commit `b87fcd3c`. See [04-reactivity.md](./04-reactivity.md) for details.
+
+## Initial Sync Optimization
+
+```
+apps/web-client/src/lib/app/sync.ts:166-217
+```
+
+When a client connects for the first time (empty local database + OPFS-capable VFS), downloading a full snapshot is faster than streaming individual changesets:
+
+```typescript
+if (isEmpty && opfsSupported) {
+    sync.state.set(AppSyncState.InitialSync);
+    const fileUrl = getRemoteDbFileUrl(url, dbid);
+    await _performInitialSync(dbid, fileUrl, sync.initialSyncProgressStore, async () => {
+        shouldReload = true;
+        await db.close();
+    });
+}
+```
+
+The `_performInitialSync` function (lines 222-281):
+
+1. **Downloads the full database file** from `/{dbid}/file` on the sync server
+2. **Stores it temporarily** in OPFS as `{dbid}-temp`
+3. **Closes the current database** connection
+4. **Deletes the old OPFS file** and renames the temp file
+5. **Triggers a page reload** to reinitialize with the fresh database
+
+After reload, `isEmptyDB()` returns false (the downloaded DB has data), so the optimization is skipped and normal WebSocket sync begins.
+
+### Site ID Reidentification
+
+After downloading the server's database, the client must establish its own identity. The `reidentifyDbNode()` function (in `core/utils.ts`) generates a new `site_id` and attributes all existing clock entries to the server. This ensures future local changes are tracked as originating from this client, not from the server.
+
+## The Sync Server and FSNotify
+
+The sync server (external repo, `@vlcn.io/ws-server` based) exposes:
+
+- **WebSocket endpoint** for real-time changeset exchange
+- **`/{dbid}/exec`** for dev/e2e RPC (execute SQL against the server's copy)
+- **`/{dbid}/file`** for serving full database snapshots
+
+### The FSNotify Mechanism
+
+The server uses `chokidar` (file system watcher) to detect when database files change on disk. When a change is detected:
+
+1. `chokidar` fires a file event with the full path
+2. `fileEventNameToDbId()` converts the file path to a database ID
+3. The server looks up connected WebSocket clients for that database ID
+4. It pushes new changesets to those clients
+
+### The Bug Fixed in PR #1169
+
+The `fileEventNameToDbId` function was using `path.parse(filename).name`, which strips file extensions. For a database named `mydb.sqlite3`:
+
+- **Listeners registered as:** `mydb.sqlite3` (the full database name)
+- **FSNotify looked up:** `mydb` (extension stripped)
+
+Result: no match, no notification, no sync. The fix changed to `path.basename(filename)`, which preserves the extension.
+
+### touchHack
+
+When changes arrive via the HTTP API (e.g., `/{dbid}/exec`), the database file might not actually change on disk if the data is only in the in-memory WAL. The `touchHack` forces a file modification timestamp update so that `chokidar` detects it:
+
+```typescript
+dbProvider.use(dbname, async (db) => {
+    // ... apply changes ...
+    touchHack(dbFilePath);  // ensures FSNotify fires
+});
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web-client/src/lib/app/sync.ts` | `AppSync` class, `startSync()`, initial sync |
+| `apps/web-client/src/lib/workers/sync-worker.ts` | Web Worker: WASM init, sync loop |
+| `apps/web-client/src/lib/workers/WorkerInterface.ts` | Main thread proxy for worker communication |
+| `apps/web-client/src/lib/workers/sync-transport-control.ts` | Chunking, progress, connection monitoring |
+| `apps/web-client/src/lib/db/cr-sqlite/db.ts` | `getChanges()`, `applyChanges()` |
+| `apps/web-client/src/lib/db/cr-sqlite/core/utils.ts` | `reidentifyDbNode()`, OPFS helpers |
+
+## Threading Model
+
+```
+Main Thread                    Sync Worker Thread
+-----------                    ------------------
+App UI (Svelte)                @vlcn.io/ws-client loop
+App DB connection              Worker DB connection
+TblRx subscriptions           SyncTransportController
+                               WebSocket I/O
+                               ChangesProcessor
+
+Shared: OPFS file (same database, independent connections)
+Communication: postMessage() / onmessage
+```
+
+Both threads have their own SQLite WASM instance and their own connection to the same underlying file. The sync worker writes changesets from the server into its connection; the main thread reads data for the UI from its connection. Cross-thread notification happens via `postMessage` -> `onChangesReceived` -> `notifyAll()`.

--- a/docs/architecture/03-migrations.md
+++ b/docs/architecture/03-migrations.md
@@ -1,0 +1,159 @@
+# Migrations: Hash-Based Schema Evolution
+
+Librocco uses a hash-based migration system rather than numbered migration files. There is one canonical schema definition, and the system detects changes by comparing a hash of the current schema content against the stored hash in the database.
+
+## The Schema File
+
+```
+apps/web-client/src/lib/schemas/init
+```
+
+This file (no extension -- intentional, to work with the sync server's file resolution) contains all `CREATE TABLE IF NOT EXISTS` statements followed by `SELECT crsql_as_crr(...)` calls. It defines 13 tables:
+
+| Table | Purpose | CRR? |
+|-------|---------|------|
+| `customer` | Customer records | Yes |
+| `customer_order_lines` | Books ordered by customers | Yes |
+| `book` | Book catalog (ISBN-keyed) | Yes |
+| `supplier` | Supplier contacts | Yes |
+| `supplier_publisher` | Publisher-to-supplier mapping | Yes |
+| `supplier_order` | Orders to suppliers | Yes |
+| `supplier_order_line` | Line items in supplier orders | Yes |
+| `reconciliation_order` | Stock reconciliation records | Yes |
+| `reconciliation_order_lines` | Line items in reconciliation | Yes |
+| `customer_order_line_supplier_order` | Links customer orders to supplier orders | Yes |
+| `warehouse` | Physical storage locations | Yes |
+| `note` | Inbound/outbound/reconciliation notes | Yes |
+| `book_transaction` | Book movements (the core of inventory) | Yes |
+| `custom_item` | Non-book items on notes | Yes |
+
+Every single table is a CRR (Conflict-free Replicated Record). See [05-crdt-conflict-resolution.md](./05-crdt-conflict-resolution.md).
+
+### Foreign Keys Are Commented Out
+
+```sql
+-- apps/web-client/src/lib/schemas/init:34-35
+PRIMARY KEY (id)
+-- FOREIGN KEY (customer_id) REFERENCES customer(id) ON UPDATE CASCADE ON DELETE CASCADE,
+-- FOREIGN KEY (isbn) REFERENCES book(isbn) ON UPDATE CASCADE ON DELETE CASCADE
+```
+
+cr-sqlite forbids checked foreign key constraints on CRR tables. The rationale: during replication, rows may arrive out of order (a child before its parent), which would violate foreign key constraints even though the data is eventually consistent. The would-be foreign keys are documented as comments, and the corresponding indexes are created manually.
+
+This has real consequences. See [05-crdt-conflict-resolution.md](./05-crdt-conflict-resolution.md) and [06-known-issues.md](./06-known-issues.md).
+
+## Version Tracking
+
+```
+apps/web-client/src/lib/db/cr-sqlite/db.ts:1-12
+```
+
+```typescript
+import schemaContent from "$lib/schemas/init?raw";
+export const schemaName = "init";
+export const schemaVersion = cryb64(schemaContent);
+```
+
+The schema version is a CRC-64 hash of the raw file content. Any change -- even whitespace -- produces a new version. The name and version are stored in `crsql_master`:
+
+```sql
+INSERT OR REPLACE INTO crsql_master (key, value) VALUES ('schema_name', 'init');
+INSERT OR REPLACE INTO crsql_master (key, value) VALUES ('schema_version', <hash>);
+```
+
+At startup, `getSchemaNameAndVersion()` (db.ts:14-24) reads these values and compares:
+
+```
+apps/web-client/src/lib/app/db.ts:140-167
+```
+
+- **No stored schema** -> fresh DB, apply schema
+- **Name and version match** -> nothing to do
+- **Mismatch** -> auto-migrate
+
+## The Auto-Migration System
+
+```
+apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts
+```
+
+This is a JavaScript port of cr-sqlite's Rust `crsql_automigrate` function. It exists because the WASM build doesn't expose the Rust automigrate directly in all configurations.
+
+### Entry Point: `jsAutomigrateTo()`
+
+```typescript
+// migrations.ts:80-128
+export async function jsAutomigrateTo(db, schemaName, schemaContent): Promise<"noop" | "apply" | "migrate">
+```
+
+Returns:
+- `"noop"` -- version matches
+- `"apply"` -- no schema stored yet (first init)
+- `"migrate"` -- version mismatch, migration needed
+
+### Migration Flow
+
+When migration is needed (`"migrate"` path):
+
+1. **Strip CRR statements** from the schema (`strip_crr_statements`, lines 256-261)
+   - Removes lines containing `crsql_as_crr` or `crsql_fract_as_ordered`
+   - Reason: the migration creates a temporary in-memory database to compute the diff, and you can't load the cr-sqlite extension inside an already-running cr-sqlite instance
+
+2. **Create an in-memory temp DB** (line 160)
+   - Apply the stripped schema to it
+   - This represents the "target" state
+
+3. **Diff the schemas** via `migrate_to()` (lines 210-239)
+   - Compare table lists between local DB and temp DB
+   - Drop tables that no longer exist
+   - For each existing table, call `maybe_modify_table()`
+
+4. **Modify tables** via `maybe_modify_table()` (lines 280-317)
+   - Compare columns between local and temp
+   - For CRDT tables: wrap changes in `SELECT crsql_begin_alter(?)` / `SELECT crsql_commit_alter(?)` (lines 305, 313)
+   - Drop removed columns
+   - Add new columns
+   - Update indexes
+
+5. **Re-apply full schema** including CRR statements (line 199)
+
+6. **Update version** in `crsql_master`
+
+### CRDT Table Detection
+
+The `is_crr()` function (lines 322-330) detects CRDT tables by checking for the presence of a trigger named `{table}__crsql_itrig`:
+
+```sql
+SELECT count(*) FROM sqlite_master WHERE type = 'trigger' AND name = ?
+```
+
+### Transaction Safety
+
+The entire migration is wrapped in `SAVEPOINT automigrate_tables` (line 178 of db.ts) so it can be rolled back if anything fails. A failed migration transitions the app to `AppDbState.Error`, which shows an error on the splash screen with a "Reset Database" button.
+
+## The `Migrating` State
+
+When `initializeDb()` detects a schema mismatch, it:
+
+1. Sets `AppDbState.Migrating` (db.ts:170) -- the splash screen updates to "Migrating the database"
+2. Calls `db.automigrateTo(schemaName, schemaContent)` (db.ts:177)
+3. On success: transitions to `Ready`
+4. On failure: transitions to `Error` with `ErrDBCorrupted`
+
+The same flow applies to the demo DB initialization in `initializeDemoDb()` (db.ts:237-247).
+
+## Key Insight: Schema Idempotency
+
+All schema statements use `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`. This is essential because:
+- The schema file is applied in full on first initialization
+- During migration, the full schema (including CRR statements) is re-applied after column modifications
+- The `IF NOT EXISTS` ensures this is always safe
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web-client/src/lib/schemas/init` | Canonical schema definition |
+| `apps/web-client/src/lib/db/cr-sqlite/db.ts` | Schema version hashing, `getSchemaNameAndVersion()` |
+| `apps/web-client/src/lib/app/db.ts` | `initializeDb()` migration check and state transitions |
+| `apps/web-client/src/lib/db/cr-sqlite/debug/migrations.ts` | Full auto-migration implementation |

--- a/docs/architecture/04-reactivity.md
+++ b/docs/architecture/04-reactivity.md
@@ -1,0 +1,172 @@
+# Reactivity: From Database Writes to UI Updates
+
+This document explains how changes to the SQLite database reach the Svelte UI. It covers two scenarios: local changes (user interaction) and remote changes (arriving via sync). The latter was broken until commit `b87fcd3c`.
+
+## The Reactive Stack
+
+```
+SQLite write
+    |
+    v
+cr-sqlite update hook  (fires on INSERT/UPDATE/DELETE)
+    |
+    v
+TblRx  (@vlcn.io/rx-tbl)  (dispatches to matching listeners)
+    |
+    v
+AppDbRx  (librocco wrapper)  (manages subscriptions, transfers on DB swap)
+    |
+    v
+Svelte store / callback  (re-queries data, updates UI)
+```
+
+## TblRx: The Foundation
+
+`TblRx` is from the `@vlcn.io/rx-tbl` package. It hooks into SQLite's update callback to detect when tables change. It provides three subscription types:
+
+- **`onPoint(table, rowid, cb)`** -- fires when a specific row in a specific table changes
+- **`onRange(tables, cb)`** -- fires when any row in any of the listed tables changes
+- **`onAny(cb)`** -- fires on any change, with source information
+
+When a local `INSERT`, `UPDATE`, or `DELETE` executes, SQLite's native update hook fires, TblRx determines which subscribers are affected, and calls their callbacks.
+
+## AppDbRx: The Wrapper
+
+```
+apps/web-client/src/lib/app/rx.ts
+```
+
+`AppDbRx` wraps `TblRx` with two critical additions:
+
+### 1. Subscription Persistence Across DB Swaps
+
+When the database changes (e.g., after migration or initial sync), the underlying `TblRx` object must be replaced. But UI components shouldn't have to re-subscribe. The `RxListenerManager` (lines 37-91) solves this:
+
+```typescript
+transferToNewRx(next: TblRx | null) {
+    for (const [id, listener] of this.#listeners.entries()) {
+        this._unsubscribeSafe(id);  // unsub from old TblRx
+        switch (listener._kind) {
+            case "range":
+                const unsubscribe = next?.onRange(tables, cb) || (() => {});
+                this.set(id, { ...listener, unsubscribe });  // resub to new TblRx
+                break;
+            // ... similar for point and any
+        }
+    }
+}
+```
+
+When `AppDb.setState(dbid, AppDbState.Ready, { db, vfs })` is called (db.ts:107-112), it invokes `rx.invalidate(db)`:
+
+```typescript
+invalidate(db: DBAsync) {
+    // Notify all invalidate listeners (e.g., components that need to refetch)
+    for (const cb of this.#invalidateListeners) cb();
+
+    if (db != this.#db) {
+        this.#db = db;
+        this.#internal = tblrx(db);  // Create new TblRx for new DB
+        this.#rxListeners.transferToNewRx(this.#internal);  // Transfer subscriptions
+    }
+}
+```
+
+### 2. The `notifyAll()` Method (Recent Fix)
+
+**Problem:** When changes arrive via sync, they're applied in the sync worker's database connection, not the main thread's connection. The main thread's `TblRx` is hooked to the main thread's SQLite update callback, which doesn't fire for changes made by a different connection (even to the same file).
+
+**Solution (commit `b87fcd3c`):** After sync changes are received, manually blast all listeners:
+
+The main thread wires this up during sync initialization. In `+layout.svelte` or the sync setup code, `onChangesReceived` triggers `app.db.rx.notifyAll()`. This is currently implemented as a debounced call.
+
+`notifyAll()` iterates every registered listener and invokes its callback with an empty update array:
+
+```typescript
+// Conceptual implementation within RxListenerManager
+notifyAll() {
+    for (const listener of this.#listeners.values()) {
+        switch (listener._kind) {
+            case "point":
+            case "range":
+                listener.cb([]);  // "something changed, please requery"
+                break;
+            case "any":
+                listener.cb([], "thisProcess");
+                break;
+        }
+    }
+}
+```
+
+**Trade-offs of this approach:**
+- It works -- the UI updates when sync changes arrive
+- It's imprecise -- every listener fires, even if its table wasn't affected
+- It can cause unnecessary re-queries for unrelated components
+- The `"thisProcess"` source attribution for `onAny` is technically incorrect (the change came from sync, not this process)
+
+## How Components Subscribe
+
+A typical pattern in a Svelte component:
+
+```typescript
+// In +layout.svelte:123
+disposer = getDbRx(app).onRange(["book_transaction"], async () => {
+    stockCache.maybeInvalidate(await getDb(app));
+});
+```
+
+This subscribes to changes on the `book_transaction` table. When a row changes (locally or via `notifyAll()`), the callback re-queries the stock cache.
+
+The `getDbRx(app)` function (db.ts:276-281) throws if the DB isn't ready, ensuring components don't subscribe before initialization.
+
+## The Invalidation Flow
+
+### Local Change
+```
+User adds book to note
+  -> db.exec("INSERT INTO book_transaction ...")
+    -> SQLite update hook fires
+      -> TblRx dispatches to onRange(["book_transaction"], cb)
+        -> cb() re-queries and updates Svelte store
+          -> UI re-renders
+```
+
+### Remote Change (Post-Fix)
+```
+Sync worker receives changeset from server
+  -> Worker applies to its DB connection
+    -> Worker posts "changesReceived" to main thread
+      -> Main thread: app.db.rx.notifyAll()
+        -> ALL listeners fire (imprecise but correct)
+          -> Each cb() re-queries from main thread's DB
+            -> Main thread's DB sees the new data (shared OPFS file)
+              -> UI re-renders
+```
+
+### Remote Change (Pre-Fix -- Broken)
+```
+Sync worker receives changeset from server
+  -> Worker applies to its DB connection
+    -> Worker posts "changesReceived" to main thread
+      -> Main thread: ??? (nothing triggered notifyAll)
+        -> TblRx never fires (no local update hook triggered)
+          -> UI doesn't update
+            -> User must reload to see changes
+```
+
+## The Cross-Thread Data Visibility Question
+
+A subtle but important point: when the sync worker writes to its database connection and the main thread re-queries from its own connection, **does the main thread see the worker's writes?**
+
+Yes, because both connections share the same OPFS file (or IDB store). SQLite's WAL (Write-Ahead Log) mode ensures that readers see the latest committed data. The main thread may need to re-open its read transaction to see new data, but `TblRx` callbacks typically trigger new queries that establish new read snapshots.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web-client/src/lib/app/rx.ts` | `AppDbRx`, `RxListenerManager`, `notifyAll()` |
+| `apps/web-client/src/lib/app/db.ts` | `setState()` calls `rx.invalidate()` on Ready |
+| `apps/web-client/src/routes/+layout.svelte` | Root subscription setup (`onRange`, `onMount`) |
+| `apps/web-client/src/lib/workers/WorkerInterface.ts` | `onChangesReceived` event relay |
+| `@vlcn.io/rx-tbl` (external) | `TblRx` -- SQLite update hook -> subscriber dispatch |

--- a/docs/architecture/05-crdt-conflict-resolution.md
+++ b/docs/architecture/05-crdt-conflict-resolution.md
@@ -1,0 +1,206 @@
+# CRDT Conflict Resolution: How cr-sqlite Merges Data
+
+This document explains how cr-sqlite resolves conflicts when two clients modify data concurrently.
+
+**The fundamental guarantee:** After bidirectional sync completes, all databases converge to identical state. This is unconditional -- it holds regardless of operation ordering, network interruptions, or concurrent modifications. cr-sqlite's CRDT math ensures deterministic convergence. If two browsers show different data, the problem is either that sync hasn't finished yet, or that the UI isn't reflecting what the database already knows.
+
+## What cr-sqlite Does
+
+cr-sqlite turns ordinary SQLite tables into **Conflict-free Replicated Records (CRRs)**. When you call:
+
+```sql
+SELECT crsql_as_crr('note');
+```
+
+cr-sqlite creates hidden metadata tables and triggers that track every column-level change with:
+- A **column version** (`col_version`) -- a per-cell logical clock
+- A **database version** (`db_version`) -- a per-database logical clock
+- A **site ID** -- a unique identifier for the database instance
+- A **causal length** (`cl`) -- how many predecessor changes led to this one
+
+## Last-Write-Wins (LWW) per Cell
+
+The core conflict resolution strategy is **Last-Write-Wins at the column level**. Not at the row level -- at the *column* level.
+
+Example: Two clients update the same customer row concurrently.
+
+| Client A | Client B |
+|----------|----------|
+| `UPDATE customer SET fullname = 'Alice' WHERE id = 1` | `UPDATE customer SET email = 'bob@x.com' WHERE id = 1` |
+
+After sync, the result is `fullname = 'Alice'` AND `email = 'bob@x.com'`. There's no conflict because different columns were modified. Each column has its own version clock.
+
+If both clients modify the *same* column, the one with the higher `col_version` wins. If versions are equal, the `site_id` is used as a tiebreaker (lexicographic comparison of UUIDs). This is deterministic: every client will arrive at the same result regardless of the order changes are applied.
+
+## The `crsql_changes` Virtual Table
+
+```
+apps/web-client/src/lib/db/cr-sqlite/db.ts:47-63
+```
+
+All changes are exchanged through the `crsql_changes` virtual table. A single change represents one cell modification:
+
+```typescript
+type Change = readonly [
+    TableName,      // "book_transaction"
+    PackedPks,      // Primary key(s), packed into a binary format
+    CID,            // Column ID (column name, e.g., "quantity")
+    Val,            // New value
+    col_version,    // How many times this specific cell has been written
+    db_version,     // Logical clock of the database at time of write
+    site_id,        // UUID of the originating database
+    cl,             // Causal length
+    seq             // Sequence within a transaction
+];
+```
+
+### Reading Local Changes
+
+```typescript
+const getChanges = (db, since) => {
+    return db.execA(`
+        SELECT "table", "pk", "cid", "val", "col_version", "db_version", "site_id", "cl", "seq"
+        FROM crsql_changes
+        WHERE db_version > ? AND site_id = crsql_site_id()
+    `, [since]);
+};
+```
+
+Note: `site_id = crsql_site_id()` filters to only local changes. The sync layer tracks "since" cursors per peer to avoid re-sending.
+
+### Applying Remote Changes
+
+```typescript
+const applyChanges = async (db, changes) => {
+    for (const change of changes) {
+        await db.exec(`
+            INSERT INTO crsql_changes
+                ("table", "pk", "cid", "val", "col_version", "db_version", "site_id", "cl", "seq")
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, change);
+    }
+};
+```
+
+When you `INSERT INTO crsql_changes`, cr-sqlite doesn't blindly overwrite. It compares the incoming `col_version` with the stored one and only applies the change if it wins the LWW comparison.
+
+## Clock Tables
+
+cr-sqlite creates hidden clock tables for each CRR:
+
+- `{table}__crsql_clock` -- tracks the latest version for each (pk, column) pair
+- `crsql_site_id` -- stores the local site ID and any known peer site IDs
+
+The `crsql_tracked_peers` table records the last `db_version` seen from each peer, so the sync layer knows where to resume.
+
+## What This Means for Librocco
+
+### Every Table is a CRR
+
+All 14 tables in the schema are activated as CRRs. This means:
+
+1. **No foreign key enforcement** -- cr-sqlite prohibits checked foreign keys on CRRs. Rows can reference nonexistent parents. Indexes are created manually to approximate the query performance foreign keys would provide.
+
+2. **Eventual consistency** -- every client will converge to the same state, but the path to convergence depends on the order changes arrive.
+
+3. **No transactions across tables at the sync level** -- SQLite transactions are local. When you `INSERT INTO note` and then `INSERT INTO book_transaction` in one local transaction, they ship as separate changes that may arrive at other clients at different times.
+
+### The `book_transaction` Composite Key
+
+```sql
+-- schemas/init:164-176
+CREATE TABLE IF NOT EXISTS book_transaction (
+    isbn TEXT NOT NULL,
+    quantity INTEGER NOT NULL DEFAULT 0,
+    note_id INTEGER NOT NULL,
+    warehouse_id INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    committed_at INTEGER,
+    last_bubbled_up INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (isbn, note_id, warehouse_id)
+);
+```
+
+The primary key is `(isbn, note_id, warehouse_id)`. This is a composite key, meaning:
+
+- `(isbn: "978-X", note_id: 42, warehouse_id: 1)` is one row
+- `(isbn: "978-X", note_id: 42, warehouse_id: 2)` is a **different** row
+
+Both can exist simultaneously. cr-sqlite treats them as independent entities that never conflict with each other (different PKs = different rows).
+
+### Why Two Browsers Showed Different Books (UI Divergence, Not DB Divergence)
+
+The observed bug -- same outbound note, different books in two browsers -- was **not** a cr-sqlite convergence failure. After sync completed, both databases contained identical data. The problem was that the UI didn't know the database had changed.
+
+**What happened:**
+
+1. Browser A adds isbn "978-A" to note 42. Browser B adds isbn "978-B" to note 42.
+2. Sync runs. Both databases now contain both "978-A" and "978-B". cr-sqlite guarantees this.
+3. **But the UI didn't re-query.** The sync worker applied changes to its database connection, but the main thread's `TblRx` was never notified. See [04-reactivity.md](./04-reactivity.md).
+4. Browser A's UI still showed only "978-A". Browser B's UI still showed only "978-B". A page refresh on either browser would reveal both books.
+
+The fix (`notifyAll()` in commit `b87fcd3c`) ensures the UI re-queries after sync changes arrive. The databases were always correct; the reactivity layer was the broken link.
+
+### Semantic Surprises (Not Conflicts)
+
+Even with convergence guaranteed, CRDTs can produce results that surprise application-level expectations. These aren't bugs -- they're consequences of the CRDT model:
+
+**The note commit race:** When a note is committed (`commitNote()`), it sets `committed = 1` and `committed_at = now()`. If Browser A commits while Browser B's book addition hasn't synced yet, then after full sync completes, both databases will show: a committed note with a book transaction that has `committed_at = NULL`. Both databases agree on this state -- it's consistent, just semantically odd. The application didn't anticipate a book arriving after commit.
+
+This is a business-logic gap, not a CRDT failure. CRDTs guarantee the databases match; they don't guarantee the result makes business sense. Handling this requires application-level guards (e.g., checking sync status before commit).
+
+## Site ID Management
+
+```
+apps/web-client/src/lib/db/cr-sqlite/core/utils.ts:313-349
+```
+
+Each database instance has a unique site ID (a UUID stored as bytes). The `reidentifyDbNode()` function is called after initial sync (downloading a full DB snapshot):
+
+```typescript
+async function reidentifyDbNode(db: DBAsync) {
+    await db.tx(async (txDb) => {
+        await txDb.exec("DELETE FROM crsql_tracked_peers");
+        await txDb.exec("DELETE FROM crsql_site_id WHERE ordinal != 0");
+        await txDb.exec("UPDATE crsql_site_id SET ordinal = 1 WHERE ordinal = 0");
+
+        const siteid = uuidV4Bytes();
+        await txDb.exec(
+            "INSERT INTO crsql_site_id (site_id, ordinal) VALUES (?, ?)",
+            [siteid, 0]
+        );
+
+        // Mark all existing clock entries as from the server
+        for (const [tbl] of crsql_clock_tables) {
+            await txDb.exec(`UPDATE ${tbl} SET site_id = 1`);
+        }
+    });
+}
+```
+
+This ensures:
+- The client gets a fresh identity
+- All pre-existing data is attributed to the server (ordinal 1)
+- Future local changes are tracked under the new site ID
+
+## Summary: What CRDTs Guarantee and What They Don't
+
+**Guaranteed (unconditionally, after bidirectional sync completes):**
+- **Database convergence:** all clients have identical database state
+- **No data loss:** concurrent edits to different cells/rows are all preserved
+- **Deterministic conflict resolution:** LWW with site ID tiebreaker produces the same winner on every client
+
+**Not guaranteed (application-layer concerns):**
+- Referential integrity: child rows can exist without parents (no checked FKs)
+- Business rule enforcement: "a committed note contains exactly these books" is not expressible at the CRDT level
+- Instant propagation: there's always a latency window where databases differ (sync in progress)
+- UI consistency: the UI must be explicitly told to re-query after sync changes arrive (the `notifyAll()` fix)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `apps/web-client/src/lib/schemas/init` | All CRR table definitions |
+| `apps/web-client/src/lib/db/cr-sqlite/db.ts` | `getChanges()`, `applyChanges()`, `getSiteId()` |
+| `apps/web-client/src/lib/db/cr-sqlite/core/utils.ts` | `reidentifyDbNode()`, clock table management |
+| `apps/web-client/src/lib/db/cr-sqlite/note.ts` | Note operations, commit logic |

--- a/docs/architecture/06-known-issues.md
+++ b/docs/architecture/06-known-issues.md
@@ -1,0 +1,178 @@
+# Diagnosis: The Slow Loading Screen and the Inconsistent Note
+
+This document brings together everything from the other architecture docs to analyze the two issues that motivated this documentation effort.
+
+## Issue 1: The Loading Screen Takes Too Long
+
+### What You See
+
+The splash screen ("Librocco is loading. Hang tight!") persists for several seconds before the app becomes usable.
+
+### Root Cause: Sequential Blocking Initialization
+
+The initialization in `initAppImpl()` (`apps/web-client/src/lib/app/init.ts:54-69`) is a strictly sequential chain:
+
+```typescript
+await initializeI18n();              // Step 1
+await initializeDb(app, dbid, vfs);  // Step 2 (the bottleneck)
+await initializeSync(app, vfs);      // Step 3
+```
+
+Nothing runs in parallel. The database initialization (Step 2) is where the time goes, and it has its own sequential sub-steps:
+
+```
+WASM fetch/compile -> VFS init -> sqlite.open() -> PRAGMA integrity_check -> schema check -> [migration]
+```
+
+### The Major Bottlenecks
+
+#### 1. WASM Loading (500ms-2s on first load)
+
+`getCrsqliteDB()` in `apps/web-client/src/lib/db/cr-sqlite/core/init.ts:46-58`:
+
+```typescript
+const ModuleFactory = await getModule();    // Dynamic import of ~1-2MB WASM module
+const initializer = createWasmInitializer({ ModuleFactory, vfsFactory, cacheKey });
+const sqlite = await initializer(() => wasmUrl);  // Compile + instantiate
+```
+
+Three WASM builds exist (`sync`, `asyncify`, `jspi`), selected by VFS. Each is a separate ~1-2MB binary. Browser caching helps on subsequent loads, but compilation still takes time.
+
+#### 2. VFS Initialization
+
+OPFS (Origin Private File System) requires negotiating file handles with the browser. If a previous session crashed without releasing locks, the browser may take extra time to recover. The "coop-sync" VFS variants require a shared worker + Atomics-based locking.
+
+#### 3. `PRAGMA integrity_check` (100ms-2s)
+
+```typescript
+// db.ts:132
+const [[res]] = await db.execA<[string]>("PRAGMA integrity_check");
+```
+
+This is a **full linear scan** of every page in the database file. For a 50MB database with tens of thousands of records, this is measurable. It runs on every startup, even if the database is perfectly fine.
+
+#### 4. I18n Before DB
+
+```typescript
+await initializeI18n();  // init.ts:57
+```
+
+I18n is loaded first and blocks everything. If translation overrides are fetched via HTTP (the `override-translations-it` URL param), this adds a full network round-trip before database initialization even begins.
+
+### Potential Improvements
+
+#### Parallelize I18n and DB Init
+I18n and DB initialization are independent. They could run concurrently:
+
+```typescript
+await Promise.all([
+    initializeI18n(),
+    initializeDb(app, dbid, vfs)
+]);
+```
+
+The splash screen doesn't need translations (it uses hardcoded English strings), so the DB can start loading immediately.
+
+#### Defer or Weaken the Integrity Check
+`PRAGMA integrity_check` is defensive but expensive. Options:
+- **Remove it entirely** -- rely on SQLite's own crash recovery (WAL journaling handles most corruption scenarios)
+- **Replace with `PRAGMA quick_check`** -- checks only structural integrity, not index consistency. Much faster.
+- **Run it in the background** after the app is ready, and only show a warning if it fails
+
+#### WASM Preloading
+The WASM binary URL is known at build time. A `<link rel="preload">` tag in `app.html` could start the fetch immediately, before any JavaScript executes:
+
+```html
+<link rel="preload" href="/crsqlite.wasm" as="fetch" crossorigin>
+```
+
+This wouldn't help with compilation time, but would eliminate the fetch latency.
+
+#### Lazy Sync Worker Initialization
+The sync worker is initialized during `initAppImpl()`, blocking the transition to Ready. If sync isn't configured, this is wasted time. Even when sync is configured, the app could show the UI immediately and start sync in the background.
+
+Currently, `initializeSync()` is called sequentially after DB init, but `startSync()` already has its own readiness checks. The worker initialization could happen in parallel with or after the first render.
+
+#### Trade-offs
+
+| Improvement | Effort | Risk | Impact |
+|-------------|--------|------|--------|
+| Parallelize I18n + DB | Low | Low (independent systems) | ~100-300ms saved |
+| Replace integrity_check | Low | Medium (less corruption detection) | ~100ms-2s saved |
+| WASM preload | Low | None | ~200-500ms saved (first load only) |
+| Lazy sync worker | Medium | Medium (race conditions) | ~50-100ms saved |
+| Skip integrity_check entirely | Low | Higher (undetected corruption) | ~100ms-2s saved |
+
+---
+
+## Issue 2: Same Outbound Note Shows Different Books
+
+### What You See
+
+Two browsers syncing with the same server. Both are viewing the same outbound note. One shows books A and B, the other shows books A and C (or just different subsets).
+
+### Key Principle: The Databases Were Identical
+
+cr-sqlite guarantees that after bidirectional sync completes, both databases converge to the same state. This is unconditional. If two browsers showed different books, the databases were either mid-sync (data not yet propagated) or the **UI wasn't reflecting the database state**. The databases themselves were not divergent.
+
+### Root Cause: Missing UI Notifications (Fixed in b87fcd3c)
+
+**Before the fix:** When sync changes arrived via the Web Worker, the main thread's `TblRx` wasn't notified. The underlying database had the correct, converged data, but the UI never re-queried. Both databases contained the same books; only the UI was stale. See [04-reactivity.md](./04-reactivity.md).
+
+**After the fix:** `notifyAll()` blasts all listeners after sync changes arrive. The UI re-queries and shows the latest data.
+
+A page refresh would have revealed that both browsers had the same data all along. The divergence was between the UI and its own database, not between the two databases.
+
+### Secondary Factor: Sync Latency Window
+
+Even with `notifyAll()` working correctly, there's always a window between when a change is made on one browser and when it appears on another:
+
+```
+Browser A: local write
+  -> cr-sqlite records change
+    -> ws-client detects and sends
+      -> Network transit
+        -> Server receives and stores
+          -> Server pushes to Browser B
+            -> Browser B worker applies
+              -> postMessage to main thread
+                -> notifyAll()
+                  -> UI re-queries and renders
+```
+
+During this window (typically <1 second on a good connection), the two databases genuinely differ -- sync hasn't finished yet. This is inherent to any distributed system and not a bug. Once bidirectional sync completes, the databases are identical.
+
+### Semantic Surprises (Not Data Divergence)
+
+Even with perfect sync and perfect UI reactivity, the CRDT model can produce results that surprise business expectations. These are not bugs in cr-sqlite -- the databases converge correctly -- but they may violate assumptions the application makes:
+
+- **Post-commit book arrival:** Browser A commits a note. Browser B's book addition syncs afterward. Both databases agree: the note is committed AND has a book_transaction with `committed_at = NULL`. Consistent data, surprising semantics.
+- **Orphaned rows:** No checked foreign keys means a `book_transaction` can reference a deleted note. Both databases agree the orphan exists.
+- **Duplicate warehouse entries:** The composite key `(isbn, note_id, warehouse_id)` means two browsers adding the same ISBN from different warehouses creates two rows. Both databases agree on both rows.
+
+In every case, the databases converge. The question is whether the application layer handles the converged state correctly.
+
+### Improvements
+
+#### 1. Confirm notifyAll Fix is Sufficient (Done)
+The e2e test in `sync.spec.ts` ("should update UI when remote-only changes arrive via sync") validates that remote changes appear in the UI without user interaction.
+
+#### 2. Add Table-Specific Notifications
+The current `notifyAll()` fires every listener. A more targeted approach would parse the incoming changeset to determine which tables changed and only notify relevant listeners. This would improve performance and reduce unnecessary re-queries.
+
+#### 3. Application-Level Guards for Critical Operations
+For business-critical operations (like committing a note), the application could:
+- Check for unsynced changes before committing
+- Require a sync round-trip before allowing commit
+- Show a warning if the note has been modified on another device
+
+This is application-level logic, not CRDT-level. CRDTs guarantee convergence; application guards enforce business rules on top of that converged state.
+
+---
+
+## Summary
+
+| Issue | Primary Cause | Status | Notes |
+|-------|--------------|--------|-------|
+| Slow loading | Sequential init + WASM load + integrity check | Open | See improvement trade-offs above |
+| Different books in UI | UI not re-querying after sync (missing `notifyAll()`) | Fixed (b87fcd3c) | Databases were always converged; the UI was stale |

--- a/docs/architecture/07-sync-user-requirements.md
+++ b/docs/architecture/07-sync-user-requirements.md
@@ -1,0 +1,506 @@
+# Sync: User Requirements and Implementation Status
+
+This document defines the user-facing requirements for sync behavior, analyzes the current implementation, identifies gaps, and provides recommendations for achieving the desired behavior. It serves as both a specification and a roadmap.
+
+## User-Facing Requirements
+
+From the user's perspective, the sync system should provide clear, reliable feedback about data safety:
+
+### Requirement 1: Green Light = Server Changes Are Local
+
+> If the user sees a green "Remote DB" light in the footer, any changes from more than one (or a few) seconds ago to the remote database on the sync server have already been synced to this browser.
+
+**Implication**: The green light is a guarantee that the local database is up-to-date with the server, within a small time window.
+
+### Requirement 2: Green Light = Local Changes Will Be Persisted
+
+> If the user sees a green "Remote DB" light in the footer, any action done locally will (to the best of the software's knowledge) immediately be persisted to the sync server.
+
+**Implication**: The green light means "it's safe to make changes -- they will be saved remotely". It's a promise that the sync channel is working in both directions.
+
+### Requirement 3: Awareness of Pending Local Changes
+
+> Librocco should be aware if there are any local changes that need to be pushed to the sync server but haven't been and can't be pushed right now. The footer should include info about it.
+
+**Implication**: Users need to know when their work exists only locally, especially before closing the browser or during network issues.
+
+### Requirement 4: Recovery from Unsyncable State
+
+> In case the remote database is unsyncable (e.g., the server database was rebuilt after corruption), the user should be given the chance to "Nuke and Resync".
+
+**Implication**: The system must detect incompatibility and offer a clear recovery path rather than silently failing or showing a misleading green light.
+
+---
+
+## Current Implementation State
+
+### The Footer Component
+
+**File**: `apps/web-client/src/lib/components/ExtensionStatusBanner.svelte`
+
+The footer now shows a single "Remote DB" badge (the Book Data Extension badge has been removed). The badge color reflects the sync state (yellow while connecting, green when connected, red when disconnected or stuck), and it appends a pending count when there are unsent local changes:
+
+```svelte
+<div class="badge" data-status={$syncState.status}>
+  <div class={indicatorClass}></div>
+  <p>{`Remote DB${$syncState.pending ? ` (${$syncState.pending} pending)` : ''}`}</p>
+</div>
+```
+
+**Current Behavior**: The indicator derives from `syncConnectivityMonitor` plus a pending-changes store that counts local `crsql_changes` rows newer than the last server-acknowledged version (`ackDbVersion`, persisted per DB). Green means connected, compatibility verified, and no pending local changes.
+
+#### Low-effort UX improvements for the indicator
+
+- Pair color with a short label: show the dot plus text (`Synced`, `Syncing…`, `Disconnected`) to help color-blind users and new users.
+- Add cause on red: include a compact reason (`offline`, `server error`, `schema mismatch`) based on existing connectivity/compatibility state.
+- Show freshness: append “as of <age>s ago”; if no steady ACK within N seconds, flip from yellow to red with “No ack for <age>s”.
+- Make yellow meaningful: use yellow only while waiting for the first steady/apply ACK or while pending > 0; otherwise prefer green/red to avoid ambiguity.
+- Expose pending in-label: when syncing, show `Syncing (N pending)` so users see drain progress.
+- Tooltip/details: clicking/hovering shows connection state, last ack version/time, pending count, schema compatibility, and a retry action; add `aria-label` with the full sentence for accessibility.
+- Retry affordance: when red, show a small “Retry” in the tooltip; when schema mismatch, show “Reload / Update app”.
+
+### Connectivity Tracking
+
+**File**: `apps/web-client/src/lib/stores/app.ts`
+
+The `syncConnectivityMonitor` tracks:
+
+- `connected`: Boolean, set `true` on WebSocket open, `false` on close
+- `stuck`: Boolean, set `true` after 3 rapid connection failures or 10s timeout
+- `diagnostics`: Object with failure reason and counts
+
+```typescript
+const unsubscribeOpen = worker?.onConnOpen(() => {
+  _syncConnectivityMonitor.connected.set(true); // GREEN
+  // ...
+});
+
+const unsubscribeClose = worker?.onConnClose(() => {
+  _syncConnectivityMonitor.connected.set(false); // RED
+  // ...
+});
+```
+
+### Sync Progress Dialog
+
+**File**: `apps/web-client/src/routes/+layout.svelte`
+
+Shows during sync with a progress bar displaying `nProcessed/nTotal`:
+
+```svelte
+{tLayout.sync_dialog.description.progress({
+  nProcessed: $syncProgress.nProcessed,
+  nTotal: $syncProgress.nTotal
+})}
+```
+
+### Sync Stuck Detection and Recovery
+
+**Files**: `lib/stores/app.ts`, `routes/+layout.svelte`
+
+When sync is detected as "stuck" (rapid connection failures or timeout), a dialog appears offering "Nuke and Resync" -- which deletes the local OPFS database and triggers re-download from the server.
+
+### Sync Server File Watching (.sqlite3 fix)
+
+**Files**: `3rd-party/js/packages/ws-server/src/fs/util.ts`, `3rd-party/js/packages/ws-server/src/fs/FSNotify.ts`, `apps/sync-server/src/index.ts`, `python-apps/launcher/launcher/config.py`
+
+The `@vlcn.io/ws-server` FSNotify code now preserves file extensions when normalizing events (it previously dropped `.sqlite3`, breaking watch registration). We also:
+
+- Proxy all `*.sqlite3` and `*.sqlite` HTTP endpoints through Caddy in the headless launcher so `/exec` and `/file` routes reach the sync server instead of 404-ing in CI.
+- Turn on `notifyPolling` in dev
+- Run `touchHack` after HTTP `/exec` mutations to force a watch event on the DB file
+
+Remote-only changes now reach WebSocket clients for `.sqlite3` databases; the e2e sync suite runs without skips.
+
+### Compatibility Handshake + UI
+
+**Files**: `apps/sync-server/src/index.ts`, `apps/web-client/src/lib/stores/sync-compatibility.ts`, `apps/web-client/src/lib/app/sync.ts`, `apps/web-client/src/routes/+layout.svelte`, `apps/web-client/src/lib/components/ExtensionStatusBanner.svelte`
+
+- The sync server emits a WebSocket `SyncStatus` handshake carrying DB `site_id` (from the database, not a sidecar), `schema_name`, and `schema_version` before streaming starts. If the handshake is incompatible, the server closes the socket after sending the status.
+- The client keeps the sync indicator in "connecting" until a compatible handshake arrives; it stores the remote `site_id` per DB and marks the UI as incompatible when the remote identity changes or the schema version differs. HTTP `/:dbname/meta` is now best-effort only (no longer required to show incompatibility).
+- After the first inbound apply succeeds, the server now emits a `SyncStatus` steady ACK with `ackDbVersion`; every subsequent inbound apply sends `stage: "apply_ack"` with the highest applied `db_version`. Apply errors emit `reason: apply_failed` mid-stream.
+- The client treats steady/apply ACKs as verification, persists the last acknowledged `db_version` per DB, and uses it to clear pending counts only when the server confirms apply. Compatibility resets when running "Nuke and Resync". E2E coverage includes a rebuilt-DB scenario even when the HTTP meta endpoint is blocked.
+
+---
+
+## Gap Analysis
+
+### Gap 1: "Connected" Doesn't Mean "Syncable"
+
+**Mitigation now**: The server emits a WebSocket `SyncStatus` handshake (site_id, schema_version) before streaming, then sends a steady `SyncStatus` with `ackDbVersion` after the first inbound apply, and `stage: "apply_ack"` for every subsequent inbound apply. Any apply error (including later batches) sends `reason: apply_failed`. The client stays in "connecting" until the first steady ACK, and surfaces incompatibility on any `apply_failed` regardless of `/meta`.
+
+**Remaining risk**: We still assume the stream remains healthy between ACKs; there's no mid-stream schema drift detection beyond apply failures, and ACKs don't yet carry durability metadata (e.g., fsync or downstream replication state).
+
+### Gap 2: No Tracking of Pending Local Changes
+
+**Current**: The footer now shows pending counts based on the last server-acknowledged `db_version` (`ackDbVersion` from `SyncStatus` steady/apply_ack). Pending only clears when the server confirms apply; apply failures keep pending > 0.
+**Required**: Consider persisting server ACK state on the server or adding a catch-up ACK when reconnecting so the client can reconcile if an ACK was lost mid-disconnect.
+
+**Why This Matters**:
+
+- Users might close the browser thinking their changes are saved
+- Network interruptions could cause silent data loss
+- No way to know if "green light" means "all synced" or "connection open but queue full"
+
+### Gap 3: Progress Numbers Are Meaningless
+
+**Current**: Progress now reports change counts (number of CR-SQL change entries) instead of chunk counts, but it still lacks a notion of record size or time remaining.
+**Required**: Progress should indicate actual data volume or time remaining; change counts are a step closer but not a full solution.
+
+### Gap 4: No Validation of Sync Compatibility
+
+**Status**: Mitigated. WebSocket `SyncStatus` now validates schema version and database identity before the connection is considered "connected", sends steady/apply ACKs with `ackDbVersion` for every inbound apply, and emits `apply_failed` for any apply error.
+
+**Next Step**: Add schema drift detection beyond apply failures (e.g., periodic schema hash) and consider persisting/replaying the last ACK on reconnect so clients can reconcile even if the final ACK was lost.
+
+## Implementation Recommendations
+
+### Recommendation 1: Implement Pending Changes Counter (Option A)
+
+Use a periodic query of `crsql_changes` to count unsynced local changes.
+
+**Status**: Implemented. The client persists the last server-acknowledged `db_version` (`ackDbVersion` from `SyncStatus`) per DB and clears pending only when the server confirms apply. Next step would be to add a server-side ACK replay on reconnect to recover if the last ACK was lost.
+
+**Approach**:
+
+1. Track the last acknowledged server version for each peer
+2. Query: `SELECT COUNT(*) FROM crsql_changes WHERE db_version > ?`
+3. Update the footer to show: "Remote DB (3 pending)" or just the green light when 0
+
+**Implementation Sketch**:
+
+```typescript
+// In lib/stores/app.ts or new file lib/stores/sync-pending.ts
+
+export const pendingChangesCount = writable<number>(0);
+
+export async function updatePendingChangesCount(db: DB) {
+  const localVersion = await getDBVersion(db);
+  const serverAckVersion = await getLastAcknowledgedVersion(db);
+
+  const result = await db.execO<{ count: number }>(`SELECT COUNT(*) as count FROM crsql_changes WHERE db_version > ?`, [serverAckVersion]);
+
+  pendingChangesCount.set(result[0]?.count ?? 0);
+}
+```
+
+**Trade-offs**:
+
+- **Pro**: Uses existing cr-sqlite mechanisms
+- **Pro**: Works offline (shows accumulated pending changes)
+- **Con**: Requires periodic polling or triggered updates
+- **Con**: "Acknowledged version" concept needs definition (see Recommendation 4)
+
+### Recommendation 2: Fix Progress Tracking to Show Record Counts
+
+**Problem**: `nProcessed/nTotal` shows chunks, not records.
+
+**Fix Approach**:
+
+1. Track total records across all chunks:
+
+   ```typescript
+   enqueue({ changes, ... }: Changes) {
+     this.#totalRecords += changes.length;  // Track actual record count
+     for (const chunk of chunks(changes, this.#maxChunkSize)) {
+       this.#queue.push({ ... });
+     }
+   }
+   ```
+
+2. Track processed records:
+
+   ```typescript
+   private _processQueue = async () => {
+     while (i < this.#queue.length) {
+       const chunk = this.#queue[i];
+       this.#processedRecords += chunk.changes.length;
+
+       this.onProgress?.({
+         active: true,
+         nProcessed: this.#processedRecords,
+         nTotal: this.#totalRecords
+       });
+     }
+   }
+   ```
+
+**Consideration**: For very large syncs, show byte-based progress or estimated time. Record counts can still be confusing if each record varies in size.
+
+### Recommendation 3: Add Sync Handshake Validation
+
+Before showing a green light, validate that sync is actually working:
+
+1. **Schema Version Check**: Compare local schema hash with server's
+2. **Identity Validation**: Verify the server recognizes this client's site_id
+3. **Data Flow Test**: Confirm at least one successful round-trip
+
+**Implementation Approach**:
+
+Add a "validation" phase after WebSocket connect:
+
+```typescript
+// In SyncTransportController or sync-worker.ts
+
+async validateSyncCompatibility(): Promise<{ compatible: boolean; reason?: string }> {
+  // 1. Send a probe message
+  // 2. Server responds with its schema version and known peers
+  // 3. Compare with local state
+  // 4. Return compatibility result
+}
+```
+
+**Note**: This requires changes to the sync server protocol. Consider whether `@vlcn.io/ws-server` supports custom handshake messages or if a separate HTTP endpoint is needed.
+
+**Alternative (Simpler)**: Detect incompatibility from sync failures:
+
+- If changes are repeatedly rejected → mark as incompatible
+- If connection closes immediately after sending changes → likely schema mismatch
+- This is essentially what the "stuck detection" does, but could be made more specific
+
+### Recommendation 4: Harden ACK Semantics
+
+A distinction between "sent" and "applied on server" now exists via `SyncStatus` (`ackDbVersion`):
+
+- Changes written locally (in `crsql_changes`)
+- Changes sent over WebSocket
+- Changes acknowledged as applied by the server (`ackDbVersion`)
+
+**Current model**:
+
+- Pending tracking uses `db_version > last_ack_version`
+- Compatibility stays in "connecting" until steady/apply ACK arrives
+- Apply failures force incompatible state
+
+**Remaining hardening**:
+
+- Add ACK replay on reconnect so a lost final ACK does not leave stale pending counts
+- Optionally attach durability metadata (if needed later) beyond "applied in server process"
+
+### Recommendation 5: Footer State Machine
+
+Define clear states for the sync indicator:
+
+| State          | Visual            | Meaning                       |
+| -------------- | ----------------- | ----------------------------- |
+| `disconnected` | Red dot           | No connection to server       |
+| `connecting`   | Yellow/pulsing    | Connection in progress        |
+| `synced`       | Green dot         | Connected, 0 pending changes  |
+| `syncing`      | Green dot + count | Connected, N pending changes  |
+| `stuck`        | Red dot + warning | Connection failing repeatedly |
+| `incompatible` | Red dot + error   | Server DB is incompatible     |
+
+### Current Gaps After Recent Changes
+
+- Progress events now surface and reflect record counts (changes) even when subscribers attach after completion; still no size/ETA.
+- Pending-count logic is ACK-based (`ackDbVersion`); remaining gap is ACK replay/reconciliation after reconnect.
+- The `.sqlite3` FSNotify fix is local to our vendored `@vlcn.io/ws-server`; upstreaming or pinning the patched build is still required to avoid regression on dependency updates.
+
+**Implementation**:
+
+```typescript
+type SyncState =
+  | { status: 'disconnected' }
+  | { status: 'connecting' }
+  | { status: 'synced' }
+  | { status: 'syncing'; pending: number }
+  | { status: 'stuck'; diagnostics: SyncStuckDiagnostics }
+  | { status: 'incompatible'; reason: string };
+
+export const syncState = derived(
+  [syncConnectivityMonitor.connected, syncConnectivityMonitor.stuck, pendingChangesCount],
+  ([connected, stuck, pending]) => {
+    if (stuck) return { status: 'stuck', diagnostics: ... };
+    if (!connected) return { status: 'disconnected' };
+    if (pending > 0) return { status: 'syncing', pending };
+    return { status: 'synced' };
+  }
+);
+```
+
+---
+
+## E2E Testing Requirements
+
+Testing sync behavior is challenging because it involves multiple async systems (WebSocket, database, Web Worker). Prioritize tests that prevent data loss.
+
+### Priority 1: Critical Path Tests (Prevent Data Loss)
+
+#### Test: Stuck Detection Triggers on Incompatible DB
+
+```typescript
+test("shows stuck dialog when server DB is rebuilt", async () => {
+  // 1. Connect normally, sync some data
+  // 2. Rebuild server DB (new site_id)
+  // 3. Verify stuck dialog appears within 10s
+  // 4. Verify "Nuke and Resync" recovers successfully
+});
+```
+
+#### Test: Local Changes Survive Reconnection
+
+```typescript
+test("local changes sync after reconnection", async () => {
+  // 1. Make local changes while connected
+  // 2. Disconnect (kill sync server or network)
+  // 3. Verify local data persists
+  // 4. Reconnect
+  // 5. Verify changes appear on server
+});
+```
+
+#### Test: Apply Failure After Handshake Surfaces Incompatibility
+
+```typescript
+test("apply failure after handshake forces incompatible state", async () => {
+  // 1. Connect and wait for steady ACK
+  // 2. Install a trigger on the server that raises on INSERT INTO crsql_changes
+  // 3. Make a local change to force an outbound batch
+  // 4. Expect SyncStatus{ ok: false, reason: 'apply_failed' } and an incompatible UI state
+});
+```
+
+### Priority 2: UI Indicator Accuracy
+
+#### Test: Footer Shows Correct Connection State
+
+```typescript
+test("footer shows red when disconnected", async () => {
+  // 1. Start with sync disabled
+  // 2. Verify footer shows red/disconnected
+  // 3. Enable sync
+  // 4. Verify footer transitions to green
+  // 5. Stop sync server
+  // 6. Verify footer transitions to red
+});
+```
+
+#### Test: Pending Changes Display (When Implemented)
+
+```typescript
+test("footer shows pending changes count", async () => {
+  // 1. Disconnect sync
+  // 2. Make 5 local changes
+  // 3. Verify footer shows "5 pending"
+  // 4. Reconnect
+  // 5. Verify count goes to 0
+});
+```
+
+### Priority 3: Progress Accuracy (When Fixed)
+
+#### Test: Sync Progress Shows Meaningful Numbers
+
+```typescript
+test("progress shows record counts not chunk counts", async () => {
+  // 1. Create 5000 records on server
+  // 2. Connect fresh client
+  // 3. Verify progress shows ~5000 total, not 5 chunks
+  // 4. Verify progress increments smoothly
+});
+```
+
+### Test Infrastructure Notes
+
+The existing `sync.spec.ts` provides a good foundation:
+
+- Uses a local sync server started in `globalSetup`
+- Can make direct HTTP calls to server's `/exec` endpoint for remote changes
+- Tests both client→server and server→client sync
+
+**Key Utilities Available**:
+
+```typescript
+// From apps/e2e/tests/helpers/sync-server.ts
+await execOnRemote(dbid, sql); // Execute SQL on server
+await waitForSync(); // Wait for sync to settle
+```
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Quick Wins (Low Effort, High Impact)
+
+1. **Remove "Book Data Extension" badge** -- done; only the Remote DB badge remains.
+2. **Improve stuck detection messaging** -- already done in recent commits
+3. **Add "connecting" state** -- yellow indicator while WebSocket handshake in progress (implemented via derived sync state)
+
+### Phase 2: Pending Changes Tracking
+
+1. Implement `pendingChangesCount` store using `crsql_changes` query (implemented; uses last acknowledged `db_version` persisted per DB)
+2. Update footer to show count when > 0 (implemented)
+3. Add E2E test for pending changes display (added in `apps/e2e/integration/sync.spec.ts`)
+
+### Phase 3: Progress Improvements
+
+1. Refactor `ChangesProcessor` to track change counts, not chunks (implemented; emits final totals even after completion)
+2. Update progress dialog to show meaningful numbers (uses change counts now; covered by bulk sync e2e)
+3. Consider adding estimated time remaining
+
+### Phase 3.5: File-Watcher Stability
+
+1. Preserve DB extensions in FSNotify (`@vlcn.io/ws-server`) and keep `touchHack` on HTTP writes (implemented locally; needs upstream/backport strategy)
+2. Keep `.sqlite3` regression tests active in `apps/e2e/integration/sync.spec.ts`
+
+### Phase 4: Sync Validation
+
+1. ✅ WebSocket `SyncStatus` handshake (site_id + schema_version) gates "connected" state; HTTP `/meta` is now best-effort only
+2. ✅ E2E for rebuilt remote DB while `/meta` is blocked (shows incompatible, then recovers after nuke/resync)
+3. ✅ Steady-state ACK after the first inbound apply; emits `apply_failed` on errors and keeps the UI in "connecting" until the ACK arrives
+4. Next: add ACK replay on reconnect and optionally extend ACK with stronger durability guarantees if needed
+
+---
+
+## Key Files Reference
+
+| File                                          | Role in Sync                          |
+| --------------------------------------------- | ------------------------------------- |
+| `lib/stores/app.ts`                           | Connectivity monitor, stuck detection |
+| `lib/components/ExtensionStatusBanner.svelte` | Footer badges                         |
+| `lib/workers/sync-transport-control.ts`       | Chunking, progress emission           |
+| `lib/workers/WorkerInterface.ts`              | Main thread ↔ Worker messaging       |
+| `lib/app/sync.ts`                             | High-level sync API, initial sync     |
+| `routes/+layout.svelte`                       | Sync dialog, stuck dialog             |
+| `e2e/tests/sync.spec.ts`                      | Sync E2E tests                        |
+
+---
+
+## Appendix: Database Queries for Sync State
+
+### Get Local Database Version
+
+```sql
+SELECT crsql_db_version();
+-- Returns: bigint (e.g., 12345)
+```
+
+### Get Peer's Known Version
+
+```sql
+SELECT MAX(db_version) FROM crsql_changes WHERE site_id = ?;
+-- Returns: last version received from that peer
+```
+
+### Count Pending Local Changes
+
+```sql
+SELECT COUNT(*) FROM crsql_changes
+WHERE site_id = crsql_site_id()
+AND db_version > ?;
+-- Where ? is the last acknowledged version
+```
+
+### Get Local Site ID
+
+```sql
+SELECT site_id FROM crsql_site_id WHERE ordinal = 0;
+-- Returns: 16-byte blob (the local client's identity)
+```
+
+### Get All Known Peers
+
+```sql
+SELECT DISTINCT quote(site_id) FROM crsql_changes;
+-- Returns: hex-encoded site IDs of all peers that have contributed changes
+```


### PR DESCRIPTION
## Summary
- add architecture docs under `docs/architecture/` covering DB init, sync, migrations, reactivity, CRDT behavior, and known issues
- include a sync requirements doc with implementation status and roadmap
- resolve internal contradictions in pending/ACK semantics so docs match current implementation

## Why
These docs were mixed into the sync behavior PR and made review much larger. Splitting keeps the code PR focused while still shipping the documentation work.
