### PR TITLE
feat(sentry): update config

### DIFF
--- a/.github/workflow.templates/pyinstaller-build.yml
+++ b/.github/workflow.templates/pyinstaller-build.yml
@@ -133,6 +133,12 @@ jobs:
       - name: Build web-client for root path
         run: cd apps/web-client && rushx build:prod-rootdir
         shell: bash
+        env:
+          SENTRY_ORG: codemyriad
+          SENTRY_PROJECT: librocco
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+          PUBLIC_SENTRY_ENVIRONMENT: bookstore
 
       #! Install Python launcher dependencies (needed for build scripts)
       #! Use uv-managed Python to ensure dev headers are available

--- a/.github/workflow.templates/pyinstaller-build.yml
+++ b/.github/workflow.templates/pyinstaller-build.yml
@@ -138,7 +138,7 @@ jobs:
           SENTRY_PROJECT: librocco
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
-          PUBLIC_SENTRY_ENVIRONMENT: bookstore
+          PUBLIC_SENTRY_ENVIRONMENT: production
 
       #! Install Python launcher dependencies (needed for build scripts)
       #! Use uv-managed Python to ensure dev headers are available

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -202,11 +202,11 @@ jobs:
         run: cd apps/web-client && rushx build:prod
         env:
           BASE_PATH: /${{ github.head_ref || github.ref_name }}
-          SENTRY_ORG: code-myriad
+          SENTRY_ORG: codemyriad
           SENTRY_PROJECT: librocco
-          SENTRY_URL: https://sentry.libroc.co
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+          PUBLIC_SENTRY_ENVIRONMENT: preview
       -  #@ install_and_configure_rclone()
       -  #@ upload_to_r2("apps/web-client/build/", "${{ github.head_ref || github.ref_name }}/")
       - name: Output link to deployed app
@@ -276,11 +276,11 @@ jobs:
         run: cd apps/web-client && rushx build:prod
         env:
           BASE_PATH: "/demo"
-          SENTRY_ORG: code-myriad
+          SENTRY_ORG: codemyriad
           SENTRY_PROJECT: librocco
-          SENTRY_URL: https://sentry.libroc.co
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+          PUBLIC_SENTRY_ENVIRONMENT: demo
           PUBLIC_IS_DEMO: "true"
           PUBLIC_DEMO_DB_URL: "https://librocco.codemyriad.io/demo_db.sqlite3"
       -  #@ install_and_configure_rclone()

--- a/.github/workflows/pyinstaller-build.yml
+++ b/.github/workflows/pyinstaller-build.yml
@@ -111,6 +111,12 @@ jobs:
     - name: Build web-client for root path
       run: cd apps/web-client && rushx build:prod-rootdir
       shell: bash
+      env:
+        SENTRY_ORG: codemyriad
+        SENTRY_PROJECT: librocco
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+        PUBLIC_SENTRY_ENVIRONMENT: bookstore
     - name: Create virtual environment and install launcher
       run: |
         cd python-apps/launcher

--- a/.github/workflows/pyinstaller-build.yml
+++ b/.github/workflows/pyinstaller-build.yml
@@ -116,7 +116,7 @@ jobs:
         SENTRY_PROJECT: librocco
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
-        PUBLIC_SENTRY_ENVIRONMENT: bookstore
+        PUBLIC_SENTRY_ENVIRONMENT: production
     - name: Create virtual environment and install launcher
       run: |
         cd python-apps/launcher

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -547,11 +547,11 @@ jobs:
       run: cd apps/web-client && rushx build:prod
       env:
         BASE_PATH: /${{ github.head_ref || github.ref_name }}
-        SENTRY_ORG: code-myriad
+        SENTRY_ORG: codemyriad
         SENTRY_PROJECT: librocco
-        SENTRY_URL: https://sentry.libroc.co
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+        PUBLIC_SENTRY_ENVIRONMENT: preview
     - name: Install and configure rclone for R2
       run: |
         wget -q https://downloads.rclone.org/v1.71.1/rclone-v1.71.1-linux-amd64.zip
@@ -701,11 +701,11 @@ jobs:
       run: cd apps/web-client && rushx build:prod
       env:
         BASE_PATH: /demo
-        SENTRY_ORG: code-myriad
+        SENTRY_ORG: codemyriad
         SENTRY_PROJECT: librocco
-        SENTRY_URL: https://sentry.libroc.co
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         PUBLIC_SENTRY_DSN: ${{ secrets.PUBLIC_SENTRY_DSN }}
+        PUBLIC_SENTRY_ENVIRONMENT: demo
         PUBLIC_IS_DEMO: "true"
         PUBLIC_DEMO_DB_URL: https://librocco.codemyriad.io/demo_db.sqlite3
     - name: Install and configure rclone for R2

--- a/apps/web-client/src/hooks.client.ts
+++ b/apps/web-client/src/hooks.client.ts
@@ -1,9 +1,12 @@
 import { init, handleErrorWithSentry } from "@sentry/sveltekit";
 import { PUBLIC_SENTRY_DSN } from "$env/static/public";
+import { env } from "$env/dynamic/public";
 
 if (PUBLIC_SENTRY_DSN) {
 	init({
 		dsn: PUBLIC_SENTRY_DSN,
+		release: import.meta.env.VITE_GIT_SHA,
+		environment: env.PUBLIC_SENTRY_ENVIRONMENT || undefined,
 		tracesSampleRate: 0.1
 	});
 }

--- a/apps/web-client/vite.config.js
+++ b/apps/web-client/vite.config.js
@@ -31,7 +31,12 @@ const config = {
 		"import.meta.env.VITE_PKG_VERSION": `"${pkg.version}"`
 	},
 	plugins: [
-		process.env.SENTRY_AUTH_TOKEN && sentrySvelteKit(),
+		process.env.SENTRY_AUTH_TOKEN &&
+			sentrySvelteKit({
+				sourceMapsUploadOptions: {
+					release: { name: process.env.VITE_GIT_SHA }
+				}
+			}),
 		sveltekit(),
 		{
 			name: "configure-response-headers",


### PR DESCRIPTION
- Wire Sentry env into pyinstaller-build workflow so the launcher's web-client build uploads source maps and ships with the runtime DSN, tagged environment=bookstore. This is the missing piece for D-214.
- Refresh preview/demo deploy jobs: SENTRY_ORG code-myriad -> codemyriad, drop stale self-hosted SENTRY_URL (now SaaS), add PUBLIC_SENTRY_ENVIRONMENT per surface.
- hooks.client.ts: tag events with release (VITE_GIT_SHA) and environment.
- vite.config.js: pass the matching release name to the sentrySvelteKit plugin so source-map symbolication lines up with runtime events.