### PR TITLE
Sharedworker service

### DIFF
--- a/apps/e2e/integration/multi-tab.spec.ts
+++ b/apps/e2e/integration/multi-tab.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Multi-tab tests for the shared service DB architecture.
+ *
+ * These tests verify that multiple browser tabs can open the same database
+ * simultaneously without OPFS lock contention. The shared service pattern
+ * elects one tab as leader (owning the DedicatedWorker + OPFS handle) and
+ * routes other tabs' DB requests through MessagePorts to that worker.
+ *
+ * Prior to the fix: Tab 2 would hang for 30s then show ErrDBInitTimeout.
+ * After the fix: Tab 2 connects via the shared service relay in ~50ms.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+import { baseURL } from "@/constants";
+import { testBase as test } from "@/helpers/fixtures";
+import { getDbHandle, createOutboundNote } from "@/helpers/cr-sqlite";
+import { getDashboard } from "@/helpers/dashboard";
+
+/**
+ * Returns the worker type chosen by worker-db.ts for this page.
+ * In environments with SharedWorker support, the shared service pattern is used.
+ * In iOS Safari or test environments without SharedWorker, DedicatedWorker fallback.
+ */
+const getWorkerType = (page: Page) => page.evaluate(() => (window as any).__librocco_worker_type as string | undefined);
+
+// Multi-tab tests involve multiple full page loads + DB init + shared service port
+// negotiation (which includes a 3s request timeout + retry cycle), so they need more
+// time than the default 15s Playwright test timeout.
+test.setTimeout(45_000);
+
+// The shared service should connect additional tabs to the leader's worker well under
+// the old 30s hard timeout. 15s gives headroom for shared service port negotiation
+// (3s request timeout + retry) plus Vite dev server compilation under load.
+const TAB2_READY_TIMEOUT = 15_000;
+
+const waitForDbReady = async (page: Page, timeout = TAB2_READY_TIMEOUT) => {
+	// #app-splash is detached from the DOM when the DB reaches AppDbState.Ready.
+	// If the DB errors out (ErrDBInitTimeout etc.) the splash stays — test will fail here.
+	await page.waitForSelector("#app-splash", { state: "detached", timeout });
+};
+
+test("two tabs open the same DB — both reach db_ready without timeout", async ({ page }) => {
+	// Tab 1 is already loaded and db_ready (testBase fixture handles setup + navigation).
+	// Tab 2 shares the same browser context -> same origin -> same localStorage -> same DB ID.
+	const page2 = await page.context().newPage();
+	try {
+		await page2.goto(baseURL);
+		// This would hang for 30s then fail with ErrDBInitTimeout before the shared service fix.
+		await waitForDbReady(page2);
+
+		// Both tabs should have db_ready set.
+		const tab1Ready = await page.evaluate(() => Boolean((window as any).db_ready));
+		const tab2Ready = await page2.evaluate(() => Boolean((window as any).db_ready));
+		expect(tab1Ready).toBe(true);
+		expect(tab2Ready).toBe(true);
+
+		// Both tabs should report the same worker type.
+		const [tab1Type, tab2Type] = await Promise.all([getWorkerType(page), getWorkerType(page2)]);
+		expect(tab1Type).toBeDefined();
+		expect(tab1Type).toBe(tab2Type);
+	} finally {
+		await page2.close();
+	}
+});
+
+test("closing tab1 does not break tab2", async ({ page }) => {
+	// Open Tab 2 and wait for it to be ready.
+	const page2 = await page.context().newPage();
+	await page2.goto(baseURL);
+	await waitForDbReady(page2);
+
+	// Close Tab 1 (simulate user closing the first tab).
+	// With shared service: if Tab 1 was the leader, Tab 2 should auto-promote
+	// and re-initialize its own DedicatedWorker via leader election.
+	await page.close();
+
+	// Tab 2 should still be functional — db_ready should still be true
+	// and the app should not have entered an error state.
+	const tab2Ready = await page2.evaluate(() => Boolean((window as any).db_ready));
+	expect(tab2Ready).toBe(true);
+
+	// Basic sanity: we can query the DOM without any error overlay blocking us.
+	const errorDialog = page2.locator('[role="alertdialog"]');
+	const errorDialogCount = await errorDialog.count();
+	expect(errorDialogCount).toBe(0);
+
+	await page2.close();
+});
+
+test("reloading a tab reconnects within timeout", async ({ page }) => {
+	// Tab 1 is already ready.
+	await page.reload();
+	// After reload, a new SharedService instance participates in leader election
+	// and gets a port to the worker. db_ready must fire within the standard timeout.
+	await waitForDbReady(page);
+
+	const isReady = await page.evaluate(() => Boolean((window as any).db_ready));
+	expect(isReady).toBe(true);
+});
+
+test("three tabs — all reach db_ready", async ({ page }) => {
+	const page2 = await page.context().newPage();
+	const page3 = await page.context().newPage();
+	try {
+		await Promise.all([page2.goto(baseURL), page3.goto(baseURL)]);
+		await Promise.all([waitForDbReady(page2), waitForDbReady(page3)]);
+
+		const [r1, r2, r3] = await Promise.all([
+			page.evaluate(() => Boolean((window as any).db_ready)),
+			page2.evaluate(() => Boolean((window as any).db_ready)),
+			page3.evaluate(() => Boolean((window as any).db_ready))
+		]);
+		expect(r1).toBe(true);
+		expect(r2).toBe(true);
+		expect(r3).toBe(true);
+	} finally {
+		await page2.close();
+		await page3.close();
+	}
+});
+
+test("Cross-tab reactivity: note created in tab1 appears in tab2", async ({ page }) => {
+	// Tab 1: navigate to Sale page.
+	await page.getByRole("link", { name: "Sale" }).click();
+	const dashboard1 = getDashboard(page);
+	const entityList1 = dashboard1.content().entityList("outbound-list");
+
+	// Confirm the list starts empty.
+	await entityList1.assertElements([]);
+
+	// Tab 2: open a new tab and navigate to the same Sale page.
+	const page2 = await page.context().newPage();
+	try {
+		await page2.goto(baseURL);
+		await waitForDbReady(page2);
+		await page2.getByRole("link", { name: "Sale" }).click();
+		const dashboard2 = getDashboard(page2);
+		const entityList2 = dashboard2.content().entityList("outbound-list");
+		await entityList2.assertElements([]);
+
+		// Tab 1: create a note via the DB handle.
+		const dbHandle = await getDbHandle(page);
+		await dbHandle.evaluate(createOutboundNote, { id: 1, displayName: "Cross-Tab Note" });
+
+		// Tab 1: the note should appear in the list (local reactivity).
+		await entityList1.assertElements([{ name: "Cross-Tab Note" }]);
+
+		// Tab 2: the note should also appear (cross-tab reactivity via TblRx BroadcastChannel).
+		await entityList2.assertElements([{ name: "Cross-Tab Note" }]);
+	} finally {
+		await page2.close();
+	}
+});

--- a/apps/web-client/src/lib/app/index.ts
+++ b/apps/web-client/src/lib/app/index.ts
@@ -8,6 +8,7 @@ import { IS_DEMO } from "$lib/constants";
 import { clearIDBBatchAtomic, deleteDBFromOPFS } from "$lib/db/cr-sqlite/core/utils";
 import type { VFSWhitelist } from "$lib/db/cr-sqlite/core";
 import { vfsSupportsOPFS } from "$lib/db/cr-sqlite/core/vfs";
+import { disconnectAllPorts } from "$lib/db/cr-sqlite/core/worker-db";
 import { resetSyncCompatibility } from "$lib/stores/sync-compatibility";
 
 export class App {
@@ -36,6 +37,9 @@ export async function nukeAndResyncDb(app: App, dbid: string, vfs: VFSWhitelist)
 	await stopSync(app);
 	// Close the current connection
 	await app.db.db?.close();
+	// Tear down SharedService and DedicatedWorker so the leader Web Lock and
+	// OPFS SyncAccessHandle are released before we delete and re-create the DB.
+	disconnectAllPorts();
 
 	// Delete the DB file (this should be safe now -- no open connections)
 	if (vfsSupportsOPFS(vfs)) {
@@ -65,6 +69,8 @@ export async function selectDb(app: App, dbid: string, vfs: VFSWhitelist) {
 	await stopSync(app);
 	// Close the current connection
 	await app.db.db?.close();
+	// Release the SharedService leader lock and OPFS handle before re-init.
+	disconnectAllPorts();
 
 	// Reinitialise the (clean) DB with provided DBID
 	// NOTE: this sets the DB state to "ready" -- thus unlocking the DB for high-level usage
@@ -86,6 +92,8 @@ export async function deleteCurrentDb(app: App, next: { dbid: string; vfs: VFSWh
 	await stopSync(app);
 	// Close the current connection
 	await app.db.db?.close();
+	// Release the SharedService leader lock and OPFS handle before re-init.
+	disconnectAllPorts();
 
 	// Delete the DB file (this should be safe now -- no open connections)
 	if (vfsSupportsOPFS(vfs)) {

--- a/apps/web-client/src/lib/app/init.ts
+++ b/apps/web-client/src/lib/app/init.ts
@@ -12,7 +12,7 @@ import { DEMO_VFS } from "$lib/db/cr-sqlite/core/constants";
 import { type App } from ".";
 import { AppDbState, getDb, initializeDb, initializeDemoDb } from "./db";
 import { ErrDBInitTimeout } from "./errors";
-import { terminateAllWorkers } from "$lib/db/cr-sqlite/core/worker-db";
+import { disconnectAllPorts } from "$lib/db/cr-sqlite/core/worker-db";
 import { _performInitialSync, initializeSync, startSync } from "./sync";
 
 import { updateTranslationOverrides } from "$lib/i18n-overrides";
@@ -44,7 +44,7 @@ export async function initApp(app: App) {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 	const timeoutPromise = new Promise<never>((_, reject) => {
 		timeoutId = setTimeout(() => {
-			terminateAllWorkers();
+			disconnectAllPorts();
 			const dbid = app.db.dbid ?? get(app.config.dbid);
 			const err = new ErrDBInitTimeout();
 			const currentState = get(app.db.state);

--- a/apps/web-client/src/lib/db/cr-sqlite/core/shared-service-relay.worker.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/shared-service-relay.worker.ts
@@ -1,0 +1,46 @@
+/**
+ * Tiny SharedWorker that forwards MessagePorts between tabs.
+ *
+ * Each tab registers with its clientId. When the provider (leader) needs to send
+ * a MessagePort to a client tab, it sends the port here, and this worker forwards
+ * it to the correct tab based on clientId.
+ *
+ * This worker never touches SQLite — it's pure port routing.
+ */
+
+const clients = new Map<string, MessagePort>();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const scope = self as any;
+scope.addEventListener("connect", (event: MessageEvent) => {
+	const workerPort = (event as MessageEvent).ports[0];
+
+	workerPort.addEventListener(
+		"message",
+		(event: MessageEvent) => {
+			const clientId = event.data.clientId;
+			clients.set(clientId, workerPort);
+
+			// Acknowledge registration so the client knows it can safely request ports.
+			workerPort.postMessage({ _type: "relay-registered" });
+
+			// When the client tab dies, its context lock releases. Detect this
+			// and clean up the entry.
+			navigator.locks.request(clientId, { mode: "shared" }, () => {
+				clients.get(clientId)?.close();
+				clients.delete(clientId);
+			});
+
+			// All subsequent messages are forwarded to the target client.
+			workerPort.addEventListener("message", (event: MessageEvent) => {
+				const target = clients.get(event.data.clientId);
+				if (target) {
+					target.postMessage(event.data, event.ports as unknown as Transferable[]);
+				}
+			});
+		},
+		{ once: true }
+	);
+
+	workerPort.start();
+});

--- a/apps/web-client/src/lib/db/cr-sqlite/core/shared-service.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/shared-service.ts
@@ -1,0 +1,328 @@
+/**
+ * SharedService: leader-elected, multi-tab service sharing via Web Locks + BroadcastChannel.
+ *
+ * Adapted from rhashimoto/wa-sqlite demo (https://github.com/rhashimoto/wa-sqlite/tree/master/demo/SharedService).
+ *
+ * One tab wins a Web Lock and becomes the "provider" (leader). It spawns the actual
+ * DedicatedWorker that holds the OPFS database. Other tabs get MessagePorts routed
+ * to that worker through a tiny SharedWorker relay (which only forwards ports, never
+ * touches SQLite). When the leader tab closes, the lock auto-releases and the next
+ * queued tab takes over.
+ */
+
+import SharedServiceRelay from "./shared-service-relay.worker?sharedworker";
+
+const PROVIDER_REQUEST_TIMEOUT = 3000;
+
+type ProviderChangeCallback = () => void;
+
+/**
+ * A SharedService instance coordinates leader election and port distribution
+ * for a single named service (e.g. one database).
+ */
+export class SharedService {
+	#serviceName: string;
+	#portProviderFunc: () => MessagePort | Promise<MessagePort>;
+	#clientId: Promise<string>;
+
+	#clientChannel = new BroadcastChannel("SharedService");
+	#onDeactivate: AbortController | null = null;
+	#onClose = new AbortController();
+
+	#providerPort: Promise<MessagePort | null>;
+	#providerCounter = 0;
+	#providerChangeCleanup: (() => void)[] = [];
+	#providerChangeListeners = new Set<ProviderChangeCallback>();
+
+	// The relay SharedWorker is shared across all instances (one per origin).
+	static #relay: SharedWorker | null = null;
+	static #relayReady: Promise<void> | null = null;
+	static #relayClientId: string | null = null;
+
+	// Event target for messages forwarded from the relay.
+	#relayEvents = new EventTarget();
+
+	constructor(serviceName: string, portProviderFunc: () => MessagePort | Promise<MessagePort>) {
+		this.#serviceName = serviceName;
+		this.#portProviderFunc = portProviderFunc;
+		this.#clientId = this.#getClientId();
+
+		// Connect to current provider and listen for future provider changes.
+		this.#providerPort = this.#providerChange();
+		this.#clientChannel.addEventListener(
+			"message",
+			({ data }) => {
+				if (data?.type === "provider" && data?.sharedService === this.#serviceName) {
+					this.#closeProviderPort(this.#providerPort);
+					this.#providerPort = this.#providerChange();
+					for (const cb of this.#providerChangeListeners) {
+						try {
+							cb();
+						} catch {
+							// best-effort
+						}
+					}
+				}
+			},
+			{ signal: this.#onClose.signal }
+		);
+	}
+
+	/** Register a callback for when the provider (leader) changes. */
+	onProviderChange(cb: ProviderChangeCallback): () => void {
+		this.#providerChangeListeners.add(cb);
+		return () => this.#providerChangeListeners.delete(cb);
+	}
+
+	/** Participate in leader election. Call once per tab. */
+	activate(): void {
+		if (this.#onDeactivate) return;
+		this.#onDeactivate = new AbortController();
+
+		navigator.locks
+			.request(`SharedService-${this.#serviceName}`, { signal: this.#onDeactivate.signal }, async () => {
+				// We won the lock — we are the provider (leader).
+				const port = await this.#portProviderFunc();
+				port.start();
+
+				const providerId = await this.#clientId;
+				const providerChannel = new BroadcastChannel("SharedService");
+
+				// Serialize port-broker request/response pairs. Without this, concurrent
+				// requests cause multiple `{ once: true }` listeners to fire on the same
+				// broker response message, misrouting ports.
+				let requestQueue = Promise.resolve();
+
+				providerChannel.addEventListener(
+					"message",
+					({ data }) => {
+						if (data?.type === "request" && data?.sharedService === this.#serviceName) {
+							requestQueue = requestQueue.then(async () => {
+								const requestedPort = await new Promise<MessagePort>((resolve) => {
+									port.addEventListener(
+										"message",
+										(event) => {
+											resolve(event.ports[0]);
+										},
+										{ once: true }
+									);
+									port.postMessage(data.clientId);
+								});
+
+								this.#sendPortToClient(data, requestedPort);
+							});
+						}
+					},
+					{ signal: this.#onDeactivate!.signal }
+				);
+
+				// Announce ourselves as the new provider.
+				providerChannel.postMessage({
+					type: "provider",
+					sharedService: this.#serviceName,
+					providerId
+				});
+
+				// Hold the lock until deactivated or tab closes.
+				return new Promise<void>((_, reject) => {
+					this.#onDeactivate!.signal.addEventListener("abort", () => {
+						providerChannel.close();
+						reject(this.#onDeactivate!.signal.reason);
+					});
+				});
+			})
+			.catch((err) => {
+				// AbortError from deactivate() is expected lifecycle — nothing to do.
+				// Other errors (e.g. portProviderFunc OPFS failures) mean this tab
+				// cannot be the provider. Bump the counter so any in-progress
+				// #providerChange loop exits with null, causing getPort() to throw
+				// and trigger the DedicatedWorker fallback in worker-db.ts.
+				if (err?.name !== "AbortError") {
+					this.#providerCounter++;
+				}
+			});
+	}
+
+	deactivate(): void {
+		this.#onDeactivate?.abort();
+		this.#onDeactivate = null;
+	}
+
+	close(): void {
+		this.deactivate();
+		this.#onClose.abort();
+	}
+
+	/** Get a MessagePort connected to the provider's service. */
+	async getPort(): Promise<MessagePort> {
+		let port = await this.#providerPort;
+		if (!port) {
+			// A provider change may have occurred while we were waiting (e.g. this
+			// tab became the leader and announced itself). #providerPort was
+			// reassigned by the provider-change listener — await the latest promise.
+			port = await this.#providerPort;
+		}
+		if (!port) {
+			throw new Error(`SharedService(${this.#serviceName}): no provider available`);
+		}
+		return port;
+	}
+
+	// --- Private helpers ---
+
+	#sendPortToClient(message: any, port: MessagePort): void {
+		const relay = SharedService.#relay;
+		if (!relay) throw new Error("SharedService relay not initialized");
+		relay.port.postMessage(message, [port]);
+	}
+
+	async #getClientId(): Promise<string> {
+		// Use a Web Lock to discover our clientId.
+		const nonce = Math.random().toString();
+		const clientId = await navigator.locks.request(nonce, async () => {
+			const { held } = await navigator.locks.query();
+			return held!.find((lock) => lock.name === nonce)?.clientId ?? "";
+		});
+
+		// Acquire a persistent lock named after our clientId so other contexts
+		// can track our lifetime.
+		await SharedService.#acquireContextLock(clientId);
+
+		// Set up the relay SharedWorker (once per origin).
+		await SharedService.#initRelay(clientId);
+
+		// Listen for messages forwarded from the relay to this instance.
+		SharedService.#relay!.port.addEventListener("message", (event: MessageEvent) => {
+			const data = { ...event.data, ports: (event as MessageEvent).ports };
+			this.#relayEvents.dispatchEvent(new MessageEvent("message", { data }));
+		});
+
+		return clientId;
+	}
+
+	async #providerChange(): Promise<MessagePort | null> {
+		const providerCounter = ++this.#providerCounter;
+		let providerPort: MessagePort | undefined;
+		const clientId = await this.#clientId;
+
+		while (!providerPort && providerCounter === this.#providerCounter) {
+			const nonce = randomString();
+			this.#clientChannel.postMessage({
+				type: "request",
+				nonce,
+				sharedService: this.#serviceName,
+				clientId
+			});
+
+			const providerPortReady = new Promise<MessagePort | undefined>((resolve) => {
+				const abortController = new AbortController();
+				this.#relayEvents.addEventListener(
+					"message",
+					((event: MessageEvent) => {
+						if (event.data?.nonce === nonce) {
+							resolve(event.data.ports?.[0]);
+							abortController.abort();
+						}
+					}) as EventListener,
+					{ signal: abortController.signal }
+				);
+				this.#providerChangeCleanup.push(() => abortController.abort());
+			});
+
+			providerPort = await Promise.race([
+				providerPortReady,
+				new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), PROVIDER_REQUEST_TIMEOUT))
+			]);
+
+			if (!providerPort) {
+				providerPortReady.then((port) => port?.close());
+			}
+		}
+
+		if (providerPort && providerCounter === this.#providerCounter) {
+			this.#providerChangeCleanup.forEach((f) => f());
+			this.#providerChangeCleanup = [];
+			providerPort.start();
+			return providerPort;
+		} else {
+			providerPort?.close();
+			return null;
+		}
+	}
+
+	#closeProviderPort(providerPort: Promise<MessagePort | null>): void {
+		providerPort.then((port) => port?.close());
+	}
+
+	// Acquire one context lock per tab (shared across all SharedService instances).
+	static #contextLockAcquired = false;
+	static async #acquireContextLock(clientId: string): Promise<void> {
+		if (SharedService.#contextLockAcquired) return;
+		SharedService.#contextLockAcquired = true;
+		return new Promise<void>((resolve) => {
+			navigator.locks.request(clientId, () => {
+				resolve();
+				// Hold indefinitely — released when tab closes.
+				return new Promise<void>(() => {});
+			});
+		});
+	}
+
+	static async #initRelay(clientId: string): Promise<void> {
+		if (SharedService.#relayReady) return SharedService.#relayReady;
+		SharedService.#relayReady = (async () => {
+			SharedService.#relay = new SharedServiceRelay();
+			SharedService.#relay.port.start();
+			SharedService.#relay.port.postMessage({ clientId });
+			SharedService.#relayClientId = clientId;
+			// Wait for the relay to acknowledge registration before proceeding.
+			// Without this, a provider tab could try to forward a port to us
+			// before the relay has registered our clientId, silently dropping it.
+			await new Promise<void>((resolve) => {
+				const listener = (e: MessageEvent) => {
+					if (e.data?._type === "relay-registered") {
+						SharedService.#relay!.port.removeEventListener("message", listener);
+						resolve();
+					}
+				};
+				SharedService.#relay!.port.addEventListener("message", listener);
+			});
+		})();
+		return SharedService.#relayReady;
+	}
+}
+
+/**
+ * Create a port that handles incoming client connection requests and creates
+ * per-client MessageChannels. Used by the leader tab to bridge client tabs
+ * to the DedicatedWorker.
+ *
+ * For each incoming client request (a postMessage with clientId), this creates
+ * a new MessageChannel: port1 is sent back (to be forwarded to the client via
+ * the relay), port2 is passed to `onClientPort` for the caller to wire up
+ * (e.g. transfer to the DedicatedWorker).
+ */
+export function createPortBroker(onClientPort: (port: MessagePort, clientId: string) => void): MessagePort {
+	const { port1: brokerPort, port2: returnPort } = new MessageChannel();
+
+	brokerPort.addEventListener("message", ({ data: clientId }) => {
+		const { port1, port2 } = new MessageChannel();
+
+		// When the client tab dies, its context lock releases. Use a shared lock
+		// request to detect this and clean up.
+		navigator.locks.request(clientId, { mode: "shared" }, () => {
+			port1.close();
+		});
+
+		// port1 stays here (forwarded to the client via relay), port2 goes to the worker.
+		onClientPort(port2, clientId);
+		brokerPort.postMessage(null, [port1]);
+	});
+	brokerPort.start();
+
+	return returnPort;
+}
+
+function randomString(): string {
+	return Math.random().toString(36).replace("0.", "");
+}

--- a/apps/web-client/src/lib/db/cr-sqlite/core/shared-service.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/shared-service.ts
@@ -12,7 +12,7 @@
 
 import SharedServiceRelay from "./shared-service-relay.worker?sharedworker";
 
-const PROVIDER_REQUEST_TIMEOUT = 3000;
+const PROVIDER_REQUEST_TIMEOUT = 500;
 
 type ProviderChangeCallback = () => void;
 

--- a/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.ts
@@ -25,7 +25,7 @@ const activePorts = new Set<MessagePort>();
 // DedicatedWorker instances (leader tab, or iOS fallback)
 const activeWorkers = new Set<Worker>();
 // Active SharedService instances
-let activeService: SharedService | null = null;
+const activeServices = new Set<SharedService>();
 
 /**
  * Synchronously closes all active DB connections:
@@ -44,10 +44,10 @@ export function disconnectAllPorts(): void {
 		w.terminate();
 	}
 	activeWorkers.clear();
-	if (activeService) {
-		activeService.close();
-		activeService = null;
+	for (const s of activeServices) {
+		s.close();
 	}
+	activeServices.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -80,10 +80,19 @@ async function getSharedServiceDB(dbname: string, vfs: string): Promise<DBAsync>
 		const wkr = new DBWorker({ name: serviceName });
 		activeWorkers.add(wkr);
 
+		const WORKER_INIT_TIMEOUT = 10_000;
 		await new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				wkr.removeEventListener("message", listener);
+				wkr.terminate();
+				activeWorkers.delete(wkr);
+				reject(new Error("DedicatedWorker init timed out"));
+			}, WORKER_INIT_TIMEOUT);
+
 			const listener = (e: MessageEvent) => {
 				const isInitMsg = (e: MessageEvent): e is MessageEvent<MsgInit> => e.data?._type === "wkr-init";
 				if (!isInitMsg(e)) return;
+				clearTimeout(timer);
 				wkr.removeEventListener("message", listener);
 				if (e.data.status === "ok") {
 					resolve();
@@ -103,7 +112,7 @@ async function getSharedServiceDB(dbname: string, vfs: string): Promise<DBAsync>
 		});
 	});
 
-	activeService = service;
+	activeServices.add(service);
 	service.activate();
 
 	// Wait for a provider to be available and get our port to the worker.
@@ -115,7 +124,7 @@ async function getSharedServiceDB(dbname: string, vfs: string): Promise<DBAsync>
 		console.warn("[worker-db] shared service init failed, falling back to DedicatedWorker:", err);
 		console.timeEnd("[worker-db] shared service port");
 		service.close();
-		activeService = null;
+		activeServices.delete(service);
 		return getDedicatedWorkerDB(dbname, vfs);
 	}
 	console.timeEnd("[worker-db] shared service port");

--- a/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.ts
@@ -14,42 +14,175 @@ import type {
 
 import DBWorker from "./worker-db.worker?worker";
 import type { MsgInit } from "./worker-db.worker";
+import { SharedService, createPortBroker } from "./shared-service";
 
-// Track all active DB workers so they can be terminated synchronously on page unload,
-// even if the page reloads before getWorkerDB() completes (before app.db.db is set).
+// ---------------------------------------------------------------------------
+// Active connection tracking (for disconnectAllPorts / pagehide teardown)
+// ---------------------------------------------------------------------------
+
+// SharedService client ports (non-leader tabs)
+const activePorts = new Set<MessagePort>();
+// DedicatedWorker instances (leader tab, or iOS fallback)
 const activeWorkers = new Set<Worker>();
+// Active SharedService instances
+let activeService: SharedService | null = null;
 
 /**
- * Synchronously terminates all active DB workers, immediately releasing OPFS file handles.
+ * Synchronously closes all active DB connections:
+ * - Closes MessagePorts (client tabs)
+ * - Terminates DedicatedWorkers (leader tab / iOS fallback)
+ * - Deactivates SharedService (releases Web Lock for leader election)
+ *
  * Call this from pagehide/beforeunload to prevent lock conflicts on rapid reload.
  */
-export function terminateAllWorkers(): void {
+export function disconnectAllPorts(): void {
+	for (const p of activePorts) {
+		p.close();
+	}
+	activePorts.clear();
 	for (const w of activeWorkers) {
 		w.terminate();
 	}
 	activeWorkers.clear();
+	if (activeService) {
+		activeService.close();
+		activeService = null;
+	}
 }
 
-export async function getWorkerDB(dbname: string, vfs: string): Promise<DBAsync> {
-	console.time("[worker-db] worker init");
-	const wkr = await initWorker(dbname, vfs);
-	console.timeEnd("[worker-db] worker init");
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
 
-	console.time("[worker-db] comlink setup");
+export async function getWorkerDB(dbname: string, vfs: string): Promise<DBAsync> {
+	// In environments without SharedWorker (iOS Safari) or during vitest browser
+	// tests (single-tab, no SharedWorker OPFS support), skip the shared service
+	// and use a plain DedicatedWorker directly.
+	const isTestEnv = import.meta.env.MODE === "test";
+	if (typeof SharedWorker === "undefined" || isTestEnv) {
+		return getDedicatedWorkerDB(dbname, vfs);
+	}
+	return getSharedServiceDB(dbname, vfs);
+}
+
+// ---------------------------------------------------------------------------
+// Shared service path (production multi-tab)
+// ---------------------------------------------------------------------------
+
+async function getSharedServiceDB(dbname: string, vfs: string): Promise<DBAsync> {
+	const serviceName = [dbname, vfs].join("---");
+
+	const service = new SharedService(serviceName, async () => {
+		// This callback runs only on the leader tab.
+		// Spawn a DedicatedWorker and wait for it to initialize (WASM load, VFS setup,
+		// DB open) before accepting client ports. This ensures the worker's client-port
+		// handler is registered before any ports arrive.
+		const wkr = new DBWorker({ name: serviceName });
+		activeWorkers.add(wkr);
+
+		await new Promise<void>((resolve, reject) => {
+			const listener = (e: MessageEvent) => {
+				const isInitMsg = (e: MessageEvent): e is MessageEvent<MsgInit> => e.data?._type === "wkr-init";
+				if (!isInitMsg(e)) return;
+				wkr.removeEventListener("message", listener);
+				if (e.data.status === "ok") {
+					resolve();
+				} else {
+					wkr.terminate();
+					activeWorkers.delete(wkr);
+					reject(new Error(e.data.error));
+				}
+			};
+			wkr.addEventListener("message", listener);
+		});
+
+		return createPortBroker((clientPort: MessagePort) => {
+			// Transfer the client's port to the DedicatedWorker so Comlink
+			// can expose the DB on it directly.
+			wkr.postMessage({ _type: "client-port" }, [clientPort]);
+		});
+	});
+
+	activeService = service;
+	service.activate();
+
+	// Wait for a provider to be available and get our port to the worker.
+	console.time("[worker-db] shared service port");
+	let port: MessagePort;
+	try {
+		port = await service.getPort();
+	} catch (err) {
+		console.warn("[worker-db] shared service init failed, falling back to DedicatedWorker:", err);
+		console.timeEnd("[worker-db] shared service port");
+		service.close();
+		activeService = null;
+		return getDedicatedWorkerDB(dbname, vfs);
+	}
+	console.timeEnd("[worker-db] shared service port");
+
+	activePorts.add(port);
+
+	// If we're the leader, the DedicatedWorker was just spawned — wait for it to init.
+	// If we're a client, the worker is already running — Comlink calls will just work.
+	// Either way, we need to wait for the wkr-init handshake IF this port is the leader's
+	// direct worker port. For client ports (via relay), the worker is already initialized
+	// and Comlink is already exposed — no handshake needed.
+	//
+	// The leader's DedicatedWorker posts wkr-init on `self` (its main port), not on
+	// client ports. So client tabs skip the handshake — Comlink.wrap just works.
+
+	console.time("[worker-db] comlink setup (shared-service)");
+	try {
+		const ifc = Comlink.wrap<DBAsyncRemote>(port);
+		const [__mutex, siteid, filename, tablesUsedStmt] = await Promise.all([ifc.__mutex, ifc.siteid, ifc.filename, ifc.tablesUsedStmt]);
+		console.timeEnd("[worker-db] comlink setup (shared-service)");
+
+		const cleanup = () => {
+			port.close();
+			activePorts.delete(port);
+		};
+
+		if (typeof window !== "undefined") (window as any).__librocco_worker_type = "shared-service";
+		return new WorkerDB(cleanup, ifc, __mutex, siteid, filename, tablesUsedStmt);
+	} catch (err) {
+		console.timeEnd("[worker-db] comlink setup (shared-service)");
+		port.close();
+		activePorts.delete(port);
+		throw err;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DedicatedWorker path (iOS Safari fallback / test env)
+// ---------------------------------------------------------------------------
+
+async function getDedicatedWorkerDB(dbname: string, vfs: string): Promise<DBAsync> {
+	console.time("[worker-db] DedicatedWorker init");
+	const wkr = await initDedicatedWorker(dbname, vfs);
+	console.timeEnd("[worker-db] DedicatedWorker init");
+
+	console.time("[worker-db] comlink setup (dedicated)");
 	try {
 		const ifc = Comlink.wrap<DBAsyncRemote>(wkr);
 		const [__mutex, siteid, filename, tablesUsedStmt] = await Promise.all([ifc.__mutex, ifc.siteid, ifc.filename, ifc.tablesUsedStmt]);
-		console.timeEnd("[worker-db] comlink setup");
-		return new WorkerDB(wkr, ifc, __mutex, siteid, filename, tablesUsedStmt);
+		console.timeEnd("[worker-db] comlink setup (dedicated)");
+
+		const cleanup = () => {
+			wkr.terminate();
+			activeWorkers.delete(wkr);
+		};
+
+		if (typeof window !== "undefined") (window as any).__librocco_worker_type = "dedicated";
+		return new WorkerDB(cleanup, ifc, __mutex, siteid, filename, tablesUsedStmt);
 	} catch (err) {
-		console.timeEnd("[worker-db] comlink setup");
+		console.timeEnd("[worker-db] comlink setup (dedicated)");
 		wkr.terminate();
 		activeWorkers.delete(wkr);
 		throw err;
 	}
 }
 
-function initWorker(dbname: string, vfs: string) {
+function initDedicatedWorker(dbname: string, vfs: string): Promise<Worker> {
 	const name = [dbname, vfs].join("---");
 	const wkr = new DBWorker({ name });
 	activeWorkers.add(wkr);
@@ -79,21 +212,23 @@ function initWorker(dbname: string, vfs: string) {
 	});
 }
 
+// ---------------------------------------------------------------------------
+// WorkerDB: main-thread proxy over the worker DB
+// ---------------------------------------------------------------------------
+
 class WorkerDB implements DBAsync {
-	private _worker: Worker;
+	private _teardown: () => void;
 	private _isConnected = false;
 
 	constructor(
-		worker: Worker,
+		teardown: () => void,
 		readonly remote: Comlink.Remote<DBAsyncRemote>,
-		// TODO: running the mutex over a Comlink proxy might not be the terribly performant solution,
-		// check if we should implement a local mutex here.
 		readonly __mutex: TMutex,
 		readonly siteid: string,
 		readonly filename: string,
 		readonly tablesUsedStmt: StmtAsync
 	) {
-		this._worker = worker;
+		this._teardown = teardown;
 		void Promise.resolve(this.remote.isConnected)
 			.then((connected) => {
 				this._isConnected = connected;
@@ -105,12 +240,11 @@ class WorkerDB implements DBAsync {
 	}
 
 	/**
-	 * Synchronously terminates the underlying Web Worker, immediately releasing
+	 * Synchronously closes the underlying connection (port or worker), immediately releasing
 	 * any OPFS file handles. Use this on page unload instead of the async close().
 	 */
 	terminate(): void {
-		this._worker.terminate();
-		activeWorkers.delete(this._worker);
+		this._teardown();
 	}
 
 	prepare(sql: string) {
@@ -134,10 +268,7 @@ class WorkerDB implements DBAsync {
 	}
 
 	close() {
-		return this.remote.close().finally(() => {
-			this._worker.terminate();
-			activeWorkers.delete(this._worker);
-		});
+		return this.remote.close().finally(() => this._teardown());
 	}
 
 	createFunction(name: string, fn: (...args: any) => unknown, opts?: Record<string, any>) {
@@ -145,8 +276,6 @@ class WorkerDB implements DBAsync {
 	}
 
 	onUpdate(cb: OnUpdateCallback): () => void {
-		// NOTE: everything done over the wire is a Promise, whereas 'onUpdate' signature expects the unsubscribe function
-		// to be returned immediately, so we create a function that (internally) waits for the unsubscribe and calls it
 		const res = this.remote.onUpdate(Comlink.proxy(cb));
 		void res.catch((error) => {
 			console.warn("[worker] Failed to subscribe onUpdate listener", error);
@@ -156,7 +285,7 @@ class WorkerDB implements DBAsync {
 				.then((unsubscribe) => unsubscribe())
 				.catch((error) => {
 					console.warn("[worker] Failed to unsubscribe onUpdate listener", error);
-				}); // Everything done over the wire is a Promise
+				});
 	}
 
 	tx(cb: TXCallback): Promise<void> {

--- a/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.worker.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/worker-db.worker.ts
@@ -85,6 +85,17 @@ async function start() {
 		Comlink.expose(db);
 		console.timeEnd("[worker] wrapDB + expose");
 
+		// Listen for client ports forwarded by the leader tab (shared service pattern).
+		// When a new client tab connects, the leader transfers a MessagePort here;
+		// we expose the same DB instance on that port via Comlink.
+		self.addEventListener("message", (e: MessageEvent) => {
+			if (e.data?._type === "client-port" && e.ports[0]) {
+				const clientPort = e.ports[0];
+				clientPort.start();
+				Comlink.expose(db, clientPort);
+			}
+		});
+
 		console.log(`[worker] db exposed, sending ok msg...`);
 		const msg: MsgInitOk = { _type: "wkr-init", status: "ok" };
 		self.postMessage(msg);

--- a/apps/web-client/src/lib/utils/debug-export.ts
+++ b/apps/web-client/src/lib/utils/debug-export.ts
@@ -2,7 +2,7 @@ import { zipSync, strToU8 } from "fflate";
 
 import { VERSION, GIT_SHA } from "$lib/constants";
 import { deleteDBFromOPFS, wrapFileHandle } from "$lib/db/cr-sqlite/core/utils";
-import { terminateAllWorkers } from "$lib/db/cr-sqlite/core/worker-db";
+import { disconnectAllPorts } from "$lib/db/cr-sqlite/core/worker-db";
 
 /**
  * Exports the current app state (SQLite DB + localStorage config) as a zip archive.
@@ -75,7 +75,7 @@ async function writeDbBytesToOPFS(bytes: Uint8Array, dbid: string): Promise<void
 	if (!magic.every((b, i) => bytes[i] === b)) throw new Error("Invalid SQLite file: magic header mismatch");
 
 	// Release all OPFS file handles held by workers, then wait briefly for the OS to free them
-	terminateAllWorkers();
+	disconnectAllPorts();
 	await new Promise<void>((r) => setTimeout(r, 300));
 
 	// Write to a temp file first so the live DB is only removed after the write succeeds

--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -20,7 +20,7 @@
 	import { Sidebar } from "$lib/components";
 
 	import { ErrDemoDBNotInitialised } from "$lib/db/cr-sqlite/errors";
-	import { terminateAllWorkers } from "$lib/db/cr-sqlite/core/worker-db";
+	import { disconnectAllPorts } from "$lib/db/cr-sqlite/core/worker-db";
 	import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 	import { timeLogger } from "$lib/utils/timer";
 	import { resetSyncStuckState, syncConnectivityMonitor } from "$lib/stores";
@@ -211,11 +211,11 @@
 	};
 
 	// Synchronously terminate all DB workers on page unload to immediately release OPFS file handles.
-	// terminateAllWorkers() is synchronous and works even if the page reloads during DB init
+	// disconnectAllPorts() is synchronous and works even if the page reloads during DB init
 	// (before app.db.db is set), because it tracks workers at module level from the moment they're created.
 	const releaseDbOnUnload = () => {
 		try {
-			terminateAllWorkers();
+			disconnectAllPorts();
 		} catch {
 			// Best-effort: ignore errors during teardown
 		}

--- a/docs/architecture/00-overview.md
+++ b/docs/architecture/00-overview.md
@@ -18,6 +18,7 @@ Each document below covers one slice of the system. They reference each other fr
 | 5 | [CRDT Conflict Resolution](./05-crdt-conflict-resolution.md) | Last-Write-Wins semantics, the `crsql_changes` virtual table, causal clocks, site IDs, and what can go wrong. **Start here for the inconsistent-note issue.** |
 | 6 | [Diagnosis: Known Issues](./06-known-issues.md) | Detailed analysis of both target issues with root causes, contributing factors, and potential improvements. |
 | 7 | [Sync User Requirements](./07-sync-user-requirements.md) | User-facing sync requirements, gap analysis, and implementation roadmap. **Start here for sync indicator and pending changes tracking.** |
+| 8 | [Multi-Tab Shared Service](./08-multi-tab-shared-service.md) | Why SharedWorker can't hold the OPFS database, the shared service leader-election pattern, and a minimal implementation plan for multi-tab support. **Start here for the multi-tab timeout issue.** |
 
 ## The 30-Second Picture
 

--- a/docs/architecture/08-multi-tab-shared-service.md
+++ b/docs/architecture/08-multi-tab-shared-service.md
@@ -1,0 +1,169 @@
+# Multi-Tab Support via Shared Service Pattern
+
+This document assesses the multi-tab OPFS lock contention problem, explains why placing SQLite directly inside a SharedWorker does not work, and outlines a minimal implementation plan based on the "shared service" pattern from the wa-sqlite community.
+
+## The Problem
+
+Librocco uses the `sync-opfs-coop-sync` VFS, which holds an exclusive OPFS `SyncAccessHandle`. Only one JavaScript context can hold it at a time. When a second tab opens, the cooperative handoff via `BroadcastChannel` fails under Chrome's background-tab throttling (30s+ delays), causing `ErrDBInitTimeout`.
+
+## Why SharedWorker Doesn't Solve It
+
+PR #1234 attempted to fix this by placing the SQLite database directly inside a `SharedWorker`. The idea: one SharedWorker instance shared across all tabs holds the OPFS lock permanently, and each tab connects via a `MessagePort`.
+
+This approach is fundamentally flawed:
+
+1. **`createSyncAccessHandle()` is spec-restricted to `DedicatedWorkerGlobalScope`**. The [File System Access spec](https://fs.spec.whatwg.org/#api-filesystemfilehandle) explicitly excludes `SharedWorkerGlobalScope`. As the wa-sqlite maintainer explains: "Ideally the database could go into a SharedWorker but unfortunately that won't work because OPFS `FileSystemSyncAccessHandle` isn't available in SharedWorker."
+
+2. **Firefox fails immediately** -- the PR's own compatibility table shows Firefox falls back to `DedicatedWorker`, meaning the multi-tab fix is not applied there.
+
+3. **Chrome may work today under `crossOriginIsolated=true`** (with COOP/COEP headers), but this is non-spec behaviour that could be reverted. It also restricts cross-origin resource loading (book covers, ISBN APIs).
+
+4. **Playwright headless Chromium fails** -- making the fix untestable in CI without falling back to `DedicatedWorker`.
+
+In every fallback case, we're back to the original lock contention problem.
+
+## The Shared Service Pattern
+
+The correct approach, outlined in [wa-sqlite discussion #81](https://github.com/rhashimoto/wa-sqlite/discussions/81) and its [demo](https://github.com/rhashimoto/wa-sqlite/tree/master/demo/SharedService), keeps the database in a **DedicatedWorker** (where `createSyncAccessHandle` is guaranteed) and multiplexes all tabs' requests to it via leader election.
+
+### Architecture
+
+```
+Tab 1 (leader)     Tab 2 (client)     Tab 3 (client)
+  |                   |                   |
+  | owns              | MessagePort       | MessagePort
+  v                   | (via relay)       | (via relay)
+DedicatedWorker  <----+-------------------+
+  |
+  +-- SQLite DB (OPFS SyncAccessHandle)
+  +-- SyncRuntime (embedded in same worker)
+```
+
+Three Web APIs coordinate:
+
+| API | Role |
+|-----|------|
+| **Web Locks** | Leader election -- `navigator.locks.request('librocco-db-<name>')`. Exactly one tab wins; others queue. Auto-promotes when leader tab closes. |
+| **BroadcastChannel** | Signaling -- leader announces itself; client tabs request `MessagePort`s. |
+| **SharedWorker** (~20 lines) | Port-forwarding relay -- routes `MessagePort`s from leader to clients. (BroadcastChannel can't transfer ports.) Falls back to ServiceWorker or BroadcastChannel-only on Android. |
+
+The SharedWorker here is a trivial relay -- it forwards ports, not runs SQLite.
+
+### Leader Migration
+
+When the leader tab closes:
+
+1. Web Lock auto-releases, next queued tab becomes leader
+2. New leader spawns a fresh DedicatedWorker (opens same OPFS file)
+3. Announces itself via BroadcastChannel
+4. Client tabs get new MessagePorts routed to the new worker
+5. Client tabs re-initialize their DB connection (see below)
+
+## Why This Is Simpler Than It Looks (in our context)
+
+Several properties of the librocco codebase make leader migration tractable:
+
+### 1. Sync lives inside the DB worker
+
+`SyncRuntime` and `SharedConnectionSyncDB` are embedded in the same `DedicatedWorker` as SQLite (`worker-db.worker.ts`). One worker = one unit to migrate. No need to coordinate separate workers.
+
+### 2. All DB access is already Comlink-over-MessagePort
+
+The main thread never touches SQLite directly. Every `db.execO()`, `db.tx()`, etc. is a Comlink RPC call over a `MessagePort`. Adding another hop (via the relay) is transparent to callers.
+
+### 3. Transactions are fully worker-contained
+
+`db.tx(callback)` executes entirely inside the worker. No transaction state leaks across the Comlink boundary. When the worker dies, any in-flight transaction either completed or didn't -- there's no half-committed state visible to the main thread.
+
+### 4. cr-sqlite is a CRDT
+
+Changes are conflict-free and idempotent. A transaction lost during migration can be safely retried without risk of duplication. The sync protocol will catch up from the server regardless.
+
+### 5. OPFS persists across worker death
+
+The database file survives worker termination. The new leader opens the same file and picks up where the old one left off. No data loss.
+
+### 6. The app already has a re-initialization state machine
+
+`AppDb` (Null -> Loading -> Ready) handles full DB initialization including schema checks and sync startup. Rather than trying to transparently hot-swap the Comlink proxy (which would require re-preparing statements, refreshing the mutex, re-wiring event subscriptions), we re-run the init sequence. It's fast because the DB already exists on OPFS.
+
+## Implementation Plan
+
+### Step 1: SharedService relay (~150-200 lines)
+
+A generic `SharedService` class (no librocco-specific logic) that:
+
+- Acquires a named Web Lock for leader election
+- Broadcasts provider announcements on a `BroadcastChannel`
+- Uses a tiny SharedWorker (~20 lines) to forward `MessagePort`s between tabs
+- Emits a `"provider-change"` event when leadership changes
+- Exposes `activate()` / `deactivate()` / `close()` lifecycle
+
+Reference implementations exist: the [wa-sqlite demo](https://github.com/rhashimoto/wa-sqlite/tree/master/demo/SharedService), [Matt-TOTW/shared-service](https://github.com/Matt-TOTW/shared-service), and [sampbarrow/observable-worker](https://github.com/sampbarrow/observable-worker).
+
+### Step 2: Multi-port support in the DedicatedWorker
+
+`worker-db.worker.ts` currently does `Comlink.expose(db)` on `self` (the single port). Change it to accept incoming `MessagePort`s and `Comlink.expose(db, port)` on each one. The leader tab sends a "new-client" message with a `MessagePort`; the worker exposes the DB on it.
+
+### Step 3: Modify `worker-db.ts` -- two paths
+
+```
+getWorkerDB(dbname, vfs)
++-- SharedService.activate()       // participate in leader election
++-- Am I the leader?
+|   +-- YES: spawn DedicatedWorker, register port factory with SharedService
+|   +-- NO:  get MessagePort via SharedService relay -> leader's worker
++-- Comlink.wrap(port)             // same as today, same WorkerDB class
+```
+
+The `WorkerDB` class stays almost unchanged. The existing `teardown: () => void` abstraction already decouples it from the specific cleanup mechanism.
+
+### Step 4: Migration handler
+
+Wire the SharedService `"provider-change"` event to the app layer:
+
+1. SharedService fires `"provider-change"`
+2. `worker-db.ts` closes the stale port
+3. `AppDb` state -> `Loading` (existing state machine)
+4. Re-runs `initializeDb()` -> `getWorkerDB()` (connects to new leader's worker)
+5. Sync restarts via existing `initializeSync()` flow
+6. `AppDb` state -> `Ready`, splash screen dismissed
+
+This is safe because:
+
+- In-flight Comlink calls reject with a port-closed error -- callers see a transient failure during the brief re-init window
+- `db.tx()` either completed before the worker died or didn't -- CRDT idempotency means retry is safe
+- Sync's `@vlcn.io/ws-client` already handles connection drops and re-syncs from last-seen version
+- Prepared statements and the mutex are re-created during init
+
+### Step 5: Tests
+
+| Scenario | What it verifies |
+|----------|------------------|
+| 2 tabs open | Both reach `db_ready` without timeout |
+| Close leader tab | Client tab auto-promotes, spawns new worker, reaches `db_ready` |
+| 3 tabs, close leader | Both remaining tabs recover |
+| Reload leader tab | New leader elected, other tabs recover |
+
+## What Is NOT Needed
+
+- **Transaction ID / idempotency tables** -- cr-sqlite's CRDT semantics already handle duplicate writes. The `crsql_changes` table is conflict-free by design.
+- **Transparent proxy hot-swap** -- Re-initialization via the existing `AppDb` state machine is simpler and more robust than keeping the same `WorkerDB` instance alive across migrations.
+- **COOP/COEP headers** -- `createSyncAccessHandle` runs in a DedicatedWorker where it's guaranteed to work. No `crossOriginIsolated` needed. No cross-origin resource loading restrictions.
+- **Complex connection state recovery** -- No temp tables or ATTACHed databases to re-establish. The only persistent state is the OPFS file.
+
+## Risk Assessment
+
+| Area | Risk | Mitigation |
+|------|------|------------|
+| Migration during sync changeset application | Transaction in worker may be mid-commit | Worker death = transaction rolled back by OS. New leader re-syncs from server via last-seen tracking. |
+| Brief UX flash on migration | Splash screen re-appears (~100-200ms) | Init from existing OPFS DB is fast. Could add a lightweight "reconnecting" state instead of full splash. |
+| Android (no SharedWorker) | Port-forwarding relay unavailable | BroadcastChannel-only fallback (messages go to all tabs, heavier but functional), or ServiceWorker relay. |
+| In-flight Comlink calls during migration | Calls reject with port-closed error | Callers already handle async errors. Could add retry-once wrapper at the `WorkerDB` level. |
+
+## References
+
+- [wa-sqlite discussion #81: "Using a shared Worker (instead of SharedWorker)"](https://github.com/rhashimoto/wa-sqlite/discussions/81)
+- [wa-sqlite SharedService demo](https://github.com/rhashimoto/wa-sqlite/tree/master/demo/SharedService)
+- [wa-sqlite SharedService-sw demo (ServiceWorker variant)](https://github.com/rhashimoto/wa-sqlite/tree/master/demo/SharedService-sw)
+- [File System Access spec: createSyncAccessHandle](https://fs.spec.whatwg.org/#api-filesystemfilehandle) (DedicatedWorker only)


### PR DESCRIPTION
Replaces the SharedWorker-based approach from #1234 with the "shared service" pattern from the [wa-sqlite community](https://github.com/rhashimoto/wa-sqlite/discussions/81). The core problem: `createSyncAccessHandle()` is spec-restricted to DedicatedWorkerGlobalScope, so placing SQLite inside a SharedWorker is not viable cross-browser.

Instead, one tab wins a Web Lock and becomes the leader, owning the DedicatedWorker + OPFS handle. Other tabs get MessagePorts routed to that worker through a tiny SharedWorker relay (which only forwards ports, never touches SQLite). When the leader tab closes, the lock auto-releases and the next queued tab takes over.

- Architecture doc: [docs/architecture/08-multi-tab-shared-service.md](vscode-webview://1med9eop470agnr39v85qisdjlg8mp5l4i478664rcachektieir/docs/architecture/08-multi-tab-shared-service.md)
- Supersedes: #1234

**What changed**
- `shared-service.ts` — Generic SharedService class: Web Locks leader election, BroadcastChannel signaling, port distribution via relay
- `shared-service-relay.worker.ts` — ~45-line SharedWorker that routes MessagePorts between tabs by clientId
worker-db.ts — Rewritten with two paths: getSharedServiceDB (production multi-tab) and getDedicatedWorkerDB (iOS Safari / test fallback)
- `worker-db.worker.ts` — Accepts client-port messages to expose the DB on additional MessagePorts via Comlink
Renamed terminateAllWorkers → disconnectAllPorts across init.ts, debug-export.ts, +layout.svelte
- Added `multi-tab.spec.ts` which tests the following cases:
    - two & three tabs open the same DB - both reach `db_ready`
    - closing tab1 does not break tab2
    - reloading a tab reconnects within timeout
    - note created in tab1 appears in tab2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-tab browser support with cross-tab data synchronization and automatic provider failover.

* **Tests**
  * Added comprehensive end-to-end test suite covering multi-tab initialization, tab closure, page reload, and data reactivity scenarios.

* **Documentation**
  * Added architecture documentation describing the multi-tab implementation pattern and shared service design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->