### PR TITLE
fix(sync): prevent false-positive nuke dialog on transient server outage

### DIFF
--- a/apps/e2e/integration/sync.spec.ts
+++ b/apps/e2e/integration/sync.spec.ts
@@ -466,6 +466,82 @@ test("remote DB indicator degrades when syncserver stops and recovers after rest
 	await expect.poll(badgeStatus, { timeout: 25000, intervals: [250] }).toBe("synced");
 });
 
+test("does not show nuke dialog for transient server outage with pending changes", async ({ page }, testInfo) => {
+	testInfo.setTimeout(60_000);
+
+	const circusControlAvailable = await isSyncServerCircusControlAvailable();
+	if (!circusControlAvailable) {
+		if (IS_CI) {
+			throw new Error("Circus control for syncserver is unavailable in CI. Refusing to skip the transient-outage nuke-dialog test.");
+		}
+		test.skip(true, "Circus control for syncserver is not available in this environment");
+	}
+
+	const dbName = `no-nuke-test-db-${Math.floor(Math.random() * 1000000)}.sqlite3`;
+	await startSyncServerViaCircus();
+	await waitForSyncServerCircusStatus("active");
+
+	await page.evaluate(
+		([syncUrl, dbName]) => {
+			window.localStorage.setItem("librocco-current-db", `"${dbName}"`);
+			window.localStorage.setItem("librocco-sync-url", `"${syncUrl}"`);
+			window.localStorage.setItem("librocco-sync-active", "true");
+		},
+		[syncUrl, dbName]
+	);
+	await page.goto(baseURL);
+
+	// Write a record and confirm it syncs — establishes baseline and creates change history
+	const dbHandle = await getDbHandle(page);
+	await dbHandle.evaluate(upsertCustomer, { id: 1, displayId: "1", fullname: "Pre-Outage Customer", email: "pre@test.com" });
+
+	await expect
+		.poll(
+			async () => {
+				const remoteDbHandle = await getStableRemoteDbHandle(page);
+				const remoteCustomers = await retry(() => remoteDbHandle.evaluate(getCustomerOrderList), { fallback: [] });
+				return remoteCustomers.some((c) => c.fullname === "Pre-Outage Customer");
+			},
+			{ timeout: 20000, intervals: [250] }
+		)
+		.toBe(true);
+
+	// Simulate total server outage: stop sync server and block the meta endpoint.
+	// This is the exact scenario that triggered false-positive nuke dialogs in production:
+	// stale recovery fires after 15s, calls checkSyncCompatibility, meta is unreachable.
+	try {
+		await stopSyncServerViaCircus();
+		await waitForSyncServerCircusStatus("stopped");
+		await page.route("**/meta", (route) => route.abort());
+
+		// Wait longer than DISCONNECT_RECOVERY_MIN_MS (15 000 ms) to guarantee stale recovery fires
+		await sleep(22_000);
+
+		// The nuke dialog must NOT have appeared — a transient outage is not a reason to destroy data
+		await expect(page.locator(".modal-box")).not.toBeVisible();
+
+		// Badge may be "connecting" / "stuck" but must never reach "incompatible"
+		const badgeStatus = await page.getAttribute('[data-testid="remote-db-badge"]', "data-status");
+		expect(badgeStatus).not.toBe("incompatible");
+	} finally {
+		await page.unroute("**/meta");
+		await startSyncServerViaCircus();
+		await waitForSyncServerCircusStatus("active");
+	}
+
+	// After server restart, sync should recover and the pre-outage record must still be present
+	await expect
+		.poll(async () => page.getAttribute('[data-testid="remote-db-badge"]', "data-status"), {
+			timeout: 25000,
+			intervals: [250]
+		})
+		.toBe("synced");
+
+	const remoteDbHandle = await getStableRemoteDbHandle(page);
+	const remoteCustomers = await retry(() => remoteDbHandle.evaluate(getCustomerOrderList), { fallback: [] });
+	expect(remoteCustomers.some((c) => c.fullname === "Pre-Outage Customer")).toBe(true);
+});
+
 test("shows incompatible state when remote DB is rebuilt and recovers after nuke and resync", async ({ page }) => {
 	const dbName = `compat-test-db-${Math.floor(Math.random() * 1000000)}.sqlite3`;
 	await page.evaluate(

--- a/apps/web-client/src/lib/stores/__tests__/sync-compatibility.test.ts
+++ b/apps/web-client/src/lib/stores/__tests__/sync-compatibility.test.ts
@@ -1,0 +1,174 @@
+/** @vitest-environment node */
+import { get } from "svelte/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// svelte-local-storage-store uses localStorage which isn't available in node.
+// Replace persisted() with a plain writable so remoteSiteIds is in-memory only.
+vi.mock("svelte-local-storage-store", () => {
+	function mkWritable<T>(init: T) {
+		let val = init;
+		const subs = new Set<(v: T) => void>();
+		return {
+			subscribe: (cb: (v: T) => void) => {
+				subs.add(cb);
+				cb(val);
+				return () => subs.delete(cb);
+			},
+			set: (v: T) => {
+				val = v;
+				for (const s of subs) s(v);
+			},
+			update: (fn: (v: T) => T) => {
+				val = fn(val);
+				for (const s of subs) s(val);
+			}
+		};
+	}
+	return { persisted: (_key: unknown, init: unknown) => mkWritable(init) };
+});
+
+// Avoid pulling in WASM / worker initialisation from cr-sqlite/db.
+vi.mock("$lib/db/cr-sqlite/db", () => ({ schemaVersion: 42 }));
+
+import { applyHandshakeStatus, checkSyncCompatibility, resetSyncCompatibility, syncCompatibility } from "../sync-compatibility";
+
+const TEST_DBID = "test-db-compat";
+const TEST_SYNC_URL = "ws://localhost:8080";
+const LOCAL_SCHEMA_VERSION = "42"; // must match the mocked schemaVersion above
+
+const makeFetch =
+	(status: number, body: object = {}): typeof fetch =>
+	() =>
+		Promise.resolve(new Response(JSON.stringify(body), { status }));
+
+const makeFailFetch =
+	(message: string): typeof fetch =>
+	() =>
+		Promise.reject(new Error(message));
+
+describe("checkSyncCompatibility – background mode", () => {
+	beforeEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	afterEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	it("404 from meta endpoint restores previous state and returns pendingMeta:true", async () => {
+		syncCompatibility.set({ status: "compatible", remoteSiteId: "existing-site", remoteSchemaVersion: null, verified: true });
+
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "background",
+			fetchImpl: makeFetch(404, { message: "Not Found" })
+		});
+
+		expect(result).toEqual({ ok: false, pendingMeta: true });
+		expect(get(syncCompatibility)).toMatchObject({ status: "compatible", remoteSiteId: "existing-site" });
+	});
+
+	it("500 from meta endpoint restores previous state and returns pendingMeta:true", async () => {
+		syncCompatibility.set({ status: "compatible", remoteSiteId: "existing-site", remoteSchemaVersion: null, verified: true });
+
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "background",
+			fetchImpl: makeFetch(500)
+		});
+
+		expect(result).toEqual({ ok: false, pendingMeta: true });
+		expect(get(syncCompatibility)).toMatchObject({ status: "compatible", remoteSiteId: "existing-site" });
+	});
+
+	it("network-level failure restores previous state", async () => {
+		syncCompatibility.set({ status: "compatible", remoteSiteId: "existing-site", remoteSchemaVersion: null, verified: true });
+
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "background",
+			fetchImpl: makeFailFetch("Network error")
+		});
+
+		expect(result).toMatchObject({ ok: false, error: expect.any(Error) });
+		expect(get(syncCompatibility)).toMatchObject({ status: "compatible", remoteSiteId: "existing-site" });
+	});
+
+	it("schema mismatch in meta response sets incompatible/schema_mismatch", async () => {
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "background",
+			fetchImpl: makeFetch(200, { siteId: "abc123", schemaVersion: "999999" })
+		});
+
+		expect(result).toEqual({ ok: false, reason: "schema_mismatch" });
+		expect(get(syncCompatibility)).toMatchObject({ status: "incompatible", reason: "schema_mismatch" });
+	});
+
+	it("missing siteId in meta response sets incompatible/missing_metadata", async () => {
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "background",
+			fetchImpl: makeFetch(200, { schemaVersion: LOCAL_SCHEMA_VERSION })
+		});
+
+		expect(result).toEqual({ ok: false, reason: "missing_metadata" });
+		expect(get(syncCompatibility)).toMatchObject({ status: "incompatible", reason: "missing_metadata" });
+	});
+});
+
+describe("checkSyncCompatibility – strict mode", () => {
+	beforeEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	afterEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	it("404 from meta endpoint sets incompatible/remote_unreachable", async () => {
+		const result = await checkSyncCompatibility({
+			dbid: TEST_DBID,
+			syncUrl: TEST_SYNC_URL,
+			mode: "strict",
+			fetchImpl: makeFetch(404, { message: "Not Found" })
+		});
+
+		expect(result).toMatchObject({ ok: false, error: expect.any(Error) });
+		expect(get(syncCompatibility)).toMatchObject({ status: "incompatible", reason: "remote_unreachable" });
+	});
+});
+
+describe("applyHandshakeStatus", () => {
+	beforeEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	afterEach(() => {
+		syncCompatibility.set({ status: "unknown" });
+		resetSyncCompatibility(TEST_DBID);
+	});
+
+	it("ok=false with reason=peer_mismatch sets incompatible/remote_reset", () => {
+		applyHandshakeStatus(TEST_DBID, { ok: false, reason: "peer_mismatch", message: "Peer identity changed" });
+
+		expect(get(syncCompatibility)).toMatchObject({ status: "incompatible", reason: "remote_reset" });
+	});
+
+	it("ok=true sets compatible and returns ok:true", () => {
+		const result = applyHandshakeStatus(TEST_DBID, { ok: true, siteId: "abc123", stage: "steady" });
+
+		expect(result).toMatchObject({ ok: true });
+		expect(get(syncCompatibility)).toMatchObject({ status: "compatible" });
+	});
+});

--- a/apps/web-client/src/lib/stores/sync-compatibility.ts
+++ b/apps/web-client/src/lib/stores/sync-compatibility.ts
@@ -119,6 +119,21 @@ async function fetchRemoteMeta(syncUrl: string, dbid: string, fetchImpl: typeof 
 	return (await resp.json()) as RemoteMeta;
 }
 
+/**
+ * Check whether the remote DB is compatible with the local DB.
+ *
+ * **mode: "background"** (default) — safe for use while sync is running or during recovery.
+ * On transient network failures (404 / 500 / unreachable), the previous compatibility state
+ * is restored unchanged and `{ ok: false, pendingMeta: true }` is returned so callers can
+ * defer the decision to the WebSocket handshake. Schema mismatches and identity changes are
+ * still surfaced immediately.
+ *
+ * **mode: "strict"** — intended for one-time setup flows (e.g. first-time sync activation)
+ * where the caller must be certain the remote is reachable before proceeding. Any network
+ * failure sets `incompatible / remote_unreachable`. Do NOT use this in recurring recovery
+ * paths: a transient outage would incorrectly mark the DB as incompatible and trigger the
+ * "Nuke and resync" dialog, risking data loss on nodes with unsynced changes.
+ */
 export async function checkSyncCompatibility(args: {
 	dbid: string;
 	syncUrl: string;

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -144,7 +144,7 @@
 			const compatibilityResult = await checkSyncCompatibility({
 				dbid: currentDbid,
 				syncUrl: currentSyncUrl,
-				mode: "strict"
+				mode: "background"
 			});
 			if (!compatibilityResult.ok) {
 				markAutoRecoveryNoop();


### PR DESCRIPTION
## Summary

- **Root cause**: `attemptStaleRecovery` called `checkSyncCompatibility` with `mode:"strict"`. After 15 s of disconnection, stale recovery fires and hits the meta endpoint. A transient outage (404/500/network error) caused strict mode to set `syncCompatibility → incompatible/remote_unreachable`, which opened the "Nuke and resync" dialog on nodes that had unsynced changes. An operator pressed Nuke and lost data.
- **Fix**: One-word change — `mode:"strict"` → `mode:"background"` in `attemptStaleRecovery`. Background mode restores the previous compatibility state on transient failures and defers the verdict to the WebSocket handshake. Real incompatibilities (schema mismatch, `remote_reset`) are still surfaced immediately.
- **JSDoc**: Added a warning to `checkSyncCompatibility` explaining that `"strict"` must not be used in recurring recovery paths, with an explicit note about the data-loss risk.
- **Tests**: 8 unit tests covering both modes and `applyHandshakeStatus`; 1 E2E regression test that stops the sync server for 22 s (past the 15 s `DISCONNECT_RECOVERY_MIN_MS` threshold), asserts the nuke modal never appears, and confirms data integrity after server restart.

## Test plan

- [x] `npx vitest run src/lib/stores/__tests__/sync-compatibility.test.ts` — all 8 tests pass
- [x] E2E test `"does not show nuke dialog for transient server outage with pending changes"` fails on `main` and passes on this branch (requires circus control)
- [x] Existing `"remote DB indicator degrades when syncserver stops"` and `"shows incompatible state when remote DB is rebuilt"` tests still pass — the fix does not regress real incompatibility detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced sync recovery behaviour during transient server outages. The application now properly handles brief connectivity issues without displaying premature incompatibility warnings. Sync state is preserved during temporary disconnections, with full compatibility verification resuming once the server returns.

* **Tests**
  * Added test coverage for sync compatibility checks and recovery during network outages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->