### PR TITLE
test(web-client): split Vitest projects for browser-backed coverage

### DIFF
--- a/.github/workflow.templates/test-job.lib.yml
+++ b/.github/workflow.templates/test-job.lib.yml
@@ -7,15 +7,15 @@
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
 
-#@ def test_script(workdir, install_playwright):
+#@ def test_script(workdir, install_playwright, test_command="rushx test:ci"):
 #@  if install_playwright:
-#@    return "cd "+workdir+" && npx playwright install && rushx test:ci"
+#@    return "cd "+workdir+" && npx playwright install && "+test_command
 #@  else:
-#@    return "cd "+workdir+" && rushx test:ci"
+#@    return "cd "+workdir+" && "+test_command
 #@  end
 #@ end
 
-#@ def test_job(name, workdir, reporter=None, install_playwright=False):
+#@ def test_job(name, workdir, reporter=None, install_playwright=False, test_command="rushx test:ci"):
 name: #@ name
 runs-on: ubuntu-latest
 timeout-minutes: 10
@@ -25,28 +25,28 @@ permissions:
   contents: read
   checks: write
 steps:
--  #@ checkout()
--  #@ pull_artefacts()
-- uses: actions/setup-node@v4
-  with:
-    node-version: "22"
-- name: Compute desired compiled artefact version
-  run: ./scripts/compute_artefacts_version.sh #! This will inform the cache to load the correct artefacts
--  #@ load_artefacts()
--  #@ load_cached_artefacts()
--  #@ cache_node()
--  #@ rush_add_path()
--  #@ rush_install()
--  #@ rush_build()
-- name: Run tests
-  run: #@ test_script(workdir, install_playwright)
-#@ if reporter!=None:
-- name: Test Report
-  uses: dorny/test-reporter@v1
-  if: success() || failure()
-  with:
-    name: #@ name
-    path: #@ workdir+"/junit.xml"
-    reporter: #@ reporter
+  -  #@ checkout()
+  -  #@ pull_artefacts()
+  - uses: actions/setup-node@v4
+    with:
+      node-version: "22"
+  - name: Compute desired compiled artefact version
+    run: ./scripts/compute_artefacts_version.sh #! This will inform the cache to load the correct artefacts
+  -  #@ load_artefacts()
+  -  #@ load_cached_artefacts()
+  -  #@ cache_node()
+  -  #@ rush_add_path()
+  -  #@ rush_install()
+  -  #@ rush_build()
+  - name: Run tests
+    run: #@ test_script(workdir, install_playwright, test_command)
+  #@ if reporter!=None:
+  - name: Test Report
+    uses: dorny/test-reporter@v1
+    if: success() || failure()
+    with:
+      name: #@ name
+      path: #@ workdir+"/junit.xml"
+      reporter: #@ reporter
 #@ end
 #@ end

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -29,6 +29,8 @@ jobs:
 
   web-client-test: #@ test_job("Web Client Tests", "apps/web-client", install_playwright=True)
 
+  web-client-storybook-test: #@ test_job("Web Client Storybook Tests", "apps/web-client", install_playwright=True, test_command="rushx test-storybook:ci")
+
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -253,6 +255,7 @@ jobs:
         build-cr-sqlite,
         book-data-extension-test,
         web-client-test,
+        web-client-storybook-test,
         e2e-test,
         lint-and-typecheck,
         check-i18n-sync,

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -208,10 +208,15 @@ jobs:
           SENTRY_URL: https://sentry.libroc.co
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+      - name: Build Storybook preview
+        run: cd apps/web-client && npx storybook build --output-dir /tmp/librocco-web-client-storybook-preview
       -  #@ install_and_configure_rclone()
       -  #@ upload_to_r2("apps/web-client/build/", "${{ github.head_ref || github.ref_name }}/")
-      - name: Output link to deployed app
-        run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
+      -  #@ upload_to_r2("/tmp/librocco-web-client-storybook-preview/", "${{ github.head_ref || github.ref_name }}/storybook/")
+      - name: Output links to deployed previews
+        run: |
+          echo "You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html" | tee -a $GITHUB_STEP_SUMMARY
+          echo "You can view Storybook on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/storybook/" | tee -a $GITHUB_STEP_SUMMARY
   e2e-merge-report:
     if: ${{ !cancelled() }}
     needs: [e2e-test]

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -613,6 +613,8 @@ jobs:
         SENTRY_URL: https://sentry.libroc.co
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+    - name: Build Storybook preview
+      run: cd apps/web-client && npx storybook build --output-dir /tmp/librocco-web-client-storybook-preview
     - name: Install and configure rclone for R2
       run: |
         wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
@@ -638,8 +640,12 @@ jobs:
         CLOUDFLARE_BUCKET_URL: ${{ secrets.CLOUDFLARE_BUCKET_URL }}
     - name: 'Upload to R2: apps/web-client/build/ -> ${{ github.head_ref || github.ref_name }}/'
       run: rclone copy apps/web-client/build/ r2:librocco-ci/${{ github.head_ref || github.ref_name }}/
-    - name: Output link to deployed app
-      run: echo You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html | tee -a $GITHUB_STEP_SUMMARY
+    - name: 'Upload to R2: /tmp/librocco-web-client-storybook-preview/ -> ${{ github.head_ref || github.ref_name }}/storybook/'
+      run: rclone copy /tmp/librocco-web-client-storybook-preview/ r2:librocco-ci/${{ github.head_ref || github.ref_name }}/storybook/
+    - name: Output links to deployed previews
+      run: |
+        echo "You can view the app on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/index.html" | tee -a $GITHUB_STEP_SUMMARY
+        echo "You can view Storybook on https://test.libroc.co/${{ github.head_ref || github.ref_name }}/storybook/" | tee -a $GITHUB_STEP_SUMMARY
   e2e-merge-report:
     if: ${{ !cancelled() }}
     needs:

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -189,6 +189,68 @@ jobs:
         fi
     - name: Run tests
       run: cd apps/web-client && npx playwright install && rushx test:ci
+  web-client-storybook-test:
+    name: Web Client Storybook Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build-cr-sqlite
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: false
+    - name: Pull artefacts from R2
+      run: ./scripts/artefacts-download.sh
+      env:
+        ARTEFACT_API_KEY: ${{ secrets.ARTEFACT_API_KEY }}
+        ARTEFACT_WORKER_URL: ${{ vars.ARTEFACT_WORKER_URL }}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+    - name: Compute desired compiled artefact version
+      run: ./scripts/compute_artefacts_version.sh
+    - uses: actions/download-artifact@v4
+      with:
+        name: built-vlcn-artefacts
+        path: 3rd-party/artefacts
+      if: ${{ !cancelled() && needs.build-cr-sqlite.outputs.rebuild == 'yes' }}
+    - name: Load cached cr-sqlite artefacts
+      uses: actions/cache/restore@v4
+      with:
+        path: 3rd-party/artefacts
+        key: ${{ runner.os }}-cr-sqlite-artefacts-${{ hashFiles('3rd-party/artefacts_version.txt') }}
+    - name: Cache node modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.rush
+          ~/.pnpm-store
+          common/temp
+          ./common/temp/node_modules/
+        key: ${{ runner.os }}-modules-node20-v3-${{ hashFiles('**/pnpm-lock.yaml') }}
+    - name: Add local rush scripts to PATH
+      run: echo "${PWD}"/common/scripts >> $GITHUB_PATH
+    - name: Install packages
+      run: rush install
+    - name: Build packages
+      run: |
+        set +e
+        rush build
+        exit_code=$?
+        if [ $exit_code -eq 0 ] || [ $exit_code -eq 1 ]; then
+          echo "Build completed (exit code: $exit_code)"
+          exit 0
+        else
+          echo "Build failed with exit code: $exit_code"
+          exit $exit_code
+        fi
+    - name: Run tests
+      run: cd apps/web-client && npx playwright install && rushx test-storybook:ci
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -646,6 +708,7 @@ jobs:
     - build-cr-sqlite
     - book-data-extension-test
     - web-client-test
+    - web-client-storybook-test
     - e2e-test
     - lint-and-typecheck
     - check-i18n-sync

--- a/apps/web-client/.storybook/main.ts
+++ b/apps/web-client/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/sveltekit";
 
 const config: StorybookConfig = {
-	stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
+	stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
 	addons: [
 		{
 			name: "@storybook/addon-svelte-csf",

--- a/apps/web-client/.storybook/main.ts
+++ b/apps/web-client/.storybook/main.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { StorybookConfig } from "@storybook/sveltekit";
 
 const config: StorybookConfig = {
@@ -11,7 +12,20 @@ const config: StorybookConfig = {
 		},
 		"@storybook/addon-a11y"
 	],
-	framework: "@storybook/sveltekit"
+	framework: "@storybook/sveltekit",
+	async viteFinal(config) {
+		return {
+			...config,
+			resolve: {
+				...config.resolve,
+				alias: {
+					...(config.resolve?.alias ?? {}),
+					"$env/dynamic/public": path.resolve(__dirname, "../src/__mocks__/$env-dynamic-public.ts"),
+					"$env/static/public": path.resolve(__dirname, "../src/__mocks__/$env-static-public.ts")
+				}
+			}
+		};
+	}
 };
 
 export default config;

--- a/apps/web-client/.storybook/preview.ts
+++ b/apps/web-client/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import "../src/lib/main.css";
 
+import type { Preview } from "@storybook/svelte";
 import { setLocale } from "@librocco/shared/i18n-svelte";
 import { loadLocaleAsync } from "@librocco/shared/i18n-util.async";
 import { DEFAULT_LOCALE } from "$lib/constants";
@@ -9,15 +10,40 @@ import { DEFAULT_LOCALE } from "$lib/constants";
 // to handle locale changes and provide better control over translation loading
 let i18nInitialized = false;
 
-export default {
+function applyStorybookTheme(backgroundValue: unknown) {
+	if (typeof document === "undefined") {
+		return;
+	}
+
+	const isDark = backgroundValue === "dark";
+	const theme = isDark ? "sunset" : "lofi";
+	const colorScheme = isDark ? "dark" : "light";
+
+	document.documentElement.setAttribute("data-theme", theme);
+	document.body.setAttribute("data-theme", theme);
+	document.documentElement.style.colorScheme = colorScheme;
+	document.body.style.colorScheme = colorScheme;
+}
+
+const preview: Preview = {
+	decorators: [
+		(Story, context) => {
+			applyStorybookTheme(context.globals?.backgrounds?.value);
+			return Story();
+		}
+	],
 	loaders: [
-		async () => {
+		async ({ globals }) => {
 			if (!i18nInitialized) {
 				await loadLocaleAsync(DEFAULT_LOCALE);
 				setLocale(DEFAULT_LOCALE);
 				i18nInitialized = true;
 			}
+
+			applyStorybookTheme(globals?.backgrounds?.value);
 			return {};
 		}
 	]
 };
+
+export default preview;

--- a/apps/web-client/.storybook/tsconfig.json
+++ b/apps/web-client/.storybook/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"module": "ESNext",
-		"types": ["node"]
+		"types": ["node"],
+		"verbatimModuleSyntax": true
 	},
 	"include": ["**/*.ts", "**/*.js", "**/*.svelte"]
 }

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -20,8 +20,9 @@
 		"story:build": "storybook build",
 		"story:dev": "storybook dev -p 6006",
 		"story:preview": "storybook preview",
-		"test": "vitest --ui",
-		"test:ci": "CI=True vitest",
+		"test": "vitest --config vitest.config.ts --ui",
+		"test:browser": "vitest --workspace vitest.projects.ts --project=browser-backed",
+		"test:ci": "CI=True vitest --workspace vitest.projects.ts --project=unit --project=browser-backed",
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold error",
 		"typesafe-i18n": "echo please run this in ../../pkg/shared ; exit 1",
 		"typesafe-i18n-check": "echo please run this in ../../pkg/shared ; exit 1"

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -23,6 +23,8 @@
 		"test": "vitest --config vitest.config.ts --ui",
 		"test:browser": "vitest --workspace vitest.projects.ts --project=browser-backed",
 		"test:ci": "CI=True vitest --workspace vitest.projects.ts --project=unit --project=browser-backed",
+		"test-storybook": "./scripts/test-storybook.sh",
+		"test-storybook:ci": "CI=True ./scripts/test-storybook.sh",
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold error",
 		"typesafe-i18n": "echo please run this in ../../pkg/shared ; exit 1",
 		"typesafe-i18n-check": "echo please run this in ../../pkg/shared ; exit 1"
@@ -95,12 +97,15 @@
 		"@storybook/svelte": "~9.1.19",
 		"@storybook/addon-svelte-csf": "~5.0.11",
 		"@storybook/addon-a11y": "~9.1.19",
+		"@storybook/test-runner": "0.23.0",
 		"@vitest/browser": "3.0.9",
 		"playwright": "~1.50.0",
 		"react": "~18.3.1",
 		"react-dom": "~18.3.1",
 		"daisyui": "~4.12.13",
 		"@tailwindcss/typography": "~0.5.15",
-		"tsx": "~4.19.1"
+		"tsx": "~4.19.1",
+		"http-server": "14.1.1",
+		"wait-on": "9.0.4"
 	}
 }

--- a/apps/web-client/scripts/test-storybook.sh
+++ b/apps/web-client/scripts/test-storybook.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${STORYBOOK_OUTPUT_DIR:-/tmp/librocco-web-client-storybook}"
+HOST="${STORYBOOK_HOST:-127.0.0.1}"
+PORT="${STORYBOOK_PORT:-6006}"
+URL="http://${HOST}:${PORT}"
+CONFIG_DIR="${ROOT_DIR}/.storybook"
+
+server_pid=""
+
+cleanup() {
+	if [[ -n "${server_pid}" ]]; then
+		kill "${server_pid}" >/dev/null 2>&1 || true
+		wait "${server_pid}" >/dev/null 2>&1 || true
+	fi
+}
+
+trap cleanup EXIT
+
+cd "${ROOT_DIR}"
+
+npx storybook build --output-dir "${OUTPUT_DIR}"
+npx http-server "${OUTPUT_DIR}" --host "${HOST}" --port "${PORT}" --silent &
+server_pid=$!
+npx wait-on "tcp:${HOST}:${PORT}"
+STORYBOOK_PROJECT_ROOT="${ROOT_DIR}" npx test-storybook --config-dir "${CONFIG_DIR}" --index-json --url "${URL}" --includeTags=test-only

--- a/apps/web-client/src/lib/components-new/CounterBadge/CounterBadge.svelte
+++ b/apps/web-client/src/lib/components-new/CounterBadge/CounterBadge.svelte
@@ -3,7 +3,7 @@
 	export let value: string | number = 0;
 </script>
 
-<div class="bg-background flex w-40 items-center justify-between gap-2 rounded-md border border-neutral-200 px-2 py-1">
+<div class="flex w-40 items-center justify-between gap-2 rounded-md border border-base-300 bg-base-100 px-2 py-1">
 	<div class="text-muted-foreground text-xs uppercase tracking-wide">{label}</div>
 	<div class="text-foreground text-lg font-bold">{value}</div>
 </div>

--- a/apps/web-client/src/lib/components-new/ReconciliationCustomerNotification/ReconciliationCustomerNotification.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationCustomerNotification/ReconciliationCustomerNotification.svelte
@@ -39,15 +39,15 @@
 	}
 </script>
 
-<div use:melt={$collapsibleRoot} class="rounded-lg border border-neutral-200 bg-neutral-50">
-	<div use:melt={$trigger} class="cursor-pointer px-4 py-3 transition-all {interactive ? 'hover:bg-neutral-100' : ''}">
+<div use:melt={$collapsibleRoot} class="rounded-lg border border-base-300 bg-base-100 text-base-content">
+	<div use:melt={$trigger} class="cursor-pointer px-4 py-3 transition-all {interactive ? 'hover:bg-base-200/60' : ''}">
 		<div class="flex items-center gap-6">
 			<div class="flex min-w-0 flex-1 items-center gap-2">
 				<Bell class="text-foreground h-4 w-4 shrink-0" aria-hidden="true" />
 				<p class="text-foreground text-sm">{label}</p>
 			</div>
 			{#if interactive}
-				<button class="shrink-0 rounded p-1 transition-colors {interactive ? 'hover:bg-neutral-200' : ''}">
+				<button class="shrink-0 rounded p-1 transition-colors {interactive ? 'hover:bg-base-200/70' : ''}">
 					<ChevronDown class={`text-foreground h-5 w-5 transition-transform ${$open ? "rotate-180" : ""}`} aria-hidden="true" />
 				</button>
 			{/if}
@@ -60,9 +60,9 @@
 				{#each books as book}
 					<div>
 						<div class="mb-1">
-							<div class="text-foreground inline-flex items-center gap-1.5 rounded bg-neutral-200 px-2 py-0.5 text-xs font-medium">
+							<div class="text-foreground inline-flex items-center gap-1.5 rounded bg-base-200 px-2 py-0.5 text-xs font-medium">
 								<span>{book.isbn}</span>
-								<span class="text-neutral-500">·</span>
+								<span class="text-base-content/50">·</span>
 								<span>{book.title}</span>
 								<span>{getCopyLabel(book.customers.length)}</span>
 							</div>
@@ -81,7 +81,7 @@
 							</div>
 							{#each book.customers as customer, index}
 								{@const isLastCustomer = index === book.customers.length - 1}
-								<div class="flex items-center gap-4 px-2 py-1 {!isLastCustomer ? 'border-b border-neutral-200' : ''}">
+								<div class="flex items-center gap-4 px-2 py-1 {!isLastCustomer ? 'border-b border-base-300/70' : ''}">
 									<div class="min-w-0 flex-1">
 										<span class="text-foreground text-sm">{customer.customer_name}</span>
 									</div>

--- a/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.stories.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.stories.svelte
@@ -155,7 +155,9 @@
 			</svelte:fragment>
 		</ReconciliationOrderSummary>
 
-		<div class="mt-8 rounded border border-neutral-300 p-2">Underdelivery behaviour: {$underdeliveryBehaviourStore}</div>
+		<div class="mt-8 rounded border border-base-300 bg-base-100 p-2 text-base-content">
+			Underdelivery behaviour: {$underdeliveryBehaviourStore}
+		</div>
 	</div>
 </Story>
 

--- a/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.svelte
@@ -35,14 +35,14 @@
 	$: t = $LL.reconcile_page;
 </script>
 
-<div use:melt={$collapsibleRoot} class="rounded-lg border border-neutral-200">
-	<div use:melt={$trigger} class="bg-card cursor-pointer px-4 py-3 transition-all {interactive ? 'hover:bg-neutral-100' : ''}">
+<div use:melt={$collapsibleRoot} class="rounded-lg border border-base-300 bg-base-100 text-base-content">
+	<div use:melt={$trigger} class="cursor-pointer bg-base-100 px-4 py-3 transition-all {interactive ? 'hover:bg-base-200/60' : ''}">
 		<div class="flex items-center justify-between gap-4">
 			<div class="flex min-w-0 flex-1 items-start gap-3">
 				<div class="min-w-0 flex-1">
 					<div class="flex flex-wrap items-center gap-2">
-						<span class="font-medium text-zinc-900">{customerName}</span>
-						<span class="text-muted-foreground text-sm">{orderId}</span>
+						<span class="font-medium text-base-content">{customerName}</span>
+						<span class="text-sm text-base-content/70">{orderId}</span>
 						{#if !allDelivered && hasBooks}
 							<span class="rounded bg-orange-100 px-2 py-1 text-xs font-medium text-orange-800">
 								{t.step2.order_summary.books_undelivered({ count: undeliveredCount })}
@@ -53,9 +53,9 @@
 					</div>
 				</div>
 				{#if interactive}
-					<button class="rounded p-1 transition-colors {interactive ? 'hover:bg-neutral-200' : ''}">
+					<button class="rounded p-1 transition-colors {interactive ? 'hover:bg-base-200/70' : ''}">
 						<ChevronDown
-							class={`lucide lucide-chevron-down h-5 w-5 text-zinc-900 transition-transform ${$open ? "rotate-180" : ""}`}
+							class={`lucide lucide-chevron-down h-5 w-5 text-base-content transition-transform ${$open ? "rotate-180" : ""}`}
 							aria-hidden="true"
 						/>
 					</button>
@@ -87,7 +87,7 @@
 						{#each books as book (book.isbn)}
 							{@const isLastBook = book === books[books.length - 1]}
 							{@const missingQuantity = book.orderedQuantity - book.deliveredQuantity}
-							<TableRow variant="naked" className="transition-all duration-100 {isLastBook ? '' : 'border-b border-neutral-100'}">
+							<TableRow variant="naked" className="transition-all duration-100 {isLastBook ? '' : 'border-b border-base-300/70'}">
 								<td class="text-foreground line-clamp-1 w-32 min-w-0 shrink-0 px-2 py-1.5 align-middle text-sm font-medium">
 									{book.isbn}
 								</td>

--- a/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/UnderdeliveryActionBadge.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/UnderdeliveryActionBadge.svelte
@@ -7,8 +7,8 @@
 </script>
 
 <div class="p-4 pt-3">
-	<p class="border-t border-neutral-200 pt-3">
+	<p class="border-t border-base-300 pt-3">
 		<span class="text-muted-foreground text-xs uppercase tracking-wide">ACTION:</span>
-		<span class="rounded bg-neutral-100 px-2 py-1 text-xs text-zinc-900">{label}</span>
+		<span class="rounded bg-base-200 px-2 py-1 text-xs text-base-content">{label}</span>
 	</p>
 </div>

--- a/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/UnderdeliveryRadioGroup.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/UnderdeliveryRadioGroup.svelte
@@ -41,35 +41,37 @@
 		{#each underdeliveryOptions as option}
 			<button
 				class="flex cursor-pointer items-center gap-2 rounded border p-2 transition-all {$isChecked(option)
-					? 'border-neutral-700 bg-[#f8f8f8]'
-					: 'bg-card border-neutral-300'}"
+					? 'border-base-content/50 bg-base-200'
+					: 'border-base-300 bg-base-100 hover:bg-base-200/60'}"
 				use:melt={$item(option)}
 				aria-labelledby="${option}-label"
 			>
 				{#if $isChecked(option)}
-					<div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-neutral-700 bg-neutral-700">
-						<div class="h-2 w-2 rounded-full bg-white"></div>
+					<div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-base-content/60 bg-base-content">
+						<div class="h-2 w-2 rounded-full bg-base-100"></div>
 					</div>
 				{:else}
-					<div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-neutral-300 bg-white"></div>
+					<div class="flex h-4 w-4 items-center justify-center rounded-full border-2 border-base-300 bg-base-100"></div>
 				{/if}
 
-				<label for={option} id="{option}-label" class="cursor-pointer text-sm leading-none">{t.options[option]()}</label>
+				<label for={option} id="{option}-label" class="cursor-pointer text-sm leading-none text-base-content">{t.options[option]()}</label>
 			</button>
 		{/each}
 	</div>
 
 	{#if isChanged && supplierId}
-		<div class="mt-3 flex items-center justify-between gap-3 rounded border border-neutral-300 bg-[#f8f8f8] p-3 text-sm text-neutral-600">
+		<div
+			class="mt-3 flex items-center justify-between gap-3 rounded border border-warning/40 bg-warning/10 p-3 text-sm text-base-content/80"
+		>
 			<div class="flex items-center gap-2">
-				<div class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-neutral-400">
-					<span class="text-neutral-500">!</span>
+				<div class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-warning/50">
+					<span class="text-warning">!</span>
 				</div>
 				<p class="leading-tight">{t.warning()}</p>
 			</div>
 			<button
 				onclick={handlePersistChanges}
-				class="self-start rounded border border-neutral-400 bg-white px-3 py-1 text-sm transition-colors hover:border-neutral-500 hover:bg-neutral-50"
+				class="self-start rounded border border-base-300 bg-base-100 px-3 py-1 text-sm text-base-content transition-colors hover:bg-base-200"
 			>
 				{t.persist_button()}
 			</button>

--- a/apps/web-client/src/lib/components-new/SupplierCard/SupplierCard.svelte
+++ b/apps/web-client/src/lib/components-new/SupplierCard/SupplierCard.svelte
@@ -75,19 +75,19 @@
 	<div class="pt-1">
 		<button
 			data-slot="button"
-			class="[&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-background text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 has-[>_svg]:px-3 hover:text-accent-foreground inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium outline-none transition-all hover:bg-accent focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+			class="[&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive has-[>_svg]:px-3 inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md border border-base-300 bg-base-100 px-4 py-2 text-sm font-medium text-base-content outline-none transition-all hover:bg-base-200 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
 			onclick={handleEdit}
 		>
 			{$LL.suppliers_page.card.edit_details()}
 		</button>
 	</div>
 
-	<div class="border-t border-gray-200 pt-4"></div>
+	<div class="border-t border-base-300 pt-4"></div>
 
 	<div>
 		<button
 			data-slot="button"
-			class="[&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-background text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 has-[>_svg]:px-3 inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium outline-none transition-all hover:border-red-600 hover:bg-red-100 hover:text-red-600 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+			class="[&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive has-[>_svg]:px-3 inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md border border-base-300 bg-base-100 px-4 py-2 text-sm font-medium text-base-content outline-none transition-all hover:border-error/70 hover:bg-error/10 hover:text-error focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
 			onclick={handleDelete}
 			disabled={deleteDisabled}
 		>

--- a/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTable.stories.svelte
+++ b/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTable.stories.svelte
@@ -27,7 +27,7 @@
 <Story name="Assigned Publishers">
 	<SupplierPublisherTable>
 		<svelte:fragment slot="title">Assigned Publishers</svelte:fragment>
-		<span slot="badge" class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white">
+		<span slot="badge" class="inline-flex items-center rounded-full bg-base-content px-2 py-0.5 text-[10px] font-medium text-base-100">
 			{assignedPublishers.length}
 		</span>
 
@@ -35,7 +35,7 @@
 			<SupplierPublisherTableRow publisherName={publisher}>
 				<button
 					slot="action-button"
-					class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-gray-500 hover:bg-red-50 hover:!text-red-600"
+					class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-base-content/60 transition-colors hover:bg-error/10 hover:!text-error"
 				>
 					Remove
 				</button>
@@ -47,7 +47,7 @@
 <Story name="Available Publishers">
 	<SupplierPublisherTable>
 		<svelte:fragment slot="title">Available Publishers</svelte:fragment>
-		<span slot="badge" class="inline-flex items-center rounded-full bg-gray-200 px-2 py-0.5 text-[10px] font-medium text-gray-600">
+		<span slot="badge" class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 text-[10px] font-medium text-base-content/70">
 			{availablePublishers.length}
 		</span>
 
@@ -64,7 +64,7 @@
 
 					<button
 						slot="action-button"
-						class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+						class="h-5 whitespace-nowrap rounded border border-base-content/50 bg-base-100 px-1 text-[11px] font-medium text-base-content transition-colors hover:bg-accent hover:text-accent-content"
 					>
 						Add
 					</button>
@@ -73,7 +73,7 @@
 				<SupplierPublisherTableRow publisherName={name}>
 					<button
 						slot="action-button"
-						class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+						class="h-5 whitespace-nowrap rounded border border-base-content/50 bg-base-100 px-1 text-[11px] font-medium text-base-content transition-colors hover:bg-accent hover:text-accent-content"
 					>
 						Re-assign
 					</button>
@@ -86,7 +86,7 @@
 <Story name="Empty State">
 	<SupplierPublisherTable showEmptyState={true} emptyStateMessage="No assigned publishers">
 		<svelte:fragment slot="title">Assigned Publishers</svelte:fragment>
-		<span slot="badge" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
+		<span slot="badge" class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 text-[10px] font-medium text-base-content/70">
 			0
 		</span>
 	</SupplierPublisherTable>
@@ -95,11 +95,11 @@
 <Story name="Custom Empty State">
 	<SupplierPublisherTable showEmptyState={true}>
 		<svelte:fragment slot="title">Custom Publishers</svelte:fragment>
-		<span slot="badge" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
+		<span slot="badge" class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 text-[10px] font-medium text-base-content/70">
 			0
 		</span>
 		<svelte:fragment slot="empty-state">
-			<div class="py-8 px-3 text-center text-sm text-blue-500">No publishers found - custom message</div>
+			<div class="py-8 px-3 text-center text-sm text-info">No publishers found - custom message</div>
 		</svelte:fragment>
 	</SupplierPublisherTable>
 </Story>

--- a/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTable.svelte
+++ b/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTable.svelte
@@ -10,10 +10,10 @@
 	export let emptyStateMessage: string = "No items";
 </script>
 
-<div class="flex min-w-0 flex-1 flex-col overflow-hidden rounded border border-gray-100">
-	<div class="sticky top-0 z-10 border-b border-gray-100 bg-gray-50 px-3 py-2">
+<div class="flex min-w-0 flex-1 flex-col overflow-hidden rounded border border-base-300 bg-base-100 text-base-content">
+	<div class="sticky top-0 z-10 border-b border-base-300 bg-base-200/60 px-3 py-2">
 		<div class="flex items-center gap-2">
-			<h3 class="text-[14px] font-normal text-gray-900">
+			<h3 class="text-[14px] font-normal text-base-content">
 				<slot name="title" />
 			</h3>
 			<slot name="badge" />
@@ -22,7 +22,7 @@
 	<div class="min-h-0 flex-1 overflow-y-auto">
 		{#if showEmptyState}
 			<slot name="empty-state">
-				<div class="py-8 px-3 text-center text-sm text-gray-500">
+				<div class="py-8 px-3 text-center text-sm text-base-content/60">
 					{emptyStateMessage}
 				</div>
 			</slot>

--- a/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTableRow.svelte
+++ b/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTableRow.svelte
@@ -5,9 +5,10 @@
 	}
 
 	export let publisherName: string;
+	export let testId: string | undefined = undefined;
 </script>
 
-<div class="flex items-center justify-between border-b border-gray-100 px-3 py-1.5 hover:bg-gray-50">
+<div class="flex items-center justify-between border-b border-gray-100 px-3 py-1.5 hover:bg-gray-50" data-testid={testId}>
 	<span class="flex items-center gap-2 truncate text-[13px] font-normal text-gray-900">
 		{publisherName}
 		<slot name="badge" />

--- a/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTableRow.svelte
+++ b/apps/web-client/src/lib/components-new/SupplierPublisherList/SupplierPublisherTableRow.svelte
@@ -8,8 +8,11 @@
 	export let testId: string | undefined = undefined;
 </script>
 
-<div class="flex items-center justify-between border-b border-gray-100 px-3 py-1.5 hover:bg-gray-50" data-testid={testId}>
-	<span class="flex items-center gap-2 truncate text-[13px] font-normal text-gray-900">
+<div
+	class="flex items-center justify-between border-b border-base-300 px-3 py-1.5 transition-colors hover:bg-base-200/60"
+	data-testid={testId}
+>
+	<span class="flex items-center gap-2 truncate text-[13px] font-normal text-base-content">
 		{publisherName}
 		<slot name="badge" />
 	</span>

--- a/apps/web-client/src/lib/components-new/Table/Table.stories.svelte
+++ b/apps/web-client/src/lib/components-new/Table/Table.stories.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <Story name="Supplier Page > Orders">
-	<div class="max-w-xl">
+	<div class="max-w-xl text-base-content">
 		<Table columnWidths={["3", "3", "6"]}>
 			<svelte:fragment slot="head-cells">
 				<th scope="col" class="text-muted-foreground w-auto px-4 py-3 text-left align-middle text-xs">Order ID</th>
@@ -63,7 +63,7 @@
 </Story>
 
 <Story name="Supplier Page > Orders (Empty State)">
-	<div class="max-w-xl">
+	<div class="max-w-xl text-base-content">
 		<Table columnWidths={["3", "3", "6"]} showEmptyState={true}>
 			<svelte:fragment slot="head-cells">
 				<th scope="col" class="text-muted-foreground w-auto px-4 py-3 text-left text-xs">Order ID</th>
@@ -77,9 +77,9 @@
 </Story>
 
 <Story name="Reconcile Deliveries > Reconciliation">
-	<div class="max-w-4xl">
+	<div class="max-w-4xl text-base-content">
 		<div class="mb-2">
-			<span class="rounded-md bg-[#f8f8f8] px-2 py-0.5 text-xs font-medium">BooksRUS #1</span>
+			<span class="rounded-md bg-base-200 px-2 py-0.5 text-xs font-medium text-base-content">BooksRUS #1</span>
 		</div>
 		<Table variant="naked" columnWidths={["2", "3", "4", "2", "2", "2"]}>
 			<svelte:fragment slot="head-cells">
@@ -106,14 +106,14 @@
 								<button
 									on:click={() => decrementDelivered(book.isbn)}
 									disabled={book.delivered === 0}
-									class="flex h-6 w-6 items-center justify-center rounded border border-neutral-200 hover:bg-neutral-200 disabled:cursor-not-allowed disabled:opacity-50"
+									class="flex h-6 w-6 items-center justify-center rounded border border-base-300 bg-base-100 text-base-content transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-50"
 									aria-label={`Decrease delivered quantity for ${book.title}, currently ${book.delivered}`}
 								>
 									−</button
 								>
 								<button
 									on:click={() => incrementDelivered(book.isbn)}
-									class="flex h-6 w-6 items-center justify-center rounded border border-neutral-200 hover:bg-neutral-200"
+									class="flex h-6 w-6 items-center justify-center rounded border border-base-300 bg-base-100 text-base-content transition-colors hover:bg-base-200"
 									aria-label={`Increase delivered quantity for ${book.title}, currently ${book.delivered}`}
 								>
 									+</button

--- a/apps/web-client/src/lib/components-new/Table/Table.svelte
+++ b/apps/web-client/src/lib/components-new/Table/Table.svelte
@@ -6,7 +6,7 @@
 	export let showEmptyState: boolean = false;
 </script>
 
-<div class="overflow-hidden {variant === 'default' ? 'rounded border border-[#E5E5E5]' : ''}">
+<div class="overflow-hidden text-base-content {variant === 'default' ? 'rounded border border-base-300 bg-base-100' : ''}">
 	<table class="w-full table-fixed">
 		{#if columnWidths && columnWidths.length > 0}
 			<colgroup>
@@ -23,7 +23,7 @@
 		{/if}
 
 		<thead>
-			<tr class="{variant === 'default' ? 'border-b border-[#E5E5E5] bg-[#FAFAFA]' : ''} px-4">
+			<tr class="{variant === 'default' ? 'border-b border-base-300 bg-base-200/60' : ''} px-4">
 				<slot name="head-cells" />
 			</tr>
 		</thead>

--- a/apps/web-client/src/lib/components-new/Table/TableRow.svelte
+++ b/apps/web-client/src/lib/components-new/Table/TableRow.svelte
@@ -6,7 +6,7 @@
 
 <tr
 	class="{variant === 'default'
-		? 'border-b border-[#E5E5E5] transition-colors last:border-b-0 hover:bg-[#FAFAFA]' + (selected ? ' bg-[#FAFAFA]' : '')
+		? 'border-b border-base-300 transition-colors last:border-b-0 hover:bg-base-200/60' + (selected ? ' bg-base-200/60' : '')
 		: ''} px-4 py-2 {className}"
 >
 	<slot />

--- a/apps/web-client/src/lib/components/Dialogs/Dialog.stories.svelte
+++ b/apps/web-client/src/lib/components/Dialogs/Dialog.stories.svelte
@@ -10,18 +10,31 @@
 
 <script lang="ts">
 	import { Story, Template } from "@storybook/addon-svelte-csf";
-	import { createDialog } from "@melt-ui/svelte";
+	import { createDialog, melt } from "@melt-ui/svelte";
 
 	const dialog = createDialog({
 		forceVisible: true
 	});
+	const {
+		elements: { portalled, overlay },
+		states: { open }
+	} = dialog;
+
+	open.set(true);
 </script>
 
-<Template let:args={{ type, title, description }}>
-	<Dialog {dialog} {type}>
-		<svelte:fragment slot="title">{title}</svelte:fragment>
-		<svelte:fragment slot="description">{@html description}</svelte:fragment>
-	</Dialog>
+<Template let:args>
+	{#if $open}
+		<div use:melt={$portalled}>
+			<div use:melt={$overlay} class="fixed inset-0 z-50 bg-black/50"></div>
+			<div class="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+				<Dialog {dialog} type={args.type}>
+					<svelte:fragment slot="title">{args.title}</svelte:fragment>
+					<svelte:fragment slot="description">{@html args.description}</svelte:fragment>
+				</Dialog>
+			</div>
+		</div>
+	{/if}
 </Template>
 
 <Story

--- a/apps/web-client/src/lib/components/FormControls/Input.svelte
+++ b/apps/web-client/src/lib/components/FormControls/Input.svelte
@@ -27,37 +27,40 @@
 	export let inputRef = null;
 	export let inputAction: Action<HTMLElement, any> = () => {};
 
-	const labelBaseClasses = ["block", "text-base", "font-medium", "text-gray-800"];
-	const helpTextBaseClasses = ["mt-2", "text-sm", "min-h-[20px]", "text-gray-500"];
+	const labelBaseClasses = ["block", "text-base", "font-medium", "text-base-content"];
+	const helpTextBaseClasses = ["mt-2", "text-sm", "min-h-[20px]", "text-base-content/70"];
 	const inputBaseClasses = [
 		"block",
 		"w-full",
 		"border-0",
+		"bg-base-100",
 		"text-base",
-		"placeholder-oyster-500",
+		"text-base-content",
+		"placeholder:text-base-content/50",
 		"focus:outline-0",
 		"focus:ring-0",
 		"disabled:cursor-not-allowed",
-		"disabled:bg-oyster-100"
+		"disabled:bg-base-200",
+		"disabled:text-base-content/50"
 	];
 
 	const containerBaseClasses = [
 		"flex",
 		"mx-[2px]",
 		"outline",
-		"outline-gray-900",
 		"rounded-md",
+		"bg-base-100",
 		"focus-within:outline-none",
 		"focus-within:ring-2",
 		"focus-within:ring-teal-500",
 		"focus-within:ring-offset-2",
-		"focus-within:ring-offset-white"
+		"focus-within:ring-offset-base-100"
 	];
 
 	const helpTextColour = "text-oyster-500 font-regular";
 	const errorTextColour = "text-red-500 font-regular";
 	const containerBorderWidth = "outline-1";
-	const containerBorderColour = "outline-oyster-300";
+	const containerBorderColour = "outline-base-300";
 	const errorBorderColour = "outline-red-500";
 
 	const labelClasses = labelBaseClasses.join(" ");
@@ -91,7 +94,7 @@
 	</label>
 	<div class={containerClasses}>
 		{#if $$slots["start-adornment"]}
-			<div class="flex items-center bg-white pl-3 pr-0 text-gray-400">
+			<div class="flex items-center bg-base-100 pl-3 pr-0 text-base-content/50">
 				<slot name="start-adornment" />
 			</div>
 		{/if}
@@ -103,7 +106,7 @@
 			<input bind:value {...inputProps} bind:this={inputRef} use:inputAction on:select />
 		{/if}
 		{#if $$slots["end-adornment"]}
-			<div class="flex items-center bg-white pl-1 pr-3 text-gray-400">
+			<div class="flex items-center bg-base-100 pl-1 pr-3 text-base-content/50">
 				<slot name="end-adornment" />
 			</div>
 		{/if}

--- a/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
+++ b/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
@@ -14,21 +14,13 @@
 </script>
 
 <Story name="Default">
-	<Input
-		name="default-placeholder"
-		label="Default with placeholder"
-		placeholder={"placeholder"}
-	>
+	<Input name="default-placeholder" label="Default with placeholder" placeholder={"placeholder"}>
 		<p slot="helpText">And some help text</p>
 	</Input>
 </Story>
 
 <Story name="Start Adornment">
-	<Input
-		name="start-adornment"
-		placeholder={"placeholderemail@gmail.com"}
-		label="Start Adornment"
-	>
+	<Input name="start-adornment" placeholder={"placeholderemail@gmail.com"} label="Start Adornment">
 		<span slot="start-adornment">
 			<Mail />
 		</span>
@@ -36,11 +28,7 @@
 </Story>
 
 <Story name="Start & End Adonrnments">
-	<Input
-		name="start-end-adornment"
-		placeholder={"placeholderemail@gmail.com"}
-		label="Start & End Adornments"
-	>
+	<Input name="start-end-adornment" placeholder={"placeholderemail@gmail.com"} label="Start & End Adornments">
 		<span slot="start-adornment">$</span>
 		<span slot="end-adornment">USD</span>
 	</Input>

--- a/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
+++ b/apps/web-client/src/lib/components/FormControls/stories/Input.stories.svelte
@@ -14,13 +14,21 @@
 </script>
 
 <Story name="Default">
-	<Input name="default-placeholder" label="Default with placeholder" placeholder="placeholder">
+	<Input
+		name="default-placeholder"
+		label="Default with placeholder"
+		placeholder={"placeholder"}
+	>
 		<p slot="helpText">And some help text</p>
 	</Input>
 </Story>
 
 <Story name="Start Adornment">
-	<Input name="start-adornment" placeholder="placeholderemail@gmail.com" label="Start Adornment">
+	<Input
+		name="start-adornment"
+		placeholder={"placeholderemail@gmail.com"}
+		label="Start Adornment"
+	>
 		<span slot="start-adornment">
 			<Mail />
 		</span>
@@ -28,7 +36,11 @@
 </Story>
 
 <Story name="Start & End Adonrnments">
-	<Input name="start-end-adornment" placeholder="placeholderemail@gmail.com" label="Start & End Adornments">
+	<Input
+		name="start-end-adornment"
+		placeholder={"placeholderemail@gmail.com"}
+		label="Start & End Adornments"
+	>
 		<span slot="start-adornment">$</span>
 		<span slot="end-adornment">USD</span>
 	</Input>

--- a/apps/web-client/src/lib/components/ProgressBar/ProgressBar.stories.svelte
+++ b/apps/web-client/src/lib/components/ProgressBar/ProgressBar.stories.svelte
@@ -15,10 +15,16 @@
 </script>
 
 <Story name="Default">
-	{#each values as value}
-		<h1>{value * 100}%</h1>
-		<ProgressBar class="my-8 mx-2" {value} />
-	{/each}
-	<h1>Unknown</h1>
-	<ProgressBar class="my-8 mx-2" />
+	<div class="space-y-6 text-base-content">
+		{#each values as value}
+			<div>
+				<h1>{value * 100}%</h1>
+				<ProgressBar class="my-8 mx-2" {value} />
+			</div>
+		{/each}
+		<div>
+			<h1>Unknown</h1>
+			<ProgressBar class="my-8 mx-2" />
+		</div>
+	</div>
 </Story>

--- a/apps/web-client/src/lib/components/ProgressBar/ProgressBar.svelte
+++ b/apps/web-client/src/lib/components/ProgressBar/ProgressBar.svelte
@@ -5,7 +5,7 @@
 	$: progressWidth = value !== undefined ? `${value * 100}%` : undefined;
 </script>
 
-<div {...$$restProps} class="relative h-4 w-52 rounded-lg border-[1.5px] border-gray-200 bg-white {$$restProps.class}">
+<div {...$$restProps} class="relative h-4 w-52 rounded-lg border-[1.5px] border-base-300 bg-base-100 {$$restProps.class}">
 	<div class="absolute -left-0.5 -top-0.5 -bottom-0.5 -right-0.5 overflow-hidden rounded">
 		{#if progressWidth}
 			<div class="absolute top-0 left-0 h-full animate-pulse overflow-hidden rounded bg-teal-500" style:width={progressWidth}></div>

--- a/apps/web-client/src/lib/components/Tables/Cells/HeadCol.svelte
+++ b/apps/web-client/src/lib/components/Tables/Cells/HeadCol.svelte
@@ -9,7 +9,7 @@
 
 <span class="inline-flex items-center gap-2">
 	<svelte:component this={icon} aria-hidden="true" />
-	<span class="whitespace-nowrap text-base font-medium leading-5 text-gray-900" class:sr-only={srOnly}>
+	<span class="whitespace-nowrap text-base font-medium leading-5 text-base-content" class:sr-only={srOnly}>
 		{label}
 	</span>
 </span>

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/BookPriceCell.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/BookPriceCell.svelte
@@ -16,9 +16,9 @@
 		<span class="sr-only">{$LL.table_components.inventory_tables.book_price_cell.discounted_price()}:</span>
 		<span data-property="discounted-price">€{((price * (100 - warehouseDiscount)) / 100).toFixed(2)}</span>
 		<span class="sr-only">{$LL.table_components.inventory_tables.book_price_cell.original_price()}:</span>
-		<span class="text-gray-400 line-through" data-property="full-price">(€{price.toFixed(2)})</span>
+		<span class="text-base-content/50 line-through" data-property="full-price">(€{price.toFixed(2)})</span>
 		<span class="sr-only">{$LL.table_components.inventory_tables.book_price_cell.percentage_discount()}:</span>
-		<span class="text-gray-400" data-property="applied-discount">-{warehouseDiscount}%</span>
+		<span class="text-base-content/50" data-property="applied-discount">-{warehouseDiscount}%</span>
 	</div>
 {:else}
 	<!-- Price only is shown regardless of the row being a book row without discount applied, or a custom item row -->

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/BooksTable.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/BooksTable.svelte
@@ -37,16 +37,16 @@
 				on:click={handleOrderBy("isbn")}
 				scope="col"
 				class="group relative cursor-pointer {$orderBy === 'isbn'
-					? 'bg-gray-700/30'
-					: 'hover:bg-gray-500/10'} w-[20%] lg:w-[13%] xl:w-[10%]"
+					? 'bg-base-content/10'
+					: 'hover:bg-base-content/5'} w-[20%] lg:w-[13%] xl:w-[10%]"
 			>
 				<span class="hidden lg:inline">ISBN</span>
 				<span class="inline lg:hidden">Book</span>
 				<span class="{$orderBy === 'isbn' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "isbn" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -54,14 +54,14 @@
 			<th
 				on:click={handleOrderBy("title")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'title' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-lg"
+				class="group relative cursor-pointer {$orderBy === 'title' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-lg"
 			>
 				<span>Title</span>
 				<span class="{$orderBy === 'title' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "title" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -69,14 +69,14 @@
 			<th
 				on:click={handleOrderBy("authors")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'authors' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-lg"
+				class="group relative cursor-pointer {$orderBy === 'authors' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-lg"
 			>
 				<span>Authors</span>
 				<span class="{$orderBy === 'authors' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "authors" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -84,14 +84,14 @@
 			<th
 				on:click={handleOrderBy("price")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'price' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} "
+				class="group relative cursor-pointer {$orderBy === 'price' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} "
 			>
 				<span>Price</span>
 				<span class="{$orderBy === 'price' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "price" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -99,14 +99,14 @@
 			<th
 				on:click={handleOrderBy("publisher")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'publisher' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} "
+				class="group relative cursor-pointer {$orderBy === 'publisher' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} "
 			>
 				<span>Publisher</span>
 				<span class="{$orderBy === 'publisher' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "publisher" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -114,14 +114,14 @@
 			<th
 				on:click={handleOrderBy("year")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'year' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-lg"
+				class="group relative cursor-pointer {$orderBy === 'year' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-lg"
 			>
 				<span>Year</span>
 				<span class="{$orderBy === 'year' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "year" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -129,14 +129,14 @@
 			<th
 				on:click={handleOrderBy("editedBy")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'editedBy' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-xl"
+				class="group relative cursor-pointer {$orderBy === 'editedBy' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-xl"
 			>
 				<span>Edited By</span>
 				<span class="{$orderBy === 'editedBy' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
-					{#if $orderBy === "editedBy" && !$orderAsc}<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+					{#if $orderBy === "editedBy" && !$orderAsc}<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>
@@ -144,7 +144,7 @@
 			<th
 				on:click={handleOrderBy("outOfPrint")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'outOfPrint' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-xl"
+				class="group relative cursor-pointer {$orderBy === 'outOfPrint' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-xl"
 			>
 				<span>O.P</span>
 				<span class="{$orderBy === 'outOfPrint' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2"></span>
@@ -153,14 +153,14 @@
 			<th
 				on:click={handleOrderBy("category")}
 				scope="col"
-				class="group relative cursor-pointer {$orderBy === 'category' ? 'bg-gray-700/30' : 'hover:bg-gray-500/10'} show-col-xl"
+				class="group relative cursor-pointer {$orderBy === 'category' ? 'bg-base-content/10' : 'hover:bg-base-content/5'} show-col-xl"
 			>
 				<span>Category</span>
 				<span class="{$orderBy === 'category' ? '' : 'hidden group-hover:block'} absolute right-2 top-1/2 -translate-y-1/2">
 					{#if $orderBy === "category" && !$orderAsc}
-						<ChevronUp class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronUp class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{:else}
-						<ChevronDown class="h-4 w-4 rounded border border-gray-900 bg-white" />
+						<ChevronDown class="h-4 w-4 rounded border border-base-content/40 bg-base-100" />
 					{/if}
 				</span>
 			</th>

--- a/apps/web-client/src/lib/components/Tables/InventoryTables/CustomItemHeadCell.svelte
+++ b/apps/web-client/src/lib/components/Tables/InventoryTables/CustomItemHeadCell.svelte
@@ -11,7 +11,7 @@
 	<!-- An empty 'span' element to align the row appropriately, as 'isbn' (first cell in a full, book, row) doesn't exist for custom items -->
 	<span></span>
 	<BodyMultiRow
-		dlClassName="flex flex-col gap-y-0.5 mt-1 font-light text-gray-500 lg:hidden"
+		dlClassName="mt-1 flex flex-col gap-y-0.5 font-light text-base-content/60 lg:hidden"
 		rows={{
 			title: { data: title },
 			price: { data: price?.toFixed(2) }

--- a/apps/web-client/src/lib/components/Tables/stories/InventoryTables.stories.svelte
+++ b/apps/web-client/src/lib/components/Tables/stories/InventoryTables.stories.svelte
@@ -37,7 +37,10 @@
 <Story name="Stock">
 	<StockTable table={stockTable}>
 		<div slot="row-actions" let:row let:rowIx>
-			<button on:click={() => console.log(row)} class="rounded p-3 text-gray-500 hover:bg-gray-50 hover:text-gray-900">
+			<button
+				on:click={() => console.log(row)}
+				class="rounded p-3 text-base-content/60 transition-colors hover:bg-base-200 hover:text-base-content"
+			>
 				<span class="sr-only">Edit row {rowIx}</span>
 				<span class="aria-hidden">
 					<FileEdit />
@@ -50,7 +53,10 @@
 <Story name="Inbound">
 	<InboundTable table={inboundTable} on:edit-row-quantity={({ detail }) => console.log("Edit Quantity", detail)}>
 		<div slot="row-actions" let:row let:rowIx>
-			<button on:click={() => console.log(row)} class="rounded p-3 text-gray-500 hover:bg-gray-50 hover:text-gray-900">
+			<button
+				on:click={() => console.log(row)}
+				class="rounded p-3 text-base-content/60 transition-colors hover:bg-base-200 hover:text-base-content"
+			>
 				<span class="sr-only">Edit row {rowIx}</span>
 				<span class="aria-hidden">
 					<FileEdit />
@@ -67,7 +73,10 @@
 		on:edit-row-quantity={({ detail }) => console.log("Edit Quantity", detail)}
 	>
 		<div slot="row-actions" let:row let:rowIx>
-			<button on:click={() => console.log(row)} class="rounded p-3 text-gray-500 hover:bg-gray-50 hover:text-gray-900">
+			<button
+				on:click={() => console.log(row)}
+				class="rounded p-3 text-base-content/60 transition-colors hover:bg-base-200 hover:text-base-content"
+			>
 				<span class="sr-only">Edit row {rowIx}</span>
 				<span class="aria-hidden">
 					<FileEdit />

--- a/apps/web-client/src/lib/components/TextEditable/NumberEditable.svelte
+++ b/apps/web-client/src/lib/components/TextEditable/NumberEditable.svelte
@@ -50,7 +50,7 @@
 </script>
 
 <div
-	class="relative block w-full rounded border-2 border-transparent bg-transparent p-2 delay-75 focus-within:border-gray-500 focus-within:bg-gray-50 hover:border-gray-500"
+	class="relative block w-full rounded border-2 border-transparent bg-transparent p-2 text-base-content delay-75 focus-within:border-primary focus-within:bg-base-200/60 hover:border-base-300"
 	use:clickOutside
 	on:clickoutside={save}
 >
@@ -61,7 +61,7 @@
 		>
 			<input
 				type="number"
-				class="min-w-0 grow border-0 bg-transparent p-0 text-gray-800 placeholder-gray-400 focus:border-transparent focus:ring-0 {textClassName}"
+				class="min-w-0 grow border-0 bg-transparent p-0 text-base-content placeholder:text-base-content/50 focus:border-transparent focus:ring-0 {textClassName}"
 				{placeholder}
 				{name}
 				{id}
@@ -76,7 +76,7 @@
 	<div
 		class="flex flex-row items-center gap-x-2
 		{isEditing ? 'invisible' : 'visible'}
-		{number === 0 || disabled ? 'text-gray-400' : 'text-gray-800'}"
+		{number === 0 || disabled ? 'text-base-content/50' : 'text-base-content'}"
 		class:cursor-pointer={!disabled}
 		role="textbox"
 		aria-label="Edit {name}"
@@ -89,7 +89,7 @@
 			{number === 0 ? placeholder : number}
 		</svelte:element>
 		{#if !disabled}
-			<span class="text-gray-500" aria-hidden="true">
+			<span class="text-base-content/60" aria-hidden="true">
 				<PencilLine size={20} />
 			</span>
 		{/if}

--- a/apps/web-client/src/lib/components/TextEditable/TextEditable.svelte
+++ b/apps/web-client/src/lib/components/TextEditable/TextEditable.svelte
@@ -57,7 +57,7 @@
 
 <div
 	id={testId("text-editable-form")}
-	class="relative block w-full rounded border-2 border-transparent bg-transparent p-2 delay-75 focus-within:border-gray-500 focus-within:bg-gray-50 hover:border-gray-500"
+	class="relative block w-full rounded border-2 border-transparent bg-transparent p-2 text-base-content delay-75 focus-within:border-primary focus-within:bg-base-200/60 hover:border-base-300"
 	use:clickOutside
 	on:clickoutside={save}
 >
@@ -71,7 +71,7 @@
 			{:else}
 				<input
 					type="text"
-					class="min-w-0 grow border-0 bg-transparent p-0 text-gray-800 placeholder-gray-400 focus:border-transparent focus:ring-0 {textClassName}"
+					class="min-w-0 grow border-0 bg-transparent p-0 text-base-content placeholder:text-base-content/50 focus:border-transparent focus:ring-0 {textClassName}"
 					{placeholder}
 					{name}
 					{id}
@@ -87,7 +87,7 @@
 	<div
 		class="flex flex-row items-center gap-x-2
 		{isEditing ? 'invisible' : 'visible'}
-		{text === '' || disabled ? 'text-gray-400' : 'text-gray-800'}"
+		{text === '' || disabled ? 'text-base-content/50' : 'text-base-content'}"
 		class:cursor-pointer={!disabled}
 		role="textbox"
 		aria-label="Edit {name}"
@@ -100,7 +100,7 @@
 			{text === "" ? placeholder : text}
 		</svelte:element>
 		{#if !disabled}
-			<span class="text-gray-500" aria-hidden="true">
+			<span class="text-base-content/60" aria-hidden="true">
 				<PencilLine size={20} />
 			</span>
 		{/if}

--- a/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
+++ b/apps/web-client/src/lib/components/WarehouseSelect/WarehouseSelect.svelte
@@ -102,7 +102,7 @@
 			{/if}
 		</div>
 	{:else}
-		<span class="font-light text-gray-600">{t.default_option()}</span>
+		<span class="font-light text-base-content/60">{t.default_option()}</span>
 	{/if}
 	<ChevronsUpDown size={18} class="ml-auto shrink-0 self-center" />
 </button>
@@ -132,7 +132,7 @@
 					{/each}
 				</div>
 			{:else}
-				<p class="p-2 text-sm text-gray-600">
+				<p class="p-2 text-sm text-base-content/60">
 					{t.empty_options()}
 				</p>
 			{/if}

--- a/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/+page.svelte
@@ -118,7 +118,7 @@
 			<div class="min-w-fit md:basis-96 md:overflow-y-auto">
 				<div class="card h-full">
 					<div class="card-body p-0">
-						<div class="col-span-3 overflow-auto border-[#E5E5E5] p-[20px] py-6 px-[20px]">
+						<div class="col-span-3 overflow-auto border-base-300 p-[20px] px-[20px] py-6">
 							{#if supplier}
 								<SupplierCard
 									name={supplier.name}
@@ -140,20 +140,20 @@
 
 			<div class="flex min-h-0 w-full flex-1 flex-col gap-y-2 overflow-y-auto">
 				<!-- Tab Navigation -->
-				<div class="z-20 bg-white px-5 pt-6 pb-6">
+				<div class="z-20 bg-base-100 px-5 pb-6 pt-6">
 					<nav class="flex gap-2">
 						<button
 							class="rounded font-normal transition-colors {$activeTab === 'orders'
-								? 'border border-gray-900 bg-gray-900 text-white'
-								: 'border border-gray-200 bg-transparent text-gray-900 hover:bg-gray-50'} px-4 py-2 text-[14px]"
+								? 'border border-base-content bg-base-content text-base-100'
+								: 'border border-base-300 bg-transparent text-base-content hover:bg-base-200'} px-4 py-2 text-[14px]"
 							on:click={() => activeTab.set("orders")}
 						>
 							{t.tabs.orders()}
 						</button>
 						<button
 							class="rounded font-normal transition-colors {$activeTab === 'publishers'
-								? 'border border-gray-900 bg-gray-900 text-white'
-								: 'border border-gray-200 bg-transparent text-gray-900 hover:bg-gray-50'} px-4 py-2 text-[14px]"
+								? 'border border-base-content bg-base-content text-base-100'
+								: 'border border-base-300 bg-transparent text-base-content hover:bg-base-200'} px-4 py-2 text-[14px]"
 							on:click={() => activeTab.set("publishers")}
 						>
 							{t.tabs.assigned_publishers()}

--- a/apps/web-client/src/routes/orders/suppliers/[id]/OrdersView.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/OrdersView.svelte
@@ -22,7 +22,7 @@
 	$: tabsT = $LL.supplier_orders_page.tabs;
 </script>
 
-<div class="px-5">
+<div class="px-5 text-base-content">
 	<div class="mb-8">
 		<h4 class="mb-4 text-[14px]">{tabsT.ordered()}</h4>
 		<Table columnWidths={["3", "3", "6"]} showEmptyState={placedOrders.length === 0}>
@@ -37,7 +37,7 @@
 					<tr
 						tabindex="0"
 						role="button"
-						class="cursor-pointer border-b border-[#E5E5E5] px-[16px] py-[8px] transition-colors last:border-b-0 hover:cursor-pointer hover:bg-[#FAFAFA]"
+						class="cursor-pointer border-b border-base-300 px-[16px] py-[8px] transition-colors last:border-b-0 hover:bg-base-200/60"
 						on:click={() => _goto(appPath("supplier_orders", id))}
 						on:keydown={(e) => e.key === "Enter" && _goto(appPath("supplier_orders", id))}
 					>
@@ -66,7 +66,7 @@
 					<tr
 						tabindex="0"
 						role="button"
-						class="cursor-pointer border-b border-[#E5E5E5] px-[16px] py-[8px] transition-colors last:border-b-0 hover:cursor-pointer hover:bg-[#FAFAFA]"
+						class="cursor-pointer border-b border-base-300 px-[16px] py-[8px] transition-colors last:border-b-0 hover:bg-base-200/60"
 						on:click={() => _goto(appPath("supplier_orders", id))}
 						on:keydown={(e) => e.key === "Enter" && _goto(appPath("supplier_orders", id))}
 					>
@@ -97,7 +97,7 @@
 					<tr
 						tabindex="0"
 						role="button"
-						class="cursor-pointer border-b border-[#E5E5E5] px-[16px] py-[8px] transition-colors last:border-b-0 hover:cursor-pointer hover:bg-[#FAFAFA]"
+						class="cursor-pointer border-b border-base-300 px-[16px] py-[8px] transition-colors last:border-b-0 hover:bg-base-200/60"
 						on:click={() => _goto(appPath("supplier_orders", id))}
 						on:keydown={(e) => e.key === "Enter" && _goto(appPath("supplier_orders", id))}
 					>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/PublisherView.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/PublisherView.svelte
@@ -1,168 +1,31 @@
 <script lang="ts">
-	import { createDialog } from "@melt-ui/svelte";
-
-	import LL from "@librocco/shared/i18n-svelte";
-
 	import type { PageData } from "./$types";
 
-	import { defaultDialogConfig } from "$lib/components/Melt";
-	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
-
 	import { associatePublisher, removePublisherFromSupplier } from "$lib/db/cr-sqlite/suppliers";
-	import { SupplierPublisherTable, SupplierPublisherTableRow } from "$lib/components-new/SupplierPublisherList";
+	import SupplierPublishersPanel from "./SupplierPublishersPanel.svelte";
 
 	import { app } from "$lib/app";
 	import { getDb } from "$lib/app/db";
 
 	export let data: PageData;
 
-	let searchQuery = "";
-
 	$: ({ supplier, assignedPublishers, availablePublishers } = data);
 
-	$: filteredAssigned = searchQuery
-		? assignedPublishers.filter((p) => p.toLowerCase().includes(searchQuery.toLowerCase()))
-		: assignedPublishers;
-
-	$: filteredAvailable = searchQuery
-		? availablePublishers.filter((p) => p.name.toLowerCase().includes(searchQuery.toLowerCase()))
-		: availablePublishers;
-
-	$: t = $LL.order_list_page;
-
-	let confirmationPublisher = "";
-	const confirmationDialog = createDialog(defaultDialogConfig);
-	const {
-		states: { open: confirmationDialogOpen }
-	} = confirmationDialog;
-
-	const handleAssignPublisher = (publisher: string) => async () => {
+	const handleAssignPublisher = async (publisher: string) => {
 		const db = await getDb(app);
 		await associatePublisher(db, supplier.id, publisher);
 	};
 
-	const handleUnassignPublisher = (publisher: string) => async () => {
+	const handleUnassignPublisher = async (publisher: string) => {
 		const db = await getDb(app);
 		await removePublisherFromSupplier(db, supplier.id, publisher);
 	};
 </script>
 
-<div class="mb-4 flex min-h-0 w-full flex-1 flex-col pb-4">
-	<div class="sticky top-0 z-20 mb-4 bg-white px-5 pb-4">
-		<div class="relative flex items-center gap-2">
-			<div class="relative w-full">
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke-width="1.5"
-					stroke="currentColor"
-					class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-					/>
-				</svg>
-				<input
-					type="text"
-					placeholder={t.placeholders.search_publishers()}
-					bind:value={searchQuery}
-					class="h-9 w-full rounded border border-none border-gray-300 bg-white py-1 pl-9 pr-3 text-sm placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-				/>
-			</div>
-			{#if searchQuery}
-				<button on:click={() => (searchQuery = "")} class="btn-xs btn-circle btn" aria-label={t.aria.clear_search()}>✕</button>
-			{/if}
-		</div>
-	</div>
-
-	<div class="flex min-h-0 flex-1 overflow-hidden px-5 pb-5">
-		<div class="grid flex-1 grid-cols-2 gap-4 overflow-hidden">
-			<div class="flex min-w-0 flex-1 flex-col border-gray-200">
-				<SupplierPublisherTable
-					showEmptyState={filteredAssigned.length === 0}
-					emptyStateMessage={searchQuery ? t.placeholders.no_matching_assigned_publishers() : t.placeholders.no_assigned_publishers()}
-				>
-					<svelte:fragment slot="title">{t.tabs.assigned_publishers()}</svelte:fragment>
-
-					<span slot="badge" class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white">
-						{filteredAssigned.length}
-					</span>
-
-					{#each filteredAssigned as publisher}
-						<SupplierPublisherTableRow publisherName={publisher}>
-							<button
-								slot="action-button"
-								on:click={handleUnassignPublisher(publisher)}
-								class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-gray-500 hover:bg-red-50 hover:!text-red-600"
-							>
-								{t.labels.remove()}
-							</button>
-						</SupplierPublisherTableRow>
-					{/each}
-				</SupplierPublisherTable>
-			</div>
-
-			<SupplierPublisherTable
-				showEmptyState={filteredAvailable.length === 0}
-				emptyStateMessage={searchQuery ? t.placeholders.no_matching_available_publishers() : t.placeholders.no_available_publishers()}
-			>
-				<svelte:fragment slot="title">{t.table.unassigned_publishers()}</svelte:fragment>
-				<span slot="badge" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
-					{filteredAvailable.length}
-				</span>
-
-				{#each filteredAvailable as pub}
-					{#if pub.supplierName}
-						<SupplierPublisherTableRow publisherName={pub.name}>
-							<span
-								slot="badge"
-								class="inline-flex truncate rounded bg-amber-100 px-1.5 text-[10px] font-medium text-amber-800"
-								title={t.placeholders.currently_assigned_to({ supplierName: pub.supplierName })}
-							>
-								{pub.supplierName}
-							</span>
-							<button
-								slot="action-button"
-								on:click={() => {
-									confirmationPublisher = pub.name;
-									confirmationDialogOpen.set(true);
-								}}
-								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
-							>
-								{t.labels.reassign()}
-							</button>
-						</SupplierPublisherTableRow>
-					{:else}
-						<SupplierPublisherTableRow publisherName={pub.name}>
-							<button
-								slot="action-button"
-								on:click={handleAssignPublisher(pub.name)}
-								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
-							>
-								{t.labels.add()}
-							</button>
-						</SupplierPublisherTableRow>
-					{/if}
-				{/each}
-			</SupplierPublisherTable>
-		</div>
-	</div>
-</div>
-
-<ConfirmDialog
-	dialog={confirmationDialog}
-	title={t.dialogs.reassign_publisher.title()}
-	description={t.dialogs.reassign_publisher.description({ publisher: confirmationPublisher, supplier: supplier.name })}
-	labels={{
-		confirm: $LL.common.actions.confirm(),
-		cancel: $LL.common.actions.cancel()
-	}}
-	onConfirm={() => {
-		handleAssignPublisher(confirmationPublisher)();
-		confirmationDialogOpen.set(false);
-	}}
-	onCancel={() => confirmationDialogOpen.set(false)}
+<SupplierPublishersPanel
+	supplierName={supplier.name}
+	{assignedPublishers}
+	{availablePublishers}
+	onAssignPublisher={handleAssignPublisher}
+	onUnassignPublisher={handleUnassignPublisher}
 />

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
@@ -1,0 +1,98 @@
+<script context="module" lang="ts">
+	import type { Meta } from "@storybook/svelte";
+
+	import SupplierPublishersPanelStoryHarnessComponent from "./SupplierPublishersPanelStoryHarness.svelte";
+
+	export const meta: Meta = {
+		title: "Routes/Orders/Suppliers/Publisher Panel",
+		component: SupplierPublishersPanelStoryHarnessComponent
+	};
+</script>
+
+<script lang="ts">
+	import { expect, waitFor, within } from "storybook/test";
+
+	import { Story, Template } from "@storybook/addon-svelte-csf";
+
+	import SupplierPublishersPanelStoryHarness from "./SupplierPublishersPanelStoryHarness.svelte";
+
+	const baseArgs = {
+		supplierName: "Story Supplier",
+		assignedPublishers: ["pub1"],
+		availablePublishers: [{ name: "pub2", supplierName: "Other Supplier" }, { name: "Publisher A" }]
+	};
+</script>
+
+<Template let:args={{ supplierName, assignedPublishers, availablePublishers }}>
+	<SupplierPublishersPanelStoryHarness {supplierName} {assignedPublishers} {availablePublishers} />
+</Template>
+
+<Story
+	name="Interactive"
+	args={baseArgs}
+	play={async ({ canvasElement, step, userEvent }) => {
+		const canvas = within(canvasElement);
+
+		const getRow = (column: "assigned" | "available", publisherName: string) =>
+			canvas.getByTestId(
+				`publisher-row-${column}-${publisherName
+					.toLowerCase()
+					.replace(/[^a-z0-9]+/g, "-")
+					.replace(/^-+|-+$/g, "")}`
+			);
+
+		await step("shows the split publishers layout", async () => {
+			await expect(canvas.getByText("Assigned Publishers")).toBeVisible();
+			await expect(canvas.getByText("Unassigned publishers")).toBeVisible();
+			await expect(canvas.getByPlaceholderText("Search publishers...")).toBeVisible();
+		});
+
+		await step("filters and clears the publishers search", async () => {
+			const searchInput = canvas.getByPlaceholderText("Search publishers...");
+			await userEvent.type(searchInput, "pub1");
+
+			await expect(getRow("assigned", "pub1")).toBeVisible();
+			await expect(canvas.queryByTestId("publisher-row-available-pub2")).not.toBeInTheDocument();
+			await expect(canvas.queryByTestId("publisher-row-available-publisher-a")).not.toBeInTheDocument();
+
+			await userEvent.click(canvas.getByRole("button", { name: "Clear search" }));
+			await expect(getRow("available", "pub2")).toBeVisible();
+		});
+
+		await step("removes an assigned publisher", async () => {
+			await userEvent.click(within(getRow("assigned", "pub1")).getByRole("button", { name: "Remove" }));
+
+			await waitFor(() => {
+				expect(canvas.queryByTestId("publisher-row-assigned-pub1")).not.toBeInTheDocument();
+				expect(within(getRow("available", "pub1")).getByRole("button", { name: "Add" })).toBeVisible();
+			});
+		});
+
+		await step("assigns an unassigned publisher", async () => {
+			await userEvent.click(within(getRow("available", "Publisher A")).getByRole("button", { name: "Add" }));
+
+			await waitFor(() => {
+				expect(canvas.queryByTestId("publisher-row-available-publisher-a")).not.toBeInTheDocument();
+				expect(within(getRow("assigned", "Publisher A")).getByRole("button", { name: "Remove" })).toBeVisible();
+			});
+		});
+
+		await step("reassigns a publisher after confirmation", async () => {
+			await userEvent.click(within(getRow("available", "pub2")).getByRole("button", { name: "Re-assign" }));
+
+			const dialog = canvas.getByRole("dialog");
+			await expect(dialog).toBeVisible();
+			await expect(dialog).toHaveTextContent(
+				"Are you sure you want to remove pub2 from its previous supplier and assign it to Story Supplier?"
+			);
+
+			await userEvent.click(within(dialog).getByRole("button", { name: "Confirm" }));
+
+			await waitFor(() => {
+				expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+				expect(canvas.queryByTestId("publisher-row-available-pub2")).not.toBeInTheDocument();
+				expect(within(getRow("assigned", "pub2")).getByRole("button", { name: "Remove" })).toBeVisible();
+			});
+		});
+	}}
+/>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
@@ -23,15 +23,17 @@
 	};
 </script>
 
-<Template let:args={{ supplierName, assignedPublishers, availablePublishers }}>
-	<SupplierPublishersPanelStoryHarness {supplierName} {assignedPublishers} {availablePublishers} />
+<Template let:args>
+	<SupplierPublishersPanelStoryHarness {...args} />
 </Template>
 
 <Story
 	name="Interactive"
 	args={baseArgs}
+	tags={["test-only"]}
 	play={async ({ canvasElement, step, userEvent }) => {
 		const canvas = within(canvasElement);
+		const documentBody = within(canvasElement.ownerDocument.body);
 
 		const getRow = (column: "assigned" | "available", publisherName: string) =>
 			canvas.getByTestId(
@@ -80,16 +82,18 @@
 		await step("reassigns a publisher after confirmation", async () => {
 			await userEvent.click(within(getRow("available", "pub2")).getByRole("button", { name: "Re-assign" }));
 
-			const dialog = canvas.getByRole("dialog");
-			await expect(dialog).toBeVisible();
-			await expect(dialog).toHaveTextContent(
-				"Are you sure you want to remove pub2 from its previous supplier and assign it to Story Supplier?"
-			);
+			await waitFor(() => {
+				expect(documentBody.getByRole("dialog")).toHaveTextContent(
+					"Are you sure you want to remove pub2 from its previous supplier and assign it to Story Supplier?"
+				);
+			});
+
+			const dialog = documentBody.getByRole("dialog");
 
 			await userEvent.click(within(dialog).getByRole("button", { name: "Confirm" }));
 
 			await waitFor(() => {
-				expect(canvas.queryByRole("dialog")).not.toBeInTheDocument();
+				expect(documentBody.queryByRole("dialog")).not.toBeInTheDocument();
 				expect(canvas.queryByTestId("publisher-row-available-pub2")).not.toBeInTheDocument();
 				expect(within(getRow("assigned", "pub2")).getByRole("button", { name: "Remove" })).toBeVisible();
 			});

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.stories.svelte
@@ -5,7 +5,12 @@
 
 	export const meta: Meta = {
 		title: "Routes/Orders/Suppliers/Publisher Panel",
-		component: SupplierPublishersPanelStoryHarnessComponent
+		component: SupplierPublishersPanelStoryHarnessComponent,
+		parameters: {
+			controls: {
+				disable: true
+			}
+		}
 	};
 </script>
 
@@ -16,10 +21,49 @@
 
 	import SupplierPublishersPanelStoryHarness from "./SupplierPublishersPanelStoryHarness.svelte";
 
+	type AvailablePublisher = {
+		name: string;
+		supplierName?: string;
+	};
+
+	type StoryArgs = {
+		supplierName: string;
+		assignedPublishers: string[];
+		availablePublishers: AvailablePublisher[];
+	};
+
 	const baseArgs = {
 		supplierName: "Story Supplier",
 		assignedPublishers: ["pub1"],
 		availablePublishers: [{ name: "pub2", supplierName: "Other Supplier" }, { name: "Publisher A" }]
+	} satisfies StoryArgs;
+
+	type PublisherColumn = "assigned" | "available";
+
+	const emptyArgs = {
+		supplierName: "Story Supplier",
+		assignedPublishers: [],
+		availablePublishers: []
+	} satisfies StoryArgs;
+
+	const publisherRowTestId = (column: PublisherColumn, publisherName: string) =>
+		`publisher-row-${column}-${publisherName
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "")}`;
+
+	const buildStoryApi = (canvasElement: HTMLElement) => {
+		const canvas = within(canvasElement);
+		const documentBody = within(canvasElement.ownerDocument.body);
+
+		return {
+			canvas,
+			documentBody,
+			getPanel: (column: PublisherColumn) => canvas.getByTestId(`publisher-panel-${column}`),
+			getCount: (column: PublisherColumn) => canvas.getByTestId(`publisher-count-${column}`),
+			getRow: (column: PublisherColumn, publisherName: string) => canvas.getByTestId(publisherRowTestId(column, publisherName)),
+			getSearchInput: () => canvas.getByPlaceholderText("Search publishers...")
+		};
 	};
 </script>
 
@@ -28,56 +72,97 @@
 </Template>
 
 <Story
-	name="Interactive"
+	name="Search"
 	args={baseArgs}
 	tags={["test-only"]}
 	play={async ({ canvasElement, step, userEvent }) => {
-		const canvas = within(canvasElement);
-		const documentBody = within(canvasElement.ownerDocument.body);
+		const { canvas, getCount, getPanel, getRow, getSearchInput } = buildStoryApi(canvasElement);
 
-		const getRow = (column: "assigned" | "available", publisherName: string) =>
-			canvas.getByTestId(
-				`publisher-row-${column}-${publisherName
-					.toLowerCase()
-					.replace(/[^a-z0-9]+/g, "-")
-					.replace(/^-+|-+$/g, "")}`
-			);
-
-		await step("shows the split publishers layout", async () => {
+		await step("shows the split publishers layout and badge counts", async () => {
 			await expect(canvas.getByText("Assigned Publishers")).toBeVisible();
 			await expect(canvas.getByText("Unassigned publishers")).toBeVisible();
-			await expect(canvas.getByPlaceholderText("Search publishers...")).toBeVisible();
+			await expect(getSearchInput()).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("1");
+			await expect(getCount("available")).toHaveTextContent("2");
 		});
 
-		await step("filters and clears the publishers search", async () => {
-			const searchInput = canvas.getByPlaceholderText("Search publishers...");
-			await userEvent.type(searchInput, "pub1");
+		await step("filters publishers and shows matching empty states", async () => {
+			await userEvent.type(getSearchInput(), "pub1");
 
 			await expect(getRow("assigned", "pub1")).toBeVisible();
-			await expect(canvas.queryByTestId("publisher-row-available-pub2")).not.toBeInTheDocument();
-			await expect(canvas.queryByTestId("publisher-row-available-publisher-a")).not.toBeInTheDocument();
+			await expect(within(getPanel("available")).getByText("No matching available publishers")).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("1");
+			await expect(getCount("available")).toHaveTextContent("0");
 
 			await userEvent.click(canvas.getByRole("button", { name: "Clear search" }));
 			await expect(getRow("available", "pub2")).toBeVisible();
-		});
+			await expect(getCount("assigned")).toHaveTextContent("1");
+			await expect(getCount("available")).toHaveTextContent("2");
 
-		await step("removes an assigned publisher", async () => {
+			await userEvent.type(getSearchInput(), "zzz");
+			await expect(within(getPanel("assigned")).getByText("No matching assigned publishers")).toBeVisible();
+			await expect(within(getPanel("available")).getByText("No matching available publishers")).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("0");
+			await expect(getCount("available")).toHaveTextContent("0");
+
+			await userEvent.click(canvas.getByRole("button", { name: "Clear search" }));
+			await expect(getRow("assigned", "pub1")).toBeVisible();
+			await expect(getRow("available", "Publisher A")).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("1");
+			await expect(getCount("available")).toHaveTextContent("2");
+		});
+	}}
+/>
+
+<Story
+	name="RemoveAssigned"
+	args={baseArgs}
+	tags={["test-only"]}
+	play={async ({ canvasElement, step, userEvent }) => {
+		const { canvas, getCount, getPanel, getRow } = buildStoryApi(canvasElement);
+
+		await step("removes an assigned publisher and exposes the empty state", async () => {
 			await userEvent.click(within(getRow("assigned", "pub1")).getByRole("button", { name: "Remove" }));
 
 			await waitFor(() => {
-				expect(canvas.queryByTestId("publisher-row-assigned-pub1")).not.toBeInTheDocument();
+				expect(canvas.queryByTestId(publisherRowTestId("assigned", "pub1"))).not.toBeInTheDocument();
 				expect(within(getRow("available", "pub1")).getByRole("button", { name: "Add" })).toBeVisible();
 			});
+
+			await expect(within(getPanel("assigned")).getByText("No assigned publishers")).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("0");
+			await expect(getCount("available")).toHaveTextContent("3");
 		});
+	}}
+/>
+
+<Story
+	name="AddUnassigned"
+	args={baseArgs}
+	tags={["test-only"]}
+	play={async ({ canvasElement, step, userEvent }) => {
+		const { canvas, getCount, getRow } = buildStoryApi(canvasElement);
 
 		await step("assigns an unassigned publisher", async () => {
 			await userEvent.click(within(getRow("available", "Publisher A")).getByRole("button", { name: "Add" }));
 
 			await waitFor(() => {
-				expect(canvas.queryByTestId("publisher-row-available-publisher-a")).not.toBeInTheDocument();
+				expect(canvas.queryByTestId(publisherRowTestId("available", "Publisher A"))).not.toBeInTheDocument();
 				expect(within(getRow("assigned", "Publisher A")).getByRole("button", { name: "Remove" })).toBeVisible();
 			});
+
+			await expect(getCount("assigned")).toHaveTextContent("2");
+			await expect(getCount("available")).toHaveTextContent("1");
 		});
+	}}
+/>
+
+<Story
+	name="ReassignWithConfirm"
+	args={baseArgs}
+	tags={["test-only"]}
+	play={async ({ canvasElement, step, userEvent }) => {
+		const { canvas, documentBody, getCount, getRow } = buildStoryApi(canvasElement);
 
 		await step("reassigns a publisher after confirmation", async () => {
 			await userEvent.click(within(getRow("available", "pub2")).getByRole("button", { name: "Re-assign" }));
@@ -89,14 +174,61 @@
 			});
 
 			const dialog = documentBody.getByRole("dialog");
-
 			await userEvent.click(within(dialog).getByRole("button", { name: "Confirm" }));
 
 			await waitFor(() => {
 				expect(documentBody.queryByRole("dialog")).not.toBeInTheDocument();
-				expect(canvas.queryByTestId("publisher-row-available-pub2")).not.toBeInTheDocument();
+				expect(canvas.queryByTestId(publisherRowTestId("available", "pub2"))).not.toBeInTheDocument();
 				expect(within(getRow("assigned", "pub2")).getByRole("button", { name: "Remove" })).toBeVisible();
 			});
+
+			await expect(getCount("assigned")).toHaveTextContent("2");
+			await expect(getCount("available")).toHaveTextContent("1");
+		});
+	}}
+/>
+
+<Story
+	name="ReassignCancel"
+	args={baseArgs}
+	tags={["test-only"]}
+	play={async ({ canvasElement, step, userEvent }) => {
+		const { canvas, documentBody, getCount, getRow } = buildStoryApi(canvasElement);
+
+		await step("cancels a reassignment without mutating either list", async () => {
+			await userEvent.click(within(getRow("available", "pub2")).getByRole("button", { name: "Re-assign" }));
+
+			await waitFor(() => {
+				expect(documentBody.getByRole("dialog")).toBeVisible();
+			});
+
+			const dialog = documentBody.getByRole("dialog");
+			await userEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+			await waitFor(() => {
+				expect(documentBody.queryByRole("dialog")).not.toBeInTheDocument();
+			});
+
+			await expect(within(getRow("available", "pub2")).getByRole("button", { name: "Re-assign" })).toBeVisible();
+			await expect(canvas.queryByTestId(publisherRowTestId("assigned", "pub2"))).not.toBeInTheDocument();
+			await expect(getCount("assigned")).toHaveTextContent("1");
+			await expect(getCount("available")).toHaveTextContent("2");
+		});
+	}}
+/>
+
+<Story
+	name="EmptyState"
+	args={emptyArgs}
+	tags={["test-only"]}
+	play={async ({ canvasElement, step }) => {
+		const { getCount, getPanel } = buildStoryApi(canvasElement);
+
+		await step("shows both empty state messages with zero badges", async () => {
+			await expect(within(getPanel("assigned")).getByText("No assigned publishers")).toBeVisible();
+			await expect(within(getPanel("available")).getByText("No available publishers")).toBeVisible();
+			await expect(getCount("assigned")).toHaveTextContent("0");
+			await expect(getCount("available")).toHaveTextContent("0");
 		});
 	}}
 />

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
@@ -76,14 +76,18 @@
 
 	<div class="flex min-h-0 flex-1 overflow-hidden px-5 pb-5">
 		<div class="grid flex-1 grid-cols-2 gap-4 overflow-hidden">
-			<div class="flex min-w-0 flex-1 flex-col border-gray-200">
+			<div data-testid="publisher-panel-assigned" class="flex min-w-0 flex-1 flex-col border-gray-200">
 				<SupplierPublisherTable
 					showEmptyState={filteredAssigned.length === 0}
 					emptyStateMessage={searchQuery ? t.placeholders.no_matching_assigned_publishers() : t.placeholders.no_assigned_publishers()}
 				>
 					<svelte:fragment slot="title">{t.tabs.assigned_publishers()}</svelte:fragment>
 
-					<span slot="badge" class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white">
+					<span
+						slot="badge"
+						data-testid="publisher-count-assigned"
+						class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white"
+					>
 						{filteredAssigned.length}
 					</span>
 
@@ -101,49 +105,55 @@
 				</SupplierPublisherTable>
 			</div>
 
-			<SupplierPublisherTable
-				showEmptyState={filteredAvailable.length === 0}
-				emptyStateMessage={searchQuery ? t.placeholders.no_matching_available_publishers() : t.placeholders.no_available_publishers()}
-			>
-				<svelte:fragment slot="title">{t.table.unassigned_publishers()}</svelte:fragment>
-				<span slot="badge" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
-					{filteredAvailable.length}
-				</span>
+			<div data-testid="publisher-panel-available" class="flex min-w-0 flex-1 flex-col">
+				<SupplierPublisherTable
+					showEmptyState={filteredAvailable.length === 0}
+					emptyStateMessage={searchQuery ? t.placeholders.no_matching_available_publishers() : t.placeholders.no_available_publishers()}
+				>
+					<svelte:fragment slot="title">{t.table.unassigned_publishers()}</svelte:fragment>
+					<span
+						slot="badge"
+						data-testid="publisher-count-available"
+						class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600"
+					>
+						{filteredAvailable.length}
+					</span>
 
-				{#each filteredAvailable as publisher}
-					{#if publisher.supplierName}
-						<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
-							<span
-								slot="badge"
-								class="inline-flex truncate rounded bg-amber-100 px-1.5 text-[10px] font-medium text-amber-800"
-								title={t.placeholders.currently_assigned_to({ supplierName: publisher.supplierName })}
-							>
-								{publisher.supplierName}
-							</span>
-							<button
-								slot="action-button"
-								on:click={() => {
-									confirmationPublisher = publisher.name;
-									confirmationDialogOpen.set(true);
-								}}
-								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
-							>
-								{t.labels.reassign()}
-							</button>
-						</SupplierPublisherTableRow>
-					{:else}
-						<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
-							<button
-								slot="action-button"
-								on:click={() => onAssignPublisher(publisher.name)}
-								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
-							>
-								{t.labels.add()}
-							</button>
-						</SupplierPublisherTableRow>
-					{/if}
-				{/each}
-			</SupplierPublisherTable>
+					{#each filteredAvailable as publisher}
+						{#if publisher.supplierName}
+							<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
+								<span
+									slot="badge"
+									class="inline-flex truncate rounded bg-amber-100 px-1.5 text-[10px] font-medium text-amber-800"
+									title={t.placeholders.currently_assigned_to({ supplierName: publisher.supplierName })}
+								>
+									{publisher.supplierName}
+								</span>
+								<button
+									slot="action-button"
+									on:click={() => {
+										confirmationPublisher = publisher.name;
+										confirmationDialogOpen.set(true);
+									}}
+									class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+								>
+									{t.labels.reassign()}
+								</button>
+							</SupplierPublisherTableRow>
+						{:else}
+							<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
+								<button
+									slot="action-button"
+									on:click={() => onAssignPublisher(publisher.name)}
+									class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+								>
+									{t.labels.add()}
+								</button>
+							</SupplierPublisherTableRow>
+						{/if}
+					{/each}
+				</SupplierPublisherTable>
+			</div>
 		</div>
 	</div>
 </div>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { createDialog } from "@melt-ui/svelte";
+
+	import LL from "@librocco/shared/i18n-svelte";
+
+	import { defaultDialogConfig } from "$lib/components/Melt";
+	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
+	import { SupplierPublisherTable, SupplierPublisherTableRow } from "$lib/components-new/SupplierPublisherList";
+
+	type AvailablePublisher = {
+		name: string;
+		supplierName?: string;
+	};
+
+	export let supplierName: string;
+	export let assignedPublishers: string[];
+	export let availablePublishers: AvailablePublisher[];
+	export let onAssignPublisher: (publisher: string) => void | Promise<void>;
+	export let onUnassignPublisher: (publisher: string) => void | Promise<void>;
+
+	let searchQuery = "";
+
+	$: filteredAssigned = searchQuery
+		? assignedPublishers.filter((publisher) => publisher.toLowerCase().includes(searchQuery.toLowerCase()))
+		: assignedPublishers;
+
+	$: filteredAvailable = searchQuery
+		? availablePublishers.filter((publisher) => publisher.name.toLowerCase().includes(searchQuery.toLowerCase()))
+		: availablePublishers;
+
+	$: t = $LL.order_list_page;
+
+	let confirmationPublisher = "";
+	const confirmationDialog = createDialog(defaultDialogConfig);
+	const {
+		states: { open: confirmationDialogOpen }
+	} = confirmationDialog;
+
+	const publisherRowTestId = (column: "assigned" | "available", publisherName: string): string =>
+		`publisher-row-${column}-${publisherName
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "")}`;
+</script>
+
+<div class="mb-4 flex min-h-0 w-full flex-1 flex-col pb-4">
+	<div class="sticky top-0 z-20 mb-4 bg-white px-5 pb-4">
+		<div class="relative flex items-center gap-2">
+			<div class="relative w-full">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+					/>
+				</svg>
+				<input
+					type="text"
+					placeholder={t.placeholders.search_publishers()}
+					bind:value={searchQuery}
+					class="h-9 w-full rounded border border-none border-gray-300 bg-white py-1 pl-9 pr-3 text-sm placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				/>
+			</div>
+			{#if searchQuery}
+				<button on:click={() => (searchQuery = "")} class="btn-xs btn-circle btn" aria-label={t.aria.clear_search()}>✕</button>
+			{/if}
+		</div>
+	</div>
+
+	<div class="flex min-h-0 flex-1 overflow-hidden px-5 pb-5">
+		<div class="grid flex-1 grid-cols-2 gap-4 overflow-hidden">
+			<div class="flex min-w-0 flex-1 flex-col border-gray-200">
+				<SupplierPublisherTable
+					showEmptyState={filteredAssigned.length === 0}
+					emptyStateMessage={searchQuery ? t.placeholders.no_matching_assigned_publishers() : t.placeholders.no_assigned_publishers()}
+				>
+					<svelte:fragment slot="title">{t.tabs.assigned_publishers()}</svelte:fragment>
+
+					<span slot="badge" class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white">
+						{filteredAssigned.length}
+					</span>
+
+					{#each filteredAssigned as publisher}
+						<SupplierPublisherTableRow publisherName={publisher} testId={publisherRowTestId("assigned", publisher)}>
+							<button
+								slot="action-button"
+								on:click={() => onUnassignPublisher(publisher)}
+								class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-gray-500 hover:bg-red-50 hover:!text-red-600"
+							>
+								{t.labels.remove()}
+							</button>
+						</SupplierPublisherTableRow>
+					{/each}
+				</SupplierPublisherTable>
+			</div>
+
+			<SupplierPublisherTable
+				showEmptyState={filteredAvailable.length === 0}
+				emptyStateMessage={searchQuery ? t.placeholders.no_matching_available_publishers() : t.placeholders.no_available_publishers()}
+			>
+				<svelte:fragment slot="title">{t.table.unassigned_publishers()}</svelte:fragment>
+				<span slot="badge" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600">
+					{filteredAvailable.length}
+				</span>
+
+				{#each filteredAvailable as publisher}
+					{#if publisher.supplierName}
+						<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
+							<span
+								slot="badge"
+								class="inline-flex truncate rounded bg-amber-100 px-1.5 text-[10px] font-medium text-amber-800"
+								title={t.placeholders.currently_assigned_to({ supplierName: publisher.supplierName })}
+							>
+								{publisher.supplierName}
+							</span>
+							<button
+								slot="action-button"
+								on:click={() => {
+									confirmationPublisher = publisher.name;
+									confirmationDialogOpen.set(true);
+								}}
+								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+							>
+								{t.labels.reassign()}
+							</button>
+						</SupplierPublisherTableRow>
+					{:else}
+						<SupplierPublisherTableRow publisherName={publisher.name} testId={publisherRowTestId("available", publisher.name)}>
+							<button
+								slot="action-button"
+								on:click={() => onAssignPublisher(publisher.name)}
+								class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+							>
+								{t.labels.add()}
+							</button>
+						</SupplierPublisherTableRow>
+					{/if}
+				{/each}
+			</SupplierPublisherTable>
+		</div>
+	</div>
+</div>
+
+<ConfirmDialog
+	dialog={confirmationDialog}
+	title={t.dialogs.reassign_publisher.title()}
+	description={t.dialogs.reassign_publisher.description({ publisher: confirmationPublisher, supplier: supplierName })}
+	labels={{
+		confirm: $LL.common.actions.confirm(),
+		cancel: $LL.common.actions.cancel()
+	}}
+	onConfirm={() => {
+		onAssignPublisher(confirmationPublisher);
+		confirmationDialogOpen.set(false);
+	}}
+	onCancel={() => confirmationDialogOpen.set(false)}
+/>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanel.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <div class="mb-4 flex min-h-0 w-full flex-1 flex-col pb-4">
-	<div class="sticky top-0 z-20 mb-4 bg-white px-5 pb-4">
+	<div class="sticky top-0 z-20 mb-4 bg-base-100 px-5 pb-4">
 		<div class="relative flex items-center gap-2">
 			<div class="relative w-full">
 				<svg
@@ -53,7 +53,7 @@
 					viewBox="0 0 24 24"
 					stroke-width="1.5"
 					stroke="currentColor"
-					class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+					class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/50"
 				>
 					<path
 						stroke-linecap="round"
@@ -65,7 +65,7 @@
 					type="text"
 					placeholder={t.placeholders.search_publishers()}
 					bind:value={searchQuery}
-					class="h-9 w-full rounded border border-none border-gray-300 bg-white py-1 pl-9 pr-3 text-sm placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+					class="h-9 w-full rounded border border-base-300 bg-base-100 py-1 pl-9 pr-3 text-sm text-base-content placeholder:text-base-content/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
 				/>
 			</div>
 			{#if searchQuery}
@@ -86,7 +86,7 @@
 					<span
 						slot="badge"
 						data-testid="publisher-count-assigned"
-						class="inline-flex items-center rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium text-white"
+						class="inline-flex items-center rounded-full bg-base-content px-2 py-0.5 text-[10px] font-medium text-base-100"
 					>
 						{filteredAssigned.length}
 					</span>
@@ -96,7 +96,7 @@
 							<button
 								slot="action-button"
 								on:click={() => onUnassignPublisher(publisher)}
-								class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-gray-500 hover:bg-red-50 hover:!text-red-600"
+								class="h-5 whitespace-nowrap rounded border-0 bg-transparent px-1 text-[11px] font-medium text-base-content/60 transition-colors hover:bg-error/10 hover:!text-error"
 							>
 								{t.labels.remove()}
 							</button>
@@ -114,7 +114,7 @@
 					<span
 						slot="badge"
 						data-testid="publisher-count-available"
-						class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600"
+						class="inline-flex items-center rounded-full bg-base-200 px-2 py-0.5 text-[10px] font-medium text-base-content/70"
 					>
 						{filteredAvailable.length}
 					</span>
@@ -135,7 +135,7 @@
 										confirmationPublisher = publisher.name;
 										confirmationDialogOpen.set(true);
 									}}
-									class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+									class="h-5 whitespace-nowrap rounded border border-base-content/50 bg-base-100 px-1 text-[11px] font-medium text-base-content transition-colors hover:bg-accent hover:text-accent-content"
 								>
 									{t.labels.reassign()}
 								</button>
@@ -145,7 +145,7 @@
 								<button
 									slot="action-button"
 									on:click={() => onAssignPublisher(publisher.name)}
-									class="hover:text-accent-foreground h-5 whitespace-nowrap rounded border border-gray-900 bg-white px-1 text-[11px] font-medium text-gray-900 hover:bg-[#00d3bb]"
+									class="h-5 whitespace-nowrap rounded border border-base-content/50 bg-base-100 px-1 text-[11px] font-medium text-base-content transition-colors hover:bg-accent hover:text-accent-content"
 								>
 									{t.labels.add()}
 								</button>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanelStoryHarness.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanelStoryHarness.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import SupplierPublishersPanel from "./SupplierPublishersPanel.svelte";
+
+	type AvailablePublisher = {
+		name: string;
+		supplierName?: string;
+	};
+
+	export let supplierName: string;
+	export let assignedPublishers: string[];
+	export let availablePublishers: AvailablePublisher[];
+
+	let localAssignedPublishers: string[] = [];
+	let localAvailablePublishers: AvailablePublisher[] = [];
+
+	$: localAssignedPublishers = [...assignedPublishers];
+	$: localAvailablePublishers = availablePublishers.map((publisher) => ({ ...publisher }));
+
+	const sortPublishers = (publishers: string[]) => [...publishers].sort((left, right) => left.localeCompare(right));
+
+	const sortAvailablePublishers = (publishers: AvailablePublisher[]) =>
+		[...publishers].sort((left, right) => left.name.localeCompare(right.name));
+
+	const handleAssignPublisher = (publisherName: string) => {
+		const publisher = localAvailablePublishers.find((entry) => entry.name === publisherName);
+		if (!publisher) return;
+
+		localAvailablePublishers = sortAvailablePublishers(localAvailablePublishers.filter((entry) => entry.name !== publisherName));
+		localAssignedPublishers = sortPublishers([...localAssignedPublishers, publisherName]);
+	};
+
+	const handleUnassignPublisher = (publisherName: string) => {
+		localAssignedPublishers = localAssignedPublishers.filter((entry) => entry !== publisherName);
+		localAvailablePublishers = sortAvailablePublishers([
+			...localAvailablePublishers,
+			{
+				name: publisherName
+			}
+		]);
+	};
+</script>
+
+<SupplierPublishersPanel
+	{supplierName}
+	assignedPublishers={localAssignedPublishers}
+	availablePublishers={localAvailablePublishers}
+	onAssignPublisher={handleAssignPublisher}
+	onUnassignPublisher={handleUnassignPublisher}
+/>

--- a/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanelStoryHarness.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/[id]/SupplierPublishersPanelStoryHarness.svelte
@@ -13,8 +13,18 @@
 	let localAssignedPublishers: string[] = [];
 	let localAvailablePublishers: AvailablePublisher[] = [];
 
-	$: localAssignedPublishers = [...assignedPublishers];
-	$: localAvailablePublishers = availablePublishers.map((publisher) => ({ ...publisher }));
+	let previousAssignedPublishers: string[] | undefined;
+	let previousAvailablePublishers: AvailablePublisher[] | undefined;
+
+	const cloneAvailablePublishers = (publishers: AvailablePublisher[]) => publishers.map((publisher) => ({ ...publisher }));
+
+	// Reset the local harness state only when Storybook args change.
+	$: if (assignedPublishers !== previousAssignedPublishers || availablePublishers !== previousAvailablePublishers) {
+		previousAssignedPublishers = assignedPublishers;
+		previousAvailablePublishers = availablePublishers;
+		localAssignedPublishers = [...assignedPublishers];
+		localAvailablePublishers = cloneAvailablePublishers(availablePublishers);
+	}
 
 	const sortPublishers = (publishers: string[]) => [...publishers].sort((left, right) => left.localeCompare(right));
 

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/ReconcileStep1.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/ReconcileStep1.svelte
@@ -36,8 +36,8 @@
 	}
 </script>
 
-<div class="flex flex-1 flex-col overflow-hidden">
-	<div class="shrink-0 border-b border-neutral-200 bg-white">
+<div class="flex flex-1 flex-col overflow-hidden bg-base-100 text-base-content">
+	<div class="shrink-0 border-b border-base-300 bg-base-100">
 		<div class="px-6 py-4">
 			<div class="space-y-4">
 				<DaisyUIScannerForm onSubmit={onScan} />
@@ -45,7 +45,7 @@
 		</div>
 	</div>
 
-	<div class="flex h-full flex-col space-y-4 overflow-hidden bg-white px-6 py-4">
+	<div class="flex h-full flex-col space-y-4 overflow-hidden bg-base-100 px-6 py-4">
 		<div class="flex gap-3">
 			<CounterBadge label={t.step1.stats.total_ordered()} value={totalOrdered} />
 			<CounterBadge label={t.step1.stats.total_delivered()} value={totalDelivered} />
@@ -55,7 +55,7 @@
 			{#each orderStats as supplierOrder (supplierOrder.supplier_order_id)}
 				<div class="mb-4">
 					<div class="-mb-6">
-						<span class="text-foreground rounded-md bg-[#f8f8f8] px-2 py-0.5 text-xs font-medium">
+						<span class="text-foreground rounded-md bg-base-200 px-2 py-0.5 text-xs font-medium">
 							{supplierOrder.supplier_name} # {supplierOrder.supplier_order_id}
 						</span>
 					</div>
@@ -82,7 +82,7 @@
 								{@const deliveredColor = getDeliveredColorClass(stats.ordered, stats.delivered)}
 								<TableRow
 									variant="naked"
-									className="hover:bg-neutral-50 transition-all duration-[120ms] {isLastBook ? '' : 'border-b border-neutral-100'}"
+									className="transition-all duration-[120ms] hover:bg-base-200/60 {isLastBook ? '' : 'border-b border-base-300/70'}"
 								>
 									<td class="text-foreground w-32 min-w-0 shrink-0 px-2 py-1.5 align-middle text-sm font-medium">
 										{book.isbn}
@@ -104,14 +104,14 @@
 											<button
 												on:click={() => onDecrement(book.isbn)}
 												disabled={stats.delivered === 0}
-												class="flex h-6 w-6 items-center justify-center rounded border border-neutral-200 transition-colors hover:bg-neutral-200 disabled:cursor-not-allowed disabled:opacity-50"
+												class="flex h-6 w-6 items-center justify-center rounded border border-base-300 bg-base-100 text-base-content transition-colors hover:bg-base-200 disabled:cursor-not-allowed disabled:opacity-50"
 												aria-label={t.step1.aria_labels.decrease_quantity({ title: book.title, count: stats.delivered })}
 											>
 												−
 											</button>
 											<button
 												on:click={() => onIncrement(book.isbn)}
-												class="flex h-6 w-6 items-center justify-center rounded border border-neutral-200 transition-colors hover:bg-neutral-200"
+												class="flex h-6 w-6 items-center justify-center rounded border border-base-300 bg-base-100 text-base-content transition-colors hover:bg-base-200"
 												aria-label={t.step1.aria_labels.increase_quantity({ title: book.title, count: stats.delivered })}
 											>
 												+
@@ -128,14 +128,14 @@
 	</div>
 
 	{#if totalDelivered > 0}
-		<div class="shrink-0 border-t border-neutral-200 bg-neutral-50 px-6 py-4">
+		<div class="shrink-0 border-t border-base-300 bg-base-200/40 px-6 py-4">
 			<div class="flex items-center justify-between">
-				<div class="text-sm text-zinc-900">
+				<div class="text-sm text-base-content">
 					{t.step1.footer.total_scanned({ count: totalDelivered })}
 				</div>
 				<button
 					on:click={onContinue}
-					class="flex items-center gap-2 rounded-md bg-zinc-900 px-6 py-2 text-white transition-colors hover:bg-zinc-800"
+					class="flex items-center gap-2 rounded-md bg-neutral px-6 py-2 text-neutral-content transition-colors hover:bg-neutral/80"
 				>
 					{t.step1.footer.continue()}
 					<ArrowRight aria-hidden />

--- a/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/ReconcileStep2.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/reconcile/[id]/ReconcileStep2.svelte
@@ -30,13 +30,13 @@
 	$: t = $LL.reconcile_page.step2;
 </script>
 
-<div class="flex h-screen max-h-full flex-1 flex-col overflow-hidden">
+<div class="flex h-screen max-h-full flex-1 flex-col overflow-hidden bg-base-100 text-base-content">
 	<div class="mt-6 mb-6 flex gap-3 px-6">
 		<CounterBadge label={t.stats.total_ordered()} value={totalOrdered} />
 		<CounterBadge label={t.stats.total_delivered()} value={totalDelivered} />
 	</div>
 
-	<div class="flex flex-1 flex-col overflow-y-auto bg-white px-6 pb-6">
+	<div class="flex flex-1 flex-col overflow-y-auto bg-base-100 px-6 pb-6">
 		<div class="mb-4 space-y-4">
 			{#each orderStats as { supplier_order_id, supplier_name, underdelivery_policy, totalUnderdelivered, lines }}
 				{@const underdeliveryAction = underdelivery_policy === 0 ? "pending" : "queue"}
@@ -61,17 +61,17 @@
 	</div>
 
 	{#if !finalized}
-		<div class="shrink-0 border-t border-neutral-200 bg-neutral-50">
+		<div class="shrink-0 border-t border-base-300 bg-base-200/40">
 			<div class="flex items-center justify-between px-6 py-4">
 				<button
 					on:click={onBack}
-					class="rounded-md border border-neutral-200 bg-white px-6 py-2 text-zinc-900 transition-colors hover:bg-neutral-50"
+					class="rounded-md border border-base-300 bg-base-100 px-6 py-2 text-base-content transition-colors hover:bg-base-200"
 				>
 					{t.actions.back()}
 				</button>
 				<button
 					disabled={finalized || disableFinalize}
-					class="rounded-md bg-zinc-900 px-6 py-2 text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-zinc-900"
+					class="rounded-md bg-neutral px-6 py-2 text-neutral-content transition-colors hover:bg-neutral/80 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-neutral"
 					on:click={onFinalize}
 				>
 					{t.actions.finalize()}
@@ -79,8 +79,8 @@
 			</div>
 		</div>
 	{:else}
-		<div class="flex shrink-0 items-center justify-between border-t border-neutral-200 bg-neutral-50 px-6 py-4">
-			<div class="text-sm text-zinc-900">{t.finalized.message({ date: new Date(data?.reconciliationOrder.updatedAt) })}</div>
+		<div class="flex shrink-0 items-center justify-between border-t border-base-300 bg-base-200/40 px-6 py-4">
+			<div class="text-sm text-base-content">{t.finalized.message({ date: new Date(data?.reconciliationOrder.updatedAt) })}</div>
 		</div>
 	{/if}
 </div>

--- a/apps/web-client/svelte.config.js
+++ b/apps/web-client/svelte.config.js
@@ -115,7 +115,8 @@ const config = {
 				compilerOptions: {
 					...config.compilerOptions,
 					resolveJsonModule: true,
-					allowSyntheticDefaultImports: true
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: true
 				}
 			})
 		}

--- a/apps/web-client/tsconfig.json
+++ b/apps/web-client/tsconfig.json
@@ -4,5 +4,30 @@
 		"types": ["svelte", "@sveltejs/kit", "@vitest/browser/matchers"],
 		"skipLibCheck": true,
 		"verbatimModuleSyntax": true
-	}
+	},
+	"include": [
+		".svelte-kit/ambient.d.ts",
+		".svelte-kit/non-ambient.d.ts",
+		".svelte-kit/types/**/$types.d.ts",
+		"vite.config.js",
+		"vite.config.ts",
+		"vitest.config.ts",
+		"vitest.projects.ts",
+		"vitest.shared.ts",
+		"src/**/*.js",
+		"src/**/*.ts",
+		"src/**/*.svelte",
+		"tests/**/*.js",
+		"tests/**/*.ts",
+		"tests/**/*.svelte"
+	],
+	"exclude": [
+		"node_modules/**",
+		"src/service-worker.js",
+		"src/service-worker/**/*.js",
+		"src/service-worker.ts",
+		"src/service-worker/**/*.ts",
+		"src/service-worker.d.ts",
+		"src/service-worker/**/*.d.ts"
+	]
 }

--- a/apps/web-client/tsconfig.json
+++ b/apps/web-client/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
 		"types": ["svelte", "@sveltejs/kit", "@vitest/browser/matchers"],
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"verbatimModuleSyntax": true
 	}
 }

--- a/apps/web-client/vitest.config.ts
+++ b/apps/web-client/vitest.config.ts
@@ -1,105 +1,15 @@
-import path from "path";
-import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig, mergeConfig } from "vitest/config";
 
-import { defineConfig } from "vitest/config";
+import { browserBackedTests, createSharedVitestConfig } from "./vitest.shared";
 
-import { USE_SUBMODULES } from "./build_constants";
-
-/**
- * A helper used to provide aliases for vlcn.io packages in dev mode:
- * - if in local test mode, we're aliasing vlcn.io imports to submoduled packages (under '3rd-party/js')
- * - if in CI, no aliases are provided: installed dependencies built from tarballs ('3rd-party/artefacts') are used
- */
-function alias_vlcn_dev() {
-	console.log("\n");
-
-	if (!USE_SUBMODULES) {
-		console.log("testing using vlcn.io packages installed from '3rd-party/artefacts'");
-		console.log("\n");
-		return {};
-	}
-
-	const aliases = {
-		"@vlcn.io/crsqlite": path.resolve(__dirname, "../../3rd-party/js/deps/cr-sqlite/core/nodejs-helper.js"),
-		"@vlcn.io/crsqlite-wasm": path.resolve(__dirname, "../../3rd-party/js/packages/crsqlite-wasm/dist"),
-		"@vlcn.io/rx-tbl": path.resolve(__dirname, "../../3rd-party/js/packages/rx-tbl/dist"),
-		"@vlcn.io/wa-sqlite": path.resolve(__dirname, "../../3rd-party/js/deps/wa-sqlite"),
-		"@vlcn.io/ws-browserdb": path.resolve(__dirname, "../../3rd-party/js/packages/ws-browserdb/dist"),
-		"@vlcn.io/ws-client/worker.js": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist/worker/worker.js"),
-		"@vlcn.io/ws-client": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist"),
-		"@vlcn.io/ws-common": path.resolve(__dirname, "../../3rd-party/js/packages/ws-common/dist"),
-		"@vlcn.io/ws-server": path.resolve(__dirname, "../../3rd-party/js/packages/ws-server/dist"),
-		"@vlcn.io/xplat-api": path.resolve(__dirname, "../../3rd-party/js/packages/xplat-api/dist/xplat-api.js")
-	};
-
-	console.log("submodule test: aliasing vlcn.io packages to respective submodules:");
-	for (const [pkg, path] of Object.entries(aliases)) {
-		console.log(`  ${pkg} -> ${path}`);
-	}
-	console.log("\n");
-
-	return aliases;
-}
-
-export default defineConfig({
-	plugins: [svelte({ hot: !process.env.VITEST })],
-	publicDir: "static",
-
-	resolve: {
-		alias: {
-			$lib: path.resolve(__dirname, "src/lib"),
-
-			// (conditionally) alias the vlcn-io submodules
-			...alias_vlcn_dev(),
-
-			// some mocks used to not break the tests while testing components using them
-			$lucide: path.resolve(__dirname, "node_modules/lucide-svelte/dist/icons"),
-
-			// sveltekit module mocks for test environment
-			//
-			// NOTE: these defaults shouldn't be terribly relevant for testing usage,
-			// but do check them out in case some tested functionality DOES depend on correct values
-			"$app/paths": path.resolve(__dirname, "src/__mocks__/$app-paths.ts"),
-			"$app/navigation": path.resolve(__dirname, "src/__mocks__/$app-navigation.ts"),
-			"$app/stores": path.resolve(__dirname, "src/__mocks__/$app-stores.ts"),
-			"$app/environment": path.resolve(__dirname, "src/__mocks__/$app-environment.ts"),
-			"$app/forms": path.resolve(__dirname, "src/__mocks__/$app-forms.ts"),
-			"$env/static/public": path.resolve(__dirname, "src/__mocks__/$env-static-public.ts"),
-			"$env/dynamic/public": path.resolve(__dirname, "src/__mocks__/$env-dynamic-public.ts")
+export default mergeConfig(
+	createSharedVitestConfig(),
+	defineConfig({
+		test: {
+			name: "unit",
+			environment: "jsdom",
+			include: ["src/**/*.{test,spec}.{js,ts}"],
+			exclude: ["src/**/*.stories.@(js|jsx|ts|tsx|svelte)", ...browserBackedTests]
 		}
-	},
-
-	optimizeDeps: {
-		exclude: ["sveltekit-superforms"],
-		esbuildOptions: {
-			alias: {
-				"$app/paths": path.resolve(__dirname, "src/__mocks__/$app-paths.ts"),
-				"$app/navigation": path.resolve(__dirname, "src/__mocks__/$app-navigation.ts"),
-				"$app/stores": path.resolve(__dirname, "src/__mocks__/$app-stores.ts"),
-				"$app/environment": path.resolve(__dirname, "src/__mocks__/$app-environment.ts"),
-				"$app/forms": path.resolve(__dirname, "src/__mocks__/$app-forms.ts"),
-				"$env/static/public": path.resolve(__dirname, "src/__mocks__/$env-static-public.ts"),
-				"$env/dynamic/public": path.resolve(__dirname, "src/__mocks__/$env-dynamic-public.ts")
-			}
-		}
-	},
-
-	test: {
-		include: ["src/**/*.{test,spec}.{js,ts}"],
-		browser: {
-			enabled: true,
-			provider: "playwright",
-			instances: [{ browser: "chromium" }]
-		}
-	},
-
-	server: {
-		hmr: {
-			// Force the HMR websocket to use the same protocol as the page
-			protocol: "ws",
-			// Use the browser's location for the HMR websocket
-			host: "localhost",
-			port: 5173
-		}
-	}
-});
+	})
+);

--- a/apps/web-client/vitest.projects.ts
+++ b/apps/web-client/vitest.projects.ts
@@ -9,6 +9,7 @@ export default defineWorkspace([
 		defineConfig({
 			test: {
 				name: "browser-backed",
+				// These specs need a real browser runtime rather than Node-only Vitest.
 				include: browserBackedTests,
 				browser: {
 					enabled: true,

--- a/apps/web-client/vitest.projects.ts
+++ b/apps/web-client/vitest.projects.ts
@@ -1,0 +1,22 @@
+import { defineConfig, defineWorkspace, mergeConfig } from "vitest/config";
+
+import { browserBackedTests, createSharedVitestConfig } from "./vitest.shared";
+
+export default defineWorkspace([
+	"./vitest.config.ts",
+	mergeConfig(
+		createSharedVitestConfig(),
+		defineConfig({
+			test: {
+				name: "browser-backed",
+				include: browserBackedTests,
+				browser: {
+					enabled: true,
+					provider: "playwright",
+					headless: true,
+					instances: [{ browser: "chromium" }]
+				}
+			}
+		})
+	)
+]);

--- a/apps/web-client/vitest.shared.ts
+++ b/apps/web-client/vitest.shared.ts
@@ -1,0 +1,117 @@
+import path from "path";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+import { defineConfig } from "vitest/config";
+
+import { USE_SUBMODULES } from "./build_constants";
+
+/**
+ * A helper used to provide aliases for vlcn.io packages in dev mode:
+ * - if in local test mode, we're aliasing vlcn.io packages to submoduled packages (under '3rd-party/js')
+ * - if in CI, no aliases are provided: installed dependencies built from tarballs ('3rd-party/artefacts') are used
+ */
+function alias_vlcn_dev() {
+	console.log("\n");
+
+	if (!USE_SUBMODULES) {
+		console.log("testing using vlcn.io packages installed from '3rd-party/artefacts'");
+		console.log("\n");
+		return {};
+	}
+
+	const aliases = {
+		"@vlcn.io/crsqlite": path.resolve(__dirname, "../../3rd-party/js/deps/cr-sqlite/core/nodejs-helper.js"),
+		"@vlcn.io/crsqlite-wasm": path.resolve(__dirname, "../../3rd-party/js/packages/crsqlite-wasm/dist"),
+		"@vlcn.io/rx-tbl": path.resolve(__dirname, "../../3rd-party/js/packages/rx-tbl/dist"),
+		"@vlcn.io/wa-sqlite": path.resolve(__dirname, "../../3rd-party/js/deps/wa-sqlite"),
+		"@vlcn.io/ws-browserdb": path.resolve(__dirname, "../../3rd-party/js/packages/ws-browserdb/dist"),
+		"@vlcn.io/ws-client/worker.js": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist/worker/worker.js"),
+		"@vlcn.io/ws-client": path.resolve(__dirname, "../../3rd-party/js/packages/ws-client/dist"),
+		"@vlcn.io/ws-common": path.resolve(__dirname, "../../3rd-party/js/packages/ws-common/dist"),
+		"@vlcn.io/ws-server": path.resolve(__dirname, "../../3rd-party/js/packages/ws-server/dist"),
+		"@vlcn.io/xplat-api": path.resolve(__dirname, "../../3rd-party/js/packages/xplat-api/dist/xplat-api.js")
+	};
+
+	console.log("submodule test: aliasing vlcn.io packages to respective submodules:");
+	for (const [pkg, path] of Object.entries(aliases)) {
+		console.log(`  ${pkg} -> ${path}`);
+	}
+	console.log("\n");
+
+	return aliases;
+}
+
+export const browserBackedTests = [
+	"src/lib/db/cr-sqlite/__tests__/book.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/customer-orders.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/db.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/history.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/note.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/reconciliation-order.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/stock.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/supplier-order.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/suppliers-publishers.test.ts",
+	"src/lib/db/cr-sqlite/__tests__/warehouse.test.ts",
+	"src/lib/actions/__tests__/table.spec.ts",
+	"src/lib/components/TextEditable/__tests__/TextEditable.spec.ts",
+	"src/lib/forms/controls/tests/FormField.spec.ts"
+];
+
+export function createSharedVitestConfig() {
+	return defineConfig({
+		plugins: [svelte({ hot: !process.env.VITEST })],
+		publicDir: "static",
+
+		resolve: {
+			alias: {
+				$lib: path.resolve(__dirname, "src/lib"),
+
+				// (conditionally) alias the vlcn-io submodules
+				...alias_vlcn_dev(),
+
+				// some mocks used to not break the tests while testing components using them
+				$lucide: path.resolve(__dirname, "node_modules/lucide-svelte/dist/icons"),
+
+				// sveltekit module mocks for test environment
+				//
+				// NOTE: these defaults shouldn't be terribly relevant for testing usage,
+				// but do check them out in case some tested functionality DOES depend on correct values
+				"$app/paths": path.resolve(__dirname, "src/__mocks__/$app-paths.ts"),
+				"$app/navigation": path.resolve(__dirname, "src/__mocks__/$app-navigation.ts"),
+				"$app/stores": path.resolve(__dirname, "src/__mocks__/$app-stores.ts"),
+				"$app/environment": path.resolve(__dirname, "src/__mocks__/$app-environment.ts"),
+				"$app/forms": path.resolve(__dirname, "src/__mocks__/$app-forms.ts"),
+				"$env/static/public": path.resolve(__dirname, "src/__mocks__/$env-static-public.ts"),
+				"$env/dynamic/public": path.resolve(__dirname, "src/__mocks__/$env-dynamic-public.ts")
+			}
+		},
+
+		optimizeDeps: {
+			exclude: ["sveltekit-superforms"],
+			esbuildOptions: {
+				alias: {
+					"$app/paths": path.resolve(__dirname, "src/__mocks__/$app-paths.ts"),
+					"$app/navigation": path.resolve(__dirname, "src/__mocks__/$app-navigation.ts"),
+					"$app/stores": path.resolve(__dirname, "src/__mocks__/$app-stores.ts"),
+					"$app/environment": path.resolve(__dirname, "src/__mocks__/$app-environment.ts"),
+					"$app/forms": path.resolve(__dirname, "src/__mocks__/$app-forms.ts"),
+					"$env/static/public": path.resolve(__dirname, "src/__mocks__/$env-static-public.ts"),
+					"$env/dynamic/public": path.resolve(__dirname, "src/__mocks__/$env-dynamic-public.ts")
+				}
+			}
+		},
+
+		server: {
+			fs: {
+				allow: [path.resolve(__dirname), path.resolve(__dirname, "../../common/temp")]
+			},
+			hmr: {
+				// Force the HMR websocket to use the same protocol as the page
+				protocol: "ws",
+				// Use the browser's location for the HMR websocket
+				host: "localhost",
+				port: 5173
+			}
+		}
+	});
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@storybook/sveltekit':
         specifier: ~9.1.19
         version: 9.1.19(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.37.3)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(prettier@3.4.2)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))(svelte@5.37.3)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4))
+      '@storybook/test-runner':
+        specifier: 0.23.0
+        version: 0.23.0(@swc/helpers@0.5.18)(@types/node@20.4.10)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(prettier@3.4.2)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
         version: 3.0.10(@sveltejs/kit@2.50.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.37.3)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))(svelte@5.37.3)(typescript@5.9.3)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))
@@ -264,6 +267,9 @@ importers:
       eslint-plugin-unused-imports:
         specifier: ^4.1.4
         version: 4.3.0(@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       playwright:
         specifier: ~1.50.0
         version: 1.50.1
@@ -321,6 +327,9 @@ importers:
       vitest:
         specifier: 3.0.9
         version: 3.0.9(@types/node@20.4.10)(@vitest/browser@3.0.9)(@vitest/ui@3.0.9)(jsdom@26.0.0)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(tsx@4.19.4)
+      wait-on:
+        specifier: 9.0.4
+        version: 9.0.4
       workbox-window:
         specifier: ~6.5.4
         version: 6.5.4
@@ -566,6 +575,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -592,6 +605,97 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-syntax-async-generators@7.8.4':
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-bigint@7.8.3':
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-properties@7.12.13':
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-class-static-block@7.14.5':
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-json-strings@7.8.3':
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3':
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4':
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3':
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3':
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3':
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5':
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-top-level-await@7.14.5':
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
@@ -607,6 +711,9 @@ packages:
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -983,11 +1090,31 @@ packages:
     resolution: {integrity: sha512-3xGptCurm23e7nuPQkdrE5rEs1FeTPHhAUsBuwwqG4/YeZLwJOoYZv+fmsppUEfo5y9lzUwNQrNqLS/q7HMc7g==}
     hasBin: true
 
+  '@hapi/address@5.1.1':
+    resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
+    engines: {node: '>=14.0.0'}
+
+  '@hapi/formula@3.0.2':
+    resolution: {integrity: sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==}
+
+  '@hapi/hoek@11.0.7':
+    resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
+  '@hapi/pinpoint@2.0.1':
+    resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
+
+  '@hapi/tlds@1.1.6':
+    resolution: {integrity: sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==}
+    engines: {node: '>=14.0.0'}
+
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hapi/topo@6.0.2':
+    resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -1039,6 +1166,96 @@ packages:
 
   '@internationalized/date@3.7.0':
     resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
+    engines: {node: '>=8'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/create-cache-key-function@30.2.0':
+    resolution: {integrity: sha512-44F4l4Enf+MirJN8X/NhdGkl71k5rBYiwdVlo4HxOwbu0sHV8QKrGEedb1VUU4K3W7fBKE0HGfbn7eZm0Ti3zg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/environment@29.7.0':
+    resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/fake-timers@29.7.0':
+    resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/pattern@30.0.1':
+    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/transform@29.7.0':
+    resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@30.2.0':
+    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1558,8 +1775,17 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
   '@sinclair/typebox@0.34.47':
     resolution: {integrity: sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==}
+
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@10.3.0':
+    resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
@@ -1629,6 +1855,13 @@ packages:
       svelte: ^5.0.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@storybook/test-runner@0.23.0':
+    resolution: {integrity: sha512-AVA6mSotfHAqsKjvWMNR7wcXIoCNQidU9P5GIGEdn+gArzkzTsLXZr6qNjH4XQRg8pSR+IUOuB1MMWZIHxhgoQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      storybook: ^0.0.0-0 || ^8.2.0 || ^9.0.0 || ^9.1.0-0
+
   '@sveltejs/acorn-typescript@1.0.8':
     resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
@@ -1670,8 +1903,89 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
 
+  '@swc/core-darwin-arm64@1.15.18':
+    resolution: {integrity: sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.18':
+    resolution: {integrity: sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.18':
+    resolution: {integrity: sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.18':
+    resolution: {integrity: sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.18':
+    resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.18':
+    resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.18':
+    resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.18':
+    resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.18':
+    resolution: {integrity: sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.18':
+    resolution: {integrity: sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.18':
+    resolution: {integrity: sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.25':
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
   '@tailwindcss/typography@0.5.19':
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
@@ -1714,6 +2028,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -1753,11 +2079,23 @@ packages:
   '@types/filewriter@0.0.33':
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
 
+  '@types/graceful-fs@4.1.9':
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1792,6 +2130,9 @@ packages:
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
 
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
@@ -1813,6 +2154,15 @@ packages:
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
+  '@types/wait-on@5.3.4':
+    resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typeschema/class-validator@0.3.0':
     resolution: {integrity: sha512-OJSFeZDIQ8EK1HTljKLT5CItM2wsbgczLN8tMEfz3I1Lmhc5TBfkZ0eikFzUC16tI3d1Nag7um6TfCgp2I2Bww==}
@@ -2050,12 +2400,32 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2069,8 +2439,18 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-transform@2.0.0:
+    resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
+    engines: {node: '>=8'}
+
+  archy@1.0.0:
+    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2146,9 +2526,37 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  babel-jest@29.7.0:
+    resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.8.0
+
+  babel-plugin-istanbul@6.1.1:
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+
+  babel-plugin-jest-hoist@29.6.3:
+    resolution: {integrity: sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0 || ^8.0.0-0
+
+  babel-preset-jest@29.6.3:
+    resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2159,6 +2567,10 @@ packages:
   baseline-browser-mapping@2.9.15:
     resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
+
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -2200,6 +2612,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2212,6 +2627,10 @@ packages:
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caching-transform@4.0.0:
+    resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -2234,6 +2653,14 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -2245,9 +2672,25 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  char-regex@2.0.2:
+    resolution: {integrity: sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==}
+    engines: {node: '>=12.20'}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -2264,15 +2707,26 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   class-validator@0.14.3:
     resolution: {integrity: sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==}
 
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2282,6 +2736,16 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2289,6 +2753,9 @@ packages:
   color-convert@3.1.3:
     resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
     engines: {node: '>=14.6'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2312,6 +2779,16 @@ packages:
   comlink@4.4.2:
     resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  commander@3.0.2:
+    resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2327,6 +2804,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2350,6 +2830,15 @@ packages:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
+  corser@2.0.1:
+    resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
+    engines: {node: '>= 0.4.0'}
+
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2372,6 +2861,10 @@ packages:
   culori@3.3.0:
     resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cwd@0.10.0:
+    resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
+    engines: {node: '>=0.8'}
 
   daisyui@4.12.24:
     resolution: {integrity: sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==}
@@ -2411,6 +2904,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -2443,6 +2940,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  default-require-extensions@3.0.1:
+    resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
+    engines: {node: '>=8'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2479,6 +2980,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
   detective@5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
@@ -2489,6 +2994,13 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diffable-html@4.1.0:
+    resolution: {integrity: sha512-++kyNek+YBLH8cLXS+iTj/Hiy2s5qkRJEJ8kgu/WHbFrVY2vz9xPFUT+fii2zGF0m1CaojDlQJjkfrCt7YWM1g==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2507,6 +3019,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@0.2.2:
+    resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
+
+  domelementtype@1.3.1:
+    resolution: {integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@2.4.2:
+    resolution: {integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==}
+
+  domutils@1.7.0:
+    resolution: {integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -2524,6 +3051,10 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2537,9 +3068,18 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@1.1.2:
+    resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2575,6 +3115,9 @@ packages:
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -2602,6 +3145,14 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2731,13 +3282,36 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expand-tilde@1.2.2:
+    resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
+    engines: {node: '>=0.10.0'}
+
+  expect-playwright@0.8.0:
+    resolution: {integrity: sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==}
+    deprecated: ⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   export-to-csv@1.3.0:
     resolution: {integrity: sha512-msPjbfozZdYzDghAEKmCVH5veMeKHNacplE6noXvGiA8AeV1qa/SOxp6JXDjF9R8Kf6v3ypI6jskiY19dkhZeA==}
@@ -2770,6 +3344,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2800,6 +3377,26 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
+  find-file-up@0.1.3:
+    resolution: {integrity: sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==}
+    engines: {node: '>=0.10.0'}
+
+  find-pkg@0.1.2:
+    resolution: {integrity: sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==}
+    engines: {node: '>=0.10.0'}
+
+  find-process@1.4.11:
+    resolution: {integrity: sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==}
+    hasBin: true
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2817,9 +3414,22 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@2.0.0:
+    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
+    engines: {node: '>=8.0.0'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -2839,8 +3449,15 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fromentries@1.3.2:
+    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-exists-sync@0.1.0:
+    resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
+    engines: {node: '>=0.10.0'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2881,9 +3498,17 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -2911,6 +3536,14 @@ packages:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  global-modules@0.2.3:
+    resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
+    engines: {node: '>=0.10.0'}
+
+  global-prefix@0.1.5:
+    resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
+    engines: {node: '>=0.10.0'}
+
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
@@ -2929,6 +3562,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -2939,6 +3575,10 @@ packages:
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2963,16 +3603,38 @@ packages:
     resolution: {integrity: sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==}
     engines: {node: '>= 0.4.0'}
 
+  hasha@5.2.2:
+    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
+    engines: {node: '>=8'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
+
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  htmlparser2@3.10.1:
+    resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2982,6 +3644,15 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+
+  http-server@14.1.1:
+    resolution: {integrity: sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -2989,6 +3660,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3015,6 +3690,11 @@ packages:
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3045,6 +3725,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -3094,6 +3777,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
 
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -3160,6 +3847,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -3171,6 +3861,14 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-windows@0.2.0:
+    resolution: {integrity: sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==}
+    engines: {node: '>=0.10.0'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -3185,11 +3883,214 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-hook@3.0.0:
+    resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@4.0.3:
+    resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@5.2.1:
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-processinfo@2.0.3:
+    resolution: {integrity: sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-environment-node@29.7.0:
+    resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-haste-map@29.7.0:
+    resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-junit@16.0.0:
+    resolution: {integrity: sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==}
+    engines: {node: '>=10.12.0'}
+
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@29.7.0:
+    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-playwright-preset@4.0.0:
+    resolution: {integrity: sha512-+dGZ1X2KqtwXaabVjTGxy0a3VzYfvYsWaRcuO8vMhyclHSOpGSI1+5cmlqzzCwQ3+fv0EjkTc7I5aV9lo08dYw==}
+    deprecated: ⚠️ The 'jest-playwright-preset' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
+    peerDependencies:
+      jest: ^29.3.1
+      jest-circus: ^29.3.1
+      jest-environment-node: ^29.3.1
+      jest-runner: ^29.3.1
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
+  jest-process-manager@0.4.0:
+    resolution: {integrity: sha512-80Y6snDyb0p8GG83pDxGI/kQzwVTkCxc7ep5FPe/F6JYdvRDhwr6RzRmPSP7SEwuLhxo80lBS/NqOdUIbHIfhw==}
+    deprecated: ⚠️ The 'jest-process-manager' package is deprecated. Please migrate to Playwright's built-in test runner (@playwright/test) which now includes full Jest-style features and parallel testing. See https://playwright.dev/docs/intro for details.
+
+  jest-regex-util@29.6.3:
+    resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-regex-util@30.0.1:
+    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-serializer-html@7.1.0:
+    resolution: {integrity: sha512-xYL2qC7kmoYHJo8MYqJkzrl/Fdlx+fat4U1AqYg+kafqwcKPiMkOcjWHPKhueuNEgr+uemhGc+jqXYiwCyRyLA==}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-watch-typeahead@2.2.2:
+    resolution: {integrity: sha512-+QgOFW4o5Xlgd6jGS5X37i08tuuXNW8X0CV9WNFi+3n8ExCIP+E1melYhvYLjv5fE6D0yyzk74vsSO8I6GqtvQ==}
+    engines: {node: ^14.17.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: ^27.0.0 || ^28.0.0 || ^29.0.0
+
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   joi@17.13.3:
     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
+  joi@18.0.2:
+    resolution: {integrity: sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==}
+    engines: {node: '>= 20'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3212,6 +4113,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
@@ -3231,11 +4135,18 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   just-compare@2.3.0:
     resolution: {integrity: sha512-6shoR7HDT+fzfL3gBahx1jZG3hWLrhPAf+l7nCwahDdT9XDtosB9kIF0ZrzUp5QY8dJWfQVr5rnsPqsbvflDzg==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -3246,6 +4157,10 @@ packages:
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3263,12 +4178,22 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.flattendeep@4.4.0:
+    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3276,9 +4201,16 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3313,6 +4245,17 @@ packages:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3326,6 +4269,9 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3351,6 +4297,10 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -3384,6 +4334,11 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -3449,6 +4404,13 @@ packages:
       encoding:
         optional: true
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
+  node-preload@0.2.1:
+    resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
+    engines: {node: '>=8'}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -3460,8 +4422,17 @@ packages:
     resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
     engines: {node: '>=14.16'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  nyc@15.1.0:
+    resolution: {integrity: sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==}
+    engines: {node: '>=8.9'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3497,13 +4468,25 @@ packages:
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-homedir@1.0.2:
+    resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
+    engines: {node: '>=0.10.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -3512,17 +4495,45 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-map@3.0.0:
+    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-hash@4.0.0:
+    resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
+    engines: {node: '>=8'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -3589,6 +4600,14 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+
   playwright-core@1.50.1:
     resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
     engines: {node: '>=18'}
@@ -3598,6 +4617,10 @@ packages:
     resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  portfinder@1.0.38:
+    resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
+    engines: {node: '>= 10.12'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3761,9 +4784,21 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  process-on-spawn@1.1.0:
+    resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
+    engines: {node: '>=8'}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   property-expr@2.0.6:
     resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
@@ -3816,6 +4851,9 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3851,6 +4889,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  release-zalgo@1.0.0:
+    resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
+    engines: {node: '>=4'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3859,12 +4901,34 @@ packages:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
+  resolve-dir@0.1.1:
+    resolution: {integrity: sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -3905,6 +4969,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3933,6 +5000,9 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
+  secure-compare@3.0.1:
+    resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3949,6 +5019,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -4002,6 +5075,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4016,6 +5092,17 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   sorcery@1.0.0:
     resolution: {integrity: sha512-5ay9oJE+7sNmhzl3YNG18jEEEf4AOQCM/FAqR5wMmzqd1FtRorFbJXn3w3SKOhbiQaVgHM+Q1lszZspjri7bpA==}
     hasBin: true
@@ -4024,6 +5111,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -4031,8 +5121,22 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  spawn-wrap@2.0.0:
+    resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}
+    engines: {node: '>=8'}
+
+  spawnd@5.0.0:
+    resolution: {integrity: sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4060,6 +5164,14 @@ packages:
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-length@5.0.1:
+    resolution: {integrity: sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==}
+    engines: {node: '>=12.20'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4083,9 +5195,21 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -4102,6 +5226,10 @@ packages:
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
     engines: {node: '>=14.0.0'}
+
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4227,6 +5355,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
@@ -4285,6 +5417,9 @@ packages:
   tldts@7.0.19:
     resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4362,9 +5497,21 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
@@ -4394,6 +5541,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
   typesafe-i18n@5.26.2:
     resolution: {integrity: sha512-2QAriFmiY5JwUAJtG7yufoE/XZ1aFBY++wj7YFS2yo89a3jLBfKoWSdq5JfQYk1V2BS7V2c/u+KEcaCQoE65hw==}
     hasBin: true
@@ -4408,6 +5558,10 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  union@0.5.0:
+    resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
+    engines: {node: '>= 0.8.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -4432,12 +5586,23 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
 
   valibot@0.31.1:
     resolution: {integrity: sha512-2YYIhPrnVSz/gfT2/iXVTrSj92HwchCt9Cga/6hX4B26iCz9zkIsGTS0HjDYTZfTi1Un0X6aRvhBi1cfqs/i0Q==}
@@ -4543,6 +5708,24 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wait-on@7.2.0:
+    resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  wait-on@9.0.4:
+    resolution: {integrity: sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  wait-port@0.2.14:
+    resolution: {integrity: sha512-kIzjWcr6ykl7WFbZd0TMae8xovwqcqbx6FM9l+7agOgUByhzdjfzZBPK2CPufldTOMxbUivss//Sh9MFawmPRQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4559,6 +5742,11 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -4588,9 +5776,16 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4631,6 +5826,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  write-file-atomic@4.0.2:
+    resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -4647,12 +5849,18 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4665,9 +5873,17 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -4785,6 +6001,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -4803,6 +6021,91 @@ snapshots:
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.28.6
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.28.6': {}
 
@@ -4828,6 +6131,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -5056,13 +6361,27 @@ snapshots:
       esbuild-runner: 2.2.2(esbuild@0.24.2)
     optional: true
 
-  '@hapi/hoek@9.3.0':
-    optional: true
+  '@hapi/address@5.1.1':
+    dependencies:
+      '@hapi/hoek': 11.0.7
+
+  '@hapi/formula@3.0.2': {}
+
+  '@hapi/hoek@11.0.7': {}
+
+  '@hapi/hoek@9.3.0': {}
+
+  '@hapi/pinpoint@2.0.1': {}
+
+  '@hapi/tlds@1.1.6': {}
 
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
-    optional: true
+
+  '@hapi/topo@6.0.2':
+    dependencies:
+      '@hapi/hoek': 11.0.7
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -5107,6 +6426,201 @@ snapshots:
   '@internationalized/date@3.7.0':
     dependencies:
       '@swc/helpers': 0.5.18
+
+  '@istanbuljs/load-nyc-config@1.1.0':
+    dependencies:
+      camelcase: 5.3.1
+      find-up: 4.1.0
+      get-package-type: 0.1.0
+      js-yaml: 3.14.2
+      resolve-from: 5.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/core@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.4.10)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/create-cache-key-function@30.2.0':
+    dependencies:
+      '@jest/types': 30.2.0
+
+  '@jest/environment@29.7.0':
+    dependencies:
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      jest-mock: 29.7.0
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/fake-timers@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@sinonjs/fake-timers': 10.3.0
+      '@types/node': 20.4.10
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/pattern@30.0.1':
+    dependencies:
+      '@types/node': 20.4.10
+      jest-regex-util: 30.0.1
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.47
+
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
+
+  '@jest/transform@29.7.0':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      micromatch: 4.0.8
+      pirates: 4.0.7
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.4.10
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jest/types@30.2.0':
+    dependencies:
+      '@jest/pattern': 30.0.1
+      '@jest/schemas': 30.0.5
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 20.4.10
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5687,16 +7201,22 @@ snapshots:
   '@sideway/address@4.1.5':
     dependencies:
       '@hapi/hoek': 9.3.0
-    optional: true
 
-  '@sideway/formula@3.0.1':
-    optional: true
+  '@sideway/formula@3.0.1': {}
 
-  '@sideway/pinpoint@2.0.0':
-    optional: true
+  '@sideway/pinpoint@2.0.0': {}
 
-  '@sinclair/typebox@0.34.47':
-    optional: true
+  '@sinclair/typebox@0.27.10': {}
+
+  '@sinclair/typebox@0.34.47': {}
+
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@10.3.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
 
   '@so-ric/colorspace@1.1.6':
     dependencies:
@@ -5777,6 +7297,36 @@ snapshots:
     transitivePeerDependencies:
       - '@sveltejs/vite-plugin-svelte'
 
+  '@storybook/test-runner@0.23.0(@swc/helpers@0.5.18)(@types/node@20.4.10)(storybook@9.1.19(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(prettier@3.4.2)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4)))':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
+      '@jest/types': 29.6.3
+      '@swc/core': 1.15.18(@swc/helpers@0.5.18)
+      '@swc/jest': 0.2.39(@swc/core@1.15.18(@swc/helpers@0.5.18))
+      expect-playwright: 0.8.0
+      jest: 29.7.0(@types/node@20.4.10)
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-junit: 16.0.0
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@20.4.10))
+      jest-runner: 29.7.0
+      jest-serializer-html: 7.1.0
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@20.4.10))
+      nyc: 15.1.0
+      playwright: 1.50.1
+      storybook: 9.1.19(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@20.4.10)(typescript@5.9.3))(prettier@3.4.2)(vite@6.0.15(@types/node@20.4.10)(tsx@4.19.4))
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - '@types/node'
+      - babel-plugin-macros
+      - debug
+      - node-notifier
+      - supports-color
+      - ts-node
+
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
@@ -5829,9 +7379,69 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/core-darwin-arm64@1.15.18':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.18':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.18':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.18':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.18':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.18':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.18':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.18':
+    optional: true
+
+  '@swc/core@1.15.18(@swc/helpers@0.5.18)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.25
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.18
+      '@swc/core-darwin-x64': 1.15.18
+      '@swc/core-linux-arm-gnueabihf': 1.15.18
+      '@swc/core-linux-arm64-gnu': 1.15.18
+      '@swc/core-linux-arm64-musl': 1.15.18
+      '@swc/core-linux-x64-gnu': 1.15.18
+      '@swc/core-linux-x64-musl': 1.15.18
+      '@swc/core-win32-arm64-msvc': 1.15.18
+      '@swc/core-win32-ia32-msvc': 1.15.18
+      '@swc/core-win32-x64-msvc': 1.15.18
+      '@swc/helpers': 0.5.18
+
+  '@swc/counter@0.1.3': {}
+
   '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/jest@0.2.39(@swc/core@1.15.18(@swc/helpers@0.5.18))':
+    dependencies:
+      '@jest/create-cache-key-function': 30.2.0
+      '@swc/core': 1.15.18(@swc/helpers@0.5.18)
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.25':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tailwindcss/typography@0.5.19(tailwindcss@3.2.7)':
     dependencies:
@@ -5876,6 +7486,27 @@ snapshots:
       '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.6
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.6
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -5929,9 +7560,23 @@ snapshots:
 
   '@types/filewriter@0.0.33': {}
 
+  '@types/graceful-fs@4.1.9':
+    dependencies:
+      '@types/node': 20.4.10
+
   '@types/har-format@1.2.16': {}
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
 
   '@types/json-schema@7.0.15':
     optional: true
@@ -5969,6 +7614,8 @@ snapshots:
 
   '@types/shimmer@1.2.0': {}
 
+  '@types/stack-utils@2.0.3': {}
+
   '@types/statuses@2.0.6': {}
 
   '@types/tedious@4.0.14':
@@ -5987,6 +7634,16 @@ snapshots:
 
   '@types/validator@13.15.10':
     optional: true
+
+  '@types/wait-on@5.3.4':
+    dependencies:
+      '@types/node': 20.4.10
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typeschema/class-validator@0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.3)':
     dependencies:
@@ -6303,6 +7960,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6310,7 +7972,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
+  ansi-escapes@6.2.1: {}
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -6323,7 +7997,17 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  append-transform@2.0.0:
+    dependencies:
+      default-require-extensions: 3.0.1
+
+  archy@1.0.0: {}
+
   arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -6415,13 +8099,80 @@ snapshots:
 
   axe-core@4.11.1: {}
 
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
+
+  babel-jest@29.7.0(@babel/core@7.28.6):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.6)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-istanbul@6.1.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.28.6
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-jest-hoist@29.6.3:
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.6):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.6)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.6)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.6)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.6)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.6)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.6):
+    dependencies:
+      '@babel/core': 7.28.6
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.6)
 
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.15: {}
+
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   better-opn@3.0.2:
     dependencies:
@@ -6485,8 +8236,11 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  buffer-from@1.1.2:
-    optional: true
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -6496,6 +8250,13 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  caching-transform@4.0.0:
+    dependencies:
+      hasha: 5.2.2
+      make-dir: 3.1.0
+      package-hash: 4.0.0
+      write-file-atomic: 3.0.3
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6518,6 +8279,10 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
+  camelcase@5.3.1: {}
+
+  camelcase@6.3.0: {}
+
   camelcase@8.0.0:
     optional: true
 
@@ -6531,10 +8296,22 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  char-regex@2.0.2: {}
 
   check-error@2.1.3: {}
 
@@ -6556,6 +8333,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  ci-info@3.9.0: {}
+
   cjs-module-lexer@1.4.3: {}
 
   class-validator@0.14.3:
@@ -6565,7 +8344,15 @@ snapshots:
       validator: 13.15.26
     optional: true
 
+  clean-stack@2.2.0: {}
+
   cli-width@4.1.0: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -6575,6 +8362,14 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
+
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6582,6 +8377,8 @@ snapshots:
   color-convert@3.1.3:
     dependencies:
       color-name: 2.1.0
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -6602,6 +8399,12 @@ snapshots:
 
   comlink@4.4.2: {}
 
+  commander@12.1.0: {}
+
+  commander@3.0.2: {}
+
+  commondir@1.0.1: {}
+
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -6619,6 +8422,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@1.9.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
@@ -6633,6 +8438,23 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  corser@2.0.1: {}
+
+  create-jest@29.7.0(@types/node@20.4.10):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.4.10)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6655,6 +8477,11 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   culori@3.3.0: {}
+
+  cwd@0.10.0:
+    dependencies:
+      find-pkg: 0.1.2
+      fs-exists-sync: 0.1.0
 
   daisyui@4.12.24(postcss@8.4.49):
     dependencies:
@@ -6703,6 +8530,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
@@ -6720,6 +8549,10 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  default-require-extensions@3.0.1:
+    dependencies:
+      strip-bom: 4.0.0
 
   define-data-property@1.1.4:
     dependencies:
@@ -6747,6 +8580,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-newline@3.1.0: {}
+
   detective@5.2.1:
     dependencies:
       acorn-node: 1.8.2
@@ -6756,6 +8591,12 @@ snapshots:
   devalue@5.6.2: {}
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
+
+  diffable-html@4.1.0:
+    dependencies:
+      htmlparser2: 3.10.1
 
   dlv@1.1.3: {}
 
@@ -6770,6 +8611,24 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-serializer@0.2.2:
+    dependencies:
+      domelementtype: 2.3.0
+      entities: 2.2.0
+
+  domelementtype@1.3.1: {}
+
+  domelementtype@2.3.0: {}
+
+  domhandler@2.4.2:
+    dependencies:
+      domelementtype: 1.3.1
+
+  domutils@1.7.0:
+    dependencies:
+      dom-serializer: 0.2.2
+      domelementtype: 1.3.1
 
   dotenv@16.6.1: {}
 
@@ -6789,6 +8648,8 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
+  emittery@0.13.1: {}
+
   emoji-regex@8.0.0: {}
 
   enabled@2.0.0: {}
@@ -6799,7 +8660,15 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@1.1.2: {}
+
+  entities@2.2.0: {}
+
   entities@6.0.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.1:
     dependencies:
@@ -6887,6 +8756,8 @@ snapshots:
 
   es-toolkit@1.44.0: {}
 
+  es6-error@4.1.1: {}
+
   esbuild-register@3.6.0(esbuild@0.24.2):
     dependencies:
       debug: 4.4.3
@@ -6961,6 +8832,10 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7136,9 +9011,39 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@4.0.7: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  exit@0.1.2: {}
+
   expand-template@2.0.3: {}
 
+  expand-tilde@1.2.2:
+    dependencies:
+      os-homedir: 1.0.2
+
+  expect-playwright@0.8.0: {}
+
   expect-type@1.3.0: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
 
   export-to-csv@1.3.0: {}
 
@@ -7201,6 +9106,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -7229,6 +9138,32 @@ snapshots:
       statuses: 2.0.2
       unpipe: 1.0.0
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
+  find-file-up@0.1.3:
+    dependencies:
+      fs-exists-sync: 0.1.0
+      resolve-dir: 0.1.1
+
+  find-pkg@0.1.2:
+    dependencies:
+      find-file-up: 0.1.3
+
+  find-process@1.4.11:
+    dependencies:
+      chalk: 4.1.2
+      commander: 12.1.0
+      loglevel: 1.9.2
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -7248,9 +9183,16 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
+  follow-redirects@1.15.11: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@2.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 3.0.7
 
   form-data@4.0.5:
     dependencies:
@@ -7268,7 +9210,11 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fromentries@1.3.2: {}
+
   fs-constants@1.0.0: {}
+
+  fs-exists-sync@0.1.0: {}
 
   fs.realpath@1.0.0: {}
 
@@ -7310,10 +9256,14 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-package-type@0.1.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -7351,6 +9301,18 @@ snapshots:
       minipass: 4.2.8
       path-scurry: 1.11.1
 
+  global-modules@0.2.3:
+    dependencies:
+      global-prefix: 0.1.5
+      is-windows: 0.2.0
+
+  global-prefix@0.1.5:
+    dependencies:
+      homedir-polyfill: 1.0.3
+      ini: 1.3.8
+      is-windows: 0.2.0
+      which: 1.3.1
+
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
@@ -7366,11 +9328,15 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   graphemer@1.4.0: {}
 
   graphql@16.12.0: {}
 
   has-bigints@1.1.0: {}
+
+  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -7390,15 +9356,41 @@ snapshots:
 
   has@1.0.4: {}
 
+  hasha@5.2.2:
+    dependencies:
+      is-stream: 2.0.1
+      type-fest: 0.8.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   headers-polyfill@4.0.3: {}
+
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
+
+  html-encoding-sniffer@3.0.0:
+    dependencies:
+      whatwg-encoding: 2.0.0
 
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
+
+  html-escaper@2.0.2: {}
+
+  htmlparser2@3.10.1:
+    dependencies:
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   http-errors@2.0.1:
     dependencies:
@@ -7415,6 +9407,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.11
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+
+  http-server@14.1.1:
+    dependencies:
+      basic-auth: 2.0.1
+      chalk: 4.1.2
+      corser: 2.0.1
+      he: 1.2.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy: 1.18.1
+      mime: 1.6.0
+      minimist: 1.2.8
+      opener: 1.5.2
+      portfinder: 1.0.38
+      secure-compare: 3.0.1
+      union: 0.5.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -7428,6 +9447,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  human-signals@2.1.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -7455,6 +9476,11 @@ snapshots:
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -7481,6 +9507,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -7529,6 +9557,8 @@ snapshots:
       call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-fn@2.1.0: {}
 
   is-generator-function@1.1.2:
     dependencies:
@@ -7593,6 +9623,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-typedarray@1.0.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -7604,6 +9636,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-windows@0.2.0: {}
+
+  is-windows@1.0.2: {}
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
@@ -7614,6 +9650,433 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-hook@3.0.0:
+    dependencies:
+      append-transform: 2.0.0
+
+  istanbul-lib-instrument@4.0.3:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-instrument@5.2.1:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.28.6
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/parser': 7.28.6
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-processinfo@2.0.3:
+    dependencies:
+      archy: 1.0.0
+      cross-spawn: 7.0.6
+      istanbul-lib-coverage: 3.2.2
+      p-map: 3.0.0
+      rimraf: 3.0.2
+      uuid: 8.3.2
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.1
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@20.4.10):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.4.10)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.4.10)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@20.4.10):
+    dependencies:
+      '@babel/core': 7.28.6
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.4.10
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-node@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
+  jest-haste-map@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/graceful-fs': 4.1.9
+      '@types/node': 20.4.10
+      anymatch: 3.1.3
+      fb-watchman: 2.0.2
+      graceful-fs: 4.2.11
+      jest-regex-util: 29.6.3
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  jest-junit@16.0.0:
+    dependencies:
+      mkdirp: 1.0.4
+      strip-ansi: 6.0.1
+      uuid: 8.3.2
+      xml: 1.0.1
+
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-message-util@29.7.0:
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      '@jest/types': 29.6.3
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      jest-util: 29.7.0
+
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@20.4.10)):
+    dependencies:
+      expect-playwright: 0.8.0
+      jest: 29.7.0(@types/node@20.4.10)
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-process-manager: 0.4.0
+      jest-runner: 29.7.0
+      nyc: 15.1.0
+      playwright-core: 1.50.1
+      rimraf: 3.0.2
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
+  jest-process-manager@0.4.0:
+    dependencies:
+      '@types/wait-on': 5.3.4
+      chalk: 4.1.2
+      cwd: 0.10.0
+      exit: 0.1.2
+      find-process: 1.4.11
+      prompts: 2.4.2
+      signal-exit: 3.0.7
+      spawnd: 5.0.0
+      tree-kill: 1.2.2
+      wait-on: 7.2.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  jest-regex-util@29.6.3: {}
+
+  jest-regex-util@30.0.1: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.11
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-serializer-html@7.1.0:
+    dependencies:
+      diffable-html: 4.1.0
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.6)
+      '@babel/types': 7.28.6
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.6)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.1
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.4.10)):
+    dependencies:
+      ansi-escapes: 6.2.1
+      chalk: 5.6.2
+      jest: 29.7.0(@types/node@20.4.10)
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.2.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.4.10
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 20.4.10
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.4.10):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.4.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   joi@17.13.3:
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -7621,9 +10084,23 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
-    optional: true
+
+  joi@18.0.2:
+    dependencies:
+      '@hapi/address': 5.1.1
+      '@hapi/formula': 3.0.2
+      '@hapi/hoek': 11.0.7
+      '@hapi/pinpoint': 2.0.1
+      '@hapi/tlds': 1.1.6
+      '@hapi/topo': 6.0.2
+      '@standard-schema/spec': 1.1.0
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -7661,6 +10138,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.28.6
@@ -7677,17 +10156,23 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   just-compare@2.3.0: {}
 
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@3.0.3: {}
+
   kleur@4.1.5: {}
 
   known-css-properties@0.35.0: {}
 
   kuler@2.0.0: {}
+
+  leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -7703,15 +10188,25 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lines-and-columns@1.2.4: {}
+
   locate-character@3.0.0: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.flattendeep@4.4.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.17.21: {}
+
+  lodash@4.17.23: {}
 
   logform@2.7.0:
     dependencies:
@@ -7721,6 +10216,8 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
+
+  loglevel@1.9.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -7752,6 +10249,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
+
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
@@ -7759,6 +10268,8 @@ snapshots:
   memoize-weak@1.0.2: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -7776,6 +10287,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0: {}
 
@@ -7800,6 +10313,8 @@ snapshots:
   minipass@7.1.2: {}
 
   mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -7856,6 +10371,12 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-int64@0.4.0: {}
+
+  node-preload@0.2.1:
+    dependencies:
+      process-on-spawn: 1.1.0
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -7863,7 +10384,43 @@ snapshots:
   normalize-url@8.1.1:
     optional: true
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   nwsapi@2.2.23: {}
+
+  nyc@15.1.0:
+    dependencies:
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      caching-transform: 4.0.0
+      convert-source-map: 1.9.0
+      decamelize: 1.2.0
+      find-cache-dir: 3.3.2
+      find-up: 4.1.0
+      foreground-child: 2.0.0
+      get-package-type: 0.1.0
+      glob: 7.2.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-hook: 3.0.0
+      istanbul-lib-instrument: 4.0.3
+      istanbul-lib-processinfo: 2.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      make-dir: 3.1.0
+      node-preload: 0.2.1
+      p-map: 3.0.0
+      process-on-spawn: 1.1.0
+      resolve-from: 5.0.0
+      rimraf: 3.0.2
+      signal-exit: 3.0.7
+      spawn-wrap: 2.0.0
+      test-exclude: 6.0.0
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   object-assign@4.1.1: {}
 
@@ -7901,11 +10458,17 @@ snapshots:
     dependencies:
       fn.name: 1.1.0
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -7916,6 +10479,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-homedir@1.0.2: {}
+
   outvariant@1.4.3: {}
 
   own-keys@1.0.1:
@@ -7924,17 +10489,47 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
 
+  p-map@3.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
+  p-try@2.2.0: {}
+
+  package-hash@4.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      hasha: 5.2.2
+      lodash.flattendeep: 4.4.0
+      release-zalgo: 1.0.0
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.28.6
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-passwd@1.0.0: {}
 
   parse5@7.3.0:
     dependencies:
@@ -7983,6 +10578,12 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pirates@4.0.7: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
+
   playwright-core@1.50.1: {}
 
   playwright@1.50.1:
@@ -7990,6 +10591,13 @@ snapshots:
       playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  portfinder@1.0.38:
+    dependencies:
+      async: 3.2.6
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8100,7 +10708,22 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  process-on-spawn@1.1.0:
+    dependencies:
+      fromentries: 1.3.2
+
   progress@2.0.3: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   property-expr@2.0.6:
     optional: true
@@ -8119,8 +10742,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  pure-rand@6.1.0:
-    optional: true
+  pure-rand@6.1.0: {}
 
   qs@6.14.1:
     dependencies:
@@ -8153,6 +10775,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react@18.3.1:
     dependencies:
@@ -8207,6 +10831,10 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  release-zalgo@1.0.0:
+    dependencies:
+      es6-error: 4.1.1
+
   require-directory@2.1.1: {}
 
   require-in-the-middle@7.5.2:
@@ -8217,9 +10845,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-main-filename@2.0.0: {}
+
+  requires-port@1.0.0: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
+  resolve-dir@0.1.1:
+    dependencies:
+      expand-tilde: 1.2.2
+      global-modules: 0.2.3
+
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.11:
     dependencies:
@@ -8288,6 +10933,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -8315,6 +10962,8 @@ snapshots:
 
   scule@1.3.0: {}
 
+  secure-compare@3.0.1: {}
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
@@ -8341,6 +10990,8 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -8408,6 +11059,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -8424,6 +11077,12 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
+  slash@3.0.0: {}
+
+  slash@5.1.0: {}
+
   sorcery@1.0.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8431,6 +11090,11 @@ snapshots:
       tiny-glob: 0.2.9
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
   source-map-support@0.5.21:
     dependencies:
@@ -8440,7 +11104,31 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  spawn-wrap@2.0.0:
+    dependencies:
+      foreground-child: 2.0.0
+      is-windows: 1.0.2
+      make-dir: 3.1.0
+      rimraf: 3.0.2
+      signal-exit: 3.0.7
+      which: 2.0.2
+
+  spawnd@5.0.0:
+    dependencies:
+      exit: 0.1.2
+      signal-exit: 3.0.7
+      tree-kill: 1.2.2
+      wait-port: 0.2.14
+    transitivePeerDependencies:
+      - supports-color
+
+  sprintf-js@1.0.3: {}
+
   stack-trace@0.0.10: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -8479,6 +11167,16 @@ snapshots:
 
   strict-event-emitter@0.5.1: {}
 
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-length@5.0.1:
+    dependencies:
+      char-regex: 2.0.2
+      strip-ansi: 7.2.0
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -8516,7 +11214,15 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -8528,6 +11234,10 @@ snapshots:
 
   superstruct@2.0.2:
     optional: true
+
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -8703,6 +11413,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+
   text-hex@1.0.0: {}
 
   text-table@0.2.0: {}
@@ -8747,6 +11463,8 @@ snapshots:
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
+
+  tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8815,7 +11533,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.0.8: {}
+
   type-fest@0.20.2: {}
+
+  type-fest@0.21.3: {}
+
+  type-fest@0.8.1: {}
 
   type-fest@2.19.0: {}
 
@@ -8861,6 +11585,10 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typesafe-i18n@5.26.2(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -8873,6 +11601,10 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  union@0.5.0:
+    dependencies:
+      qs: 6.14.1
 
   unpipe@1.0.0: {}
 
@@ -8900,9 +11632,19 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-join@4.0.1: {}
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@8.3.2: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
 
   valibot@0.31.1:
     optional: true
@@ -8997,6 +11739,38 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  wait-on@7.2.0:
+    dependencies:
+      axios: 1.13.6
+      joi: 17.13.3
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  wait-on@9.0.4:
+    dependencies:
+      axios: 1.13.6
+      joi: 18.0.2
+      lodash: 4.17.23
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  wait-port@0.2.14:
+    dependencies:
+      chalk: 2.4.2
+      commander: 3.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -9006,6 +11780,10 @@ snapshots:
   webpack-virtual-modules@0.5.0: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-encoding@2.0.0:
+    dependencies:
+      iconv-lite: 0.6.3
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -9054,6 +11832,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -9063,6 +11843,10 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:
@@ -9116,13 +11900,29 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@3.0.3:
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
+
+  write-file-atomic@4.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 3.0.7
+
   ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
 
+  xml@1.0.1: {}
+
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  y18n@4.0.3: {}
 
   y18n@5.0.8: {}
 
@@ -9130,7 +11930,26 @@ snapshots:
 
   yaml@1.10.2: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1973,26 +1973,26 @@ packages:
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vlcn.io/crsqlite-wasm@file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz':
-    resolution: {integrity: sha512-y6Qc3rzIxVCQTAehrJCZLejX+4dNazJS8PBQUSvc+FvljoDl+HbuwDH/57MPSDejWjOFON+lKpUgAyJM0oZ1qQ==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz}
+    resolution: {integrity: sha512-71n812IABIhAvsFRivIc9wwlfXJEUy5W8RlAH+kYNLVmLPOXv5PQuouhVDIttEXC3oc8VbG2B0jbx39gDP8sLA==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-wasm-0.16.0.tgz}
     version: 0.16.0
 
   '@vlcn.io/crsqlite@file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.3.tgz':
-    resolution: {integrity: sha512-XyE3emGQBT8CoYdFXz80JA7qs//QIZykOTcEkBhoyfjEKZHFW3ij0XHLhphxlwr+y8QxSk+8UX7HDrIujBI3rg==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.3.tgz}
+    resolution: {integrity: sha512-3+fjubzMnecbVRO+rCJwY421PcYH17k91/O7bCG/9yQ/qAFmPctVYrcGWrtW6TD8pyV8BT0h2u25heB6meSbIg==, tarball: file:../../3rd-party/artefacts/vlcn.io-crsqlite-0.16.3.tgz}
     version: 0.16.3
 
   '@vlcn.io/logger-provider@0.2.0':
     resolution: {integrity: sha512-HLYSnXDo5gCLN22CEIX1eg78JTuw49l7F/KEDTbtoZXch6IJDQ1621z0m162q6T9oIOGTM400y/RUOXaKCRo8w==}
 
   '@vlcn.io/rx-tbl@file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz':
-    resolution: {integrity: sha512-bnnNnAKXq1LM7DDf6ENKrfDxL6j35lqcm8fBl79z6LROJyaBtCB+1divScTys6TD+AFlbdgUgx1e6/yYd2V88Q==, tarball: file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz}
+    resolution: {integrity: sha512-epKqgAKVhI9hS4dPnWgwtbBmaoPlCJ830ditASKNx9egogwjp/fhxa64yfsajmD7XrixS3WHk2/ah19UAGN3dw==, tarball: file:../../3rd-party/artefacts/vlcn.io-rx-tbl-0.15.0.tgz}
     version: 0.15.0
 
   '@vlcn.io/wa-sqlite@file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz':
-    resolution: {integrity: sha512-C4VwdfMvdOni4FBj7+6ql6xC5JgiW859OKN69uYx/uiWnrzVT+8dLASCsVGBnsaTvy7/ZvwdtfqRmggqjXpiww==, tarball: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz}
+    resolution: {integrity: sha512-yjEt9rA09VzBR3A68Lz+h/mniqMR/FJDUynbGjeJYH8svLyeKEdzPUKMU31WcQHPsKMXRnNRy87DrWl34qVV1A==, tarball: file:../../3rd-party/artefacts/vlcn.io-wa-sqlite-0.22.0.tgz}
     version: 0.22.0
 
   '@vlcn.io/ws-browserdb@file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz':
-    resolution: {integrity: sha512-4FmhxZUdtvMVFlOJWlMznLXDdN+cdha+xhCCjcEdU5uc4Dhi3/NvSvDm/6xcqP6LjwzlXHMaYH0+oiOUFW/znw==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz}
+    resolution: {integrity: sha512-H0K6mI2gwjjo/CwGP5fnG5NynuH4QYZaJYznvySHC9CpKpnd29iowgXT4udJLCoZ084OoMF73mqZdU8Mh4wuWw==, tarball: file:../../3rd-party/artefacts/vlcn.io-ws-browserdb-0.2.0.tgz}
     version: 0.2.0
 
   '@vlcn.io/ws-client@file:../../3rd-party/artefacts/vlcn.io-ws-client-0.2.0.tgz':
@@ -2008,7 +2008,7 @@ packages:
     version: 0.2.2
 
   '@vlcn.io/xplat-api@file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz':
-    resolution: {integrity: sha512-JwDmca4DXun43c0Zn0snlviiBYEpWsUGclWSg6x6M/SFZwuOs4cn7OYSbb5hddfB2Q3S3/WnRG/aNRqGWUtkCA==, tarball: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz}
+    resolution: {integrity: sha512-IWi6aJrWnILtvWWdqYY++wmr9ywzwevpzUE0jKCHqYxeel/EPul3MQcdyCeNsN8NrxQbvk53l+Bu8eYTml+IPA==, tarball: file:../../3rd-party/artefacts/vlcn.io-xplat-api-0.15.0.tgz}
     version: 0.15.0
 
   accepts@1.3.8:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "7f5b07b74e68deb5dc38026d919dea42501ac8cd",
+  "pnpmShrinkwrapHash": "b58d360b26f5174a0d669c24c856490e613f44c3",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "98b3623142e58eeab344ddb0d7bae84d0e2d6d83",
+  "pnpmShrinkwrapHash": "7f5b07b74e68deb5dc38026d919dea42501ac8cd",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
The web client currently mixes fast unit tests and browser-backed interaction tests in the same Vitest setup. That makes UI-oriented coverage harder to reason about and awkward to evolve. This PR separates those lanes so browser-backed tests have a clear, explicit home without slowing down every test run.

- Split Vitest into unit and browser-backed projects, with shared config extracted into vitest.shared.ts.
- Add the browser-backed bucket and package-level documentation around it.
- Include the Vitest project files in tsconfig so typed linting and CI keep seeing the whole setup.

Follow-up PRs use this split to add Storybook-driven coverage and CI wiring.