### PR TITLE
feat(sync-server): surface negative committed stock as a /health warning (D-296)

### DIFF
--- a/apps/sync-server/src/db-health.test.ts
+++ b/apps/sync-server/src/db-health.test.ts
@@ -59,6 +59,31 @@ function createCorruptDb(name: string): string {
 	return dbPath;
 }
 
+// Creates a minimal librocco-shaped DB (note + book_transaction CRRs) with a
+// committed inbound of +5 and a committed outbound sale. With `outboundQty` > 5
+// the derived stock for the (isbn, warehouse) pair goes negative.
+function createDbWithStock(name: string, outboundQty: number): string {
+	const dbPath = path.join(TEST_DIR, name);
+	const db = new Database(dbPath);
+	db.loadExtension(extensionPath);
+	db.exec(`
+		CREATE TABLE note (id INTEGER PRIMARY KEY NOT NULL, warehouse_id INTEGER, is_reconciliation_note INTEGER DEFAULT 0, committed INTEGER NOT NULL DEFAULT 0);
+		CREATE TABLE book_transaction (isbn TEXT NOT NULL, quantity INTEGER NOT NULL DEFAULT 0, note_id INTEGER NOT NULL, warehouse_id INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (isbn, note_id, warehouse_id));
+		SELECT crsql_as_crr('note');
+		SELECT crsql_as_crr('book_transaction');
+	`);
+	// committed inbound +5 into warehouse 1
+	db.exec(`INSERT INTO note (id, warehouse_id, committed) VALUES (1, 1, 1);`);
+	db.exec(`INSERT INTO book_transaction (isbn, quantity, note_id, warehouse_id) VALUES ('111', 5, 1, 1);`);
+	// committed outbound sale of `outboundQty` from warehouse 1
+	db.exec(`INSERT INTO note (id, warehouse_id, committed) VALUES (2, NULL, 1);`);
+	db.exec(`INSERT INTO book_transaction (isbn, quantity, note_id, warehouse_id) VALUES ('111', ${outboundQty}, 2, 1);`);
+	db.exec(`INSERT OR REPLACE INTO crsql_master (key, value) VALUES ('schema_name', 'init');`);
+	db.exec(`INSERT OR REPLACE INTO crsql_master (key, value) VALUES ('schema_version', '1');`);
+	db.close();
+	return dbPath;
+}
+
 describe("Database Health Check", () => {
 	beforeEach(() => {
 		cleanup();
@@ -209,5 +234,42 @@ describe("Sync Server Startup", () => {
 
 		expect(formatted).toContain("Restore from a backup");
 		expect(formatted).toContain("Delete the corrupted database");
+	});
+
+	describe("negative_stock check (D-296)", () => {
+		it("flags negative committed stock as a WARNING without marking the database unhealthy", () => {
+			// outbound 8 from a warehouse holding only 5 => derived stock -3
+			const dbPath = createDbWithStock("negative.sqlite3", 8);
+			const result = checkDatabaseHealth(dbPath, extensionPath);
+
+			const check = result.checks.find((c) => c.name === "negative_stock");
+			expect(check).toBeDefined();
+			expect(check!.passed).toBe(false);
+			expect(check!.severity).toBe("warning");
+			expect(check!.message).toContain("111@wh1=-3");
+
+			// A warning must NOT make the DB unhealthy (would block startup / 503 /health).
+			expect(result.ok).toBe(true);
+		});
+
+		it("passes the negative_stock check for balanced stock", () => {
+			// outbound 2 from a warehouse holding 5 => derived stock +3
+			const dbPath = createDbWithStock("balanced.sqlite3", 2);
+			const result = checkDatabaseHealth(dbPath, extensionPath);
+
+			const check = result.checks.find((c) => c.name === "negative_stock");
+			expect(check!.passed).toBe(true);
+			expect(result.ok).toBe(true);
+		});
+
+		it("skips the negative_stock check gracefully for a non-librocco schema", () => {
+			// createHealthyDb only has a `test` table, no note/book_transaction.
+			const dbPath = createHealthyDb("plain.sqlite3");
+			const result = checkDatabaseHealth(dbPath, extensionPath);
+
+			const check = result.checks.find((c) => c.name === "negative_stock");
+			expect(check!.passed).toBe(true); // skipped, not failed
+			expect(result.ok).toBe(true);
+		});
 	});
 });

--- a/apps/sync-server/src/db-health.ts
+++ b/apps/sync-server/src/db-health.ts
@@ -222,9 +222,10 @@ export function checkDatabaseHealth(dbPath: string, extensionPath: string): Heal
 				let maxDbVersion = 0n;
 
 				for (const table of tables) {
-					const stats = db
-						.prepare(`SELECT COUNT(*) as count, MAX(db_version) as max_v FROM "${table.name}"`)
-						.get() as { count: number; max_v: bigint | null };
+					const stats = db.prepare(`SELECT COUNT(*) as count, MAX(db_version) as max_v FROM "${table.name}"`).get() as {
+						count: number;
+						max_v: bigint | null;
+					};
 					totalClockEntries += stats.count;
 					if (stats.max_v && stats.max_v > maxDbVersion) {
 						maxDbVersion = stats.max_v;
@@ -243,6 +244,56 @@ export function checkDatabaseHealth(dbPath: string, extensionPath: string): Heal
 				name: "clock_tables_exist",
 				passed: false,
 				message: `Failed to check clock tables: ${err instanceof Error ? err.message : String(err)}`,
+				severity: "warning"
+			});
+		}
+
+		// Check 8: Negative derived stock invariant.
+		// Stock in librocco is derived as SUM(+inbound/+reconciliation, -outbound) per
+		// (isbn, warehouse_id) over committed notes; physical stock can never be < 0.
+		// A negative sum means the ledger is unbalanced (e.g. a warehouse with committed
+		// sales was deleted, stranding the outbound (-) lines with no matching inbound —
+		// see D-293/D-217). Surfaced as a WARNING so it shows up in /health for monitoring
+		// (D-296) without blocking startup or marking the DB unhealthy.
+		try {
+			const signedSum = "SUM(CASE WHEN n.warehouse_id IS NOT NULL OR n.is_reconciliation_note = 1 THEN bt.quantity ELSE -bt.quantity END)";
+			const negatives = db
+				.prepare(
+					`SELECT bt.isbn AS isbn, bt.warehouse_id AS warehouseId, ${signedSum} AS quantity
+					 FROM book_transaction bt
+					 JOIN note n ON bt.note_id = n.id
+					 WHERE n.committed = 1
+					 GROUP BY bt.isbn, bt.warehouse_id
+					 HAVING ${signedSum} < 0
+					 ORDER BY quantity ASC`
+				)
+				.all() as { isbn: string; warehouseId: number; quantity: number }[];
+
+			if (negatives.length === 0) {
+				checks.push({
+					name: "negative_stock",
+					passed: true,
+					message: "No negative committed stock",
+					severity: "warning"
+				});
+			} else {
+				const sample = negatives
+					.slice(0, 5)
+					.map((r) => `${r.isbn}@wh${r.warehouseId}=${r.quantity}`)
+					.join(", ");
+				checks.push({
+					name: "negative_stock",
+					passed: false,
+					message: `${negatives.length} (isbn, warehouse) pair(s) have negative committed stock: ${sample}${negatives.length > 5 ? ", …" : ""}`,
+					severity: "warning"
+				});
+			}
+		} catch (err) {
+			// note / book_transaction not present (non-librocco DB) -> skip gracefully.
+			checks.push({
+				name: "negative_stock",
+				passed: true,
+				message: `Negative-stock check skipped: ${err instanceof Error ? err.message : String(err)}`,
 				severity: "warning"
 			});
 		}
@@ -322,7 +373,11 @@ export function formatHealthCheckResults(results: Map<string, HealthCheckResult>
 		lines.push(`${BOLD}Database: ${dbName}${RESET} ${statusIcon}`);
 
 		for (const check of result.checks) {
-			const checkIcon = check.passed ? `${GREEN}[PASS]${RESET}` : check.severity === "error" ? `${RED}[FAIL]${RESET}` : `${YELLOW}[WARN]${RESET}`;
+			const checkIcon = check.passed
+				? `${GREEN}[PASS]${RESET}`
+				: check.severity === "error"
+					? `${RED}[FAIL]${RESET}`
+					: `${YELLOW}[WARN]${RESET}`;
 			lines.push(`  ${checkIcon} ${check.name}: ${check.message}`);
 		}
 		lines.push("");


### PR DESCRIPTION
## Why
Investigation of the negative-stock incident (Linear **D-217**/**D-293**) showed the cheapest, highest-value detector for the whole class is a **negative committed-stock invariant** — and it already fires on production today. This wires that invariant into the sync server so a recurrence is caught automatically instead of when the shop phones.

## What
Adds a `negative_stock` check to `checkDatabaseHealth`. Stock is derived as `SUM(+inbound/+reconciliation, −outbound)` per `(isbn, warehouse_id)` over committed notes; physical stock can never be `< 0`. A negative sum means the ledger is unbalanced — e.g. a warehouse with committed sales was deleted, stranding the outbound (−) lines with no matching inbound (D-293/D-217).

It surfaces in `GET /health` and `GET /:db/health` (each lists per-check `passed`/`severity`/`message`), so an external monitor (Uptime Kuma keyword match on the body) can alert.

### Deliberately a WARNING, not an error
`ok` is computed only from `error`-severity failures, and startup exits / `/health` returns 503 only when `!ok`. A data imbalance must **not** stop the shop or refuse startup, so this is `severity: "warning"`: visible to monitoring, invisible to availability. It also **skips gracefully** on non-librocco DBs (no `note`/`book_transaction` table).

## Testing
- `rushx test:ci` (sync-server): **28 passed**, including 3 new cases — negative (warning, db still `ok`), balanced (passes), and graceful-skip on a non-librocco schema.
- `tsc --noEmit`: no new errors in the changed files. prettier-clean.

Pairs with the read-layer clamp in #1243 (which stops the cashier *seeing* negatives) — this PR makes the underlying imbalance *observable*.

Refs: D-296, D-293, D-217

🤖 Generated with [Claude Code](https://claude.com/claude-code)