### PR TITLE
fix(sync-server): vendor ws-server gap-recovery fix (D-302)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "3rd-party/js"]
 	path = 3rd-party/js
-	url = git@github.com:vlcn-io/js
-	branch = wa-sqlite-updates
+	url = git@github.com:librocco/vlcn-js
+	branch = main
 [submodule "3rd-party/typed-sql"]
 	path = 3rd-party/typed-sql
 	url = git@github.com:vlcn-io/typed-sql

--- a/3rd-party/artefacts/version-cached.txt
+++ b/3rd-party/artefacts/version-cached.txt
@@ -1,2 +1,2 @@
-js repo hash: 435b75d4d9b499c89ff10b9e12e44c305643971d
+js repo hash: e99c5d700a7e4da9712ab10be1249a296cf72384
 typed-sql repo hash: bed447324d1d078d30eedc73504ac99e7874fe31

--- a/3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
+++ b/3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:077381934b69cc9957abb732caa9c603d7f0a01d31a4f157f1b07780abcef6d0
-size 42143
+oid sha256:61dbddbdf612f2e64544b0f90448a53dff88ebc6258601068d511d678db844d8
+size 42342

--- a/3rd-party/artefacts_version.txt
+++ b/3rd-party/artefacts_version.txt
@@ -1,2 +1,2 @@
-js repo hash: 435b75d4d9b499c89ff10b9e12e44c305643971d
+js repo hash: e99c5d700a7e4da9712ab10be1249a296cf72384
 typed-sql repo hash: bed447324d1d078d30eedc73504ac99e7874fe31

--- a/apps/sync-server/src/ws-server-reject-recovery.test.ts
+++ b/apps/sync-server/src/ws-server-reject-recovery.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for the gap-recovery fix in @vlcn.io/ws-server (Linear D-302).
+ *
+ * Like peer-coherence.test.ts, this runs against the *installed* ws-server
+ * tarball (not the submodule source), so an artefact that was rebuilt without
+ * the fix — or never rebuilt — fails CI here.
+ *
+ * The bug: OutboundStream.reset() was a no-op. When a peer detects a gap and
+ * sends RejectChanges, the server must rewind its cursor and re-send the missing
+ * range; otherwise a peer that falls behind mid-connection silently and
+ * permanently diverges (the mechanism behind D-217).
+ */
+
+import { test, expect } from "vitest";
+import OutboundStream from "@vlcn.io/ws-server/dist/streams/OutboundStream.js";
+
+// A crsql_changes row tuple: [table, pk, cid, val, col_version, db_version, site_id, cl, seq].
+// OutboundStream only reads index 5 (db_version).
+const change = (dbVersion: bigint): any => ["item", new Uint8Array([1]), "v", null, 1n, dbVersion, null, 1n, 0];
+
+test("ws-server OutboundStream.reset() rewinds and re-sends after a peer rejects a gap (installed tarball)", () => {
+	// Minimal IDB: OutboundStream only uses siteId, onChange, pullChangeset.
+	const db: any = {
+		siteId: new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]),
+		onChange: () => () => {},
+		pullChangeset: (since: readonly [bigint, number]) => [change(1n), change(2n), change(3n)].filter((c) => c[5] > since[0])
+	};
+	const sent: any[] = [];
+	const transport: any = {
+		sendChanges: (msg: any) => {
+			sent.push(msg);
+			return "sent";
+		}
+	};
+
+	const stream = new (OutboundStream as any)(transport, db, [], new Uint8Array([1, 2, 3, 4]));
+	stream.start(); // initial kickoff sends db_version 1,2,3 and advances the cursor to 3
+	expect(sent).toHaveLength(1);
+
+	// Peer only applied up to db_version 1 (batch 2/3 lost) and rejects, asking to resume from [1, 0].
+	// tag 3 == tags.RejectChanges.
+	stream.reset({ _tag: 3, whose: db.siteId, since: [1n, 0] });
+
+	// Must rewind and re-send the missing changes. If reset() were still a no-op this would be 1.
+	expect(sent).toHaveLength(2);
+	expect(sent[1].since).toEqual([1n, 0]);
+	expect(sent[1].changes.map((c: any) => c[5])).toEqual([2n, 3n]);
+});


### PR DESCRIPTION
## What
Brings the sync server's vendored `@vlcn.io/ws-server` up to include the **OutboundStream gap-recovery fix** (fork PR [librocco/vlcn-js#1](https://github.com/librocco/vlcn-js/pull/1), merged).

`OutboundStream.reset()` was a no-op, so when a peer detected a gap and sent `RejectChanges`, the server never rewound or re-sent — a peer that fell behind mid-connection then silently and permanently diverged while still reporting "synced". This is the delivery-layer mechanism behind the negative-stock incident (**D-217**); it was diagnosed by comparing two live replicas, which differed by ~36k changes yet converged once the missing changes were supplied (i.e. a delivery gap, not a CRDT merge bug).

## Changes
- `3rd-party/artefacts/vlcn.io-ws-server-0.2.2.tgz` — rebuilt with the fix (and uploaded to the R2 artefact store, keyed by its new sha256, so CI can pull it).
- `3rd-party/js` — repointed at `librocco/vlcn-js@main` (`e99c5d7`); updates `artefacts_version.txt` / `version-cached.txt`. Also corrects a pre-existing skew where the submodule referenced `vlcn-io/js` upstream while the artefacts already carried librocco's forked fixes.
- `pnpm-lock.yaml` — refreshed via `rush update`.
- `apps/sync-server/src/ws-server-reject-recovery.test.ts` — installed-tarball regression test (same pattern as `peer-coherence.test.ts`) so a stale/un-rebuilt artefact fails CI.

## Testing
- `rushx test:ci` (sync-server): **26 passed**, including the new regression test and the existing `peer-coherence` installed-tarball test.
- Fork change verified red→green in isolation against the real `OutboundStream` source.

Server-only; clients already send `RejectChanges` correctly. Deploying needs only the sync server. A separate data-cleanup (orphaned wh-0 rows from D-293) is tracked independently.

Refs: D-302, D-217, D-293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated submodule configuration for JavaScript dependencies and refreshed cached version hashes.
  * Updated Git LFS pointers for archived third-party artefacts with new references.

* **Tests**
  * Added regression test to verify correct synchronisation recovery behaviour when peers detect gaps in change streams and request resynchronisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->