### PR TITLE
fix: populate DB sync URL in settings

### DIFF
--- a/apps/web-client/src/routes/history/isbn/[isbn]/actions.ts
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/actions.ts
@@ -67,7 +67,8 @@ export const createSearchDropdown = ({
 	const reset = () => (open.set(false), value.set(""));
 
 	const closeOnOutsideClick = (e: Event) => {
-		if ([_search, _dropdown].map(get).some((el) => el?.contains(e.target as Node))) return;
+		if ([_search, _dropdown].map(get).some((el: HTMLElement | HTMLInputElement | undefined | null) => el?.contains(e.target as Node)))
+			return;
 		open.set(false);
 	};
 

--- a/apps/web-client/src/routes/settings/+page.ts
+++ b/apps/web-client/src/routes/settings/+page.ts
@@ -19,7 +19,7 @@ const _load: PageLoad = async ({ parent }) => {
 
 	const dbid = get(app.config.dbid);
 	const syncUrl = get(app.config.syncUrl);
-	const syncSettingsData = { dbid, syncUrl };
+	const syncSettingsData = { dbid, url: syncUrl };
 	const syncSettingsForm = await superValidate(syncSettingsData, zod(syncSettingsSchema));
 
 	return { deviceSettingsForm, syncSettingsForm };


### PR DESCRIPTION
## Summary
- Fixes #1173: the DB sync URL field in `/settings` is now properly populated when the page loads. The issue was a property name mismatch (`syncUrl` instead of `url`) in the data object passed to the schema validation.
- Fixed a minor type error in `apps/web-client/src/routes/history/isbn/[isbn]/actions.ts` that caused `rushx typecheck` to fail.