### PR TITLE
fix: list react and react-dom deps (required by Storybook -- peer deps) finally fixing the rush update failure

### DIFF
--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -96,6 +96,8 @@
 		"@storybook/addon-a11y": "~9.1.19",
 		"@vitest/browser": "3.0.9",
 		"playwright": "~1.50.0",
+		"react": "~18.3.1",
+		"react-dom": "~18.3.1",
 		"daisyui": "~4.12.13",
 		"@tailwindcss/typography": "~0.5.15",
 		"tsx": "~4.19.1"

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -279,6 +279,12 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ~0.6.8
         version: 0.6.14(prettier-plugin-svelte@3.4.1(prettier@3.4.2)(svelte@5.37.3))(prettier@3.4.2)
+      react:
+        specifier: ~18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ~18.3.1
+        version: 18.3.1(react@18.3.1)
       storybook:
         specifier: ~9.1.19
         version: 9.1.19(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(prettier@3.4.2)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4))
@@ -3274,6 +3280,10 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -3798,8 +3808,17 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -3907,6 +3926,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -7700,6 +7722,10 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -8120,7 +8146,17 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-is@17.0.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   read-cache@1.0.0:
     dependencies:
@@ -8272,6 +8308,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scule@1.3.0: {}
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "64ee3d770e076b881023660d49c8fd8bca9bdaf7",
+  "pnpmShrinkwrapHash": "98b3623142e58eeab344ddb0d7bae84d0e2d6d83",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
## A nasty issue:

`rushx <command>` fails saying rush flags are invalid (or pnpm flags -- anyway: repo state invalid).
`rush update` fails on postinstall with not much to go on.
Running the install script (manually) `pnpm ...` causes mayhem on the repo (as pnpm is unaware of rush).
Setting PNPM_DIR (whatever the exact env var), that rush does when running pnpm, doesn't work as pnpm can't locate the appropriate config file.
Finally running the script constantly fails with peer dep versions not being in sync (`strictPeerDependencies = true` -- we're definitely keeping this).

Agents try and either:
- apply simple fix: `strictPeerDependencies = false` - no-go: we're absolutely keeping this `true`
- work around constraints, be a smart-ass and list all peer deps in pnpm config `ignore`

## Actual issue

Storybook needs `react` and `react-dom` (for whatever reason - either the web UI or some addon depends on it -- didn't investigate)

## Simple fix

Explicitly `react` and `react-dom` to `web-client/package.json` 

This seems to fix it. I can't guarantee all is kosher, but it looks like a light at the end of the tunnel (I'll take it!)