### PR TITLE
fix: delete warehouse stock symmetrically to avoid phantom negatives

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
@@ -4,6 +4,7 @@ import { getRandomDb } from "./lib";
 
 import { upsertWarehouse, getAllWarehouses, getWarehouseById, getWarehouseIdSeq, deleteWarehouse } from "../warehouse";
 import { addVolumesToNote, createAndCommitReconciliationNote, createInboundNote, createOutboundNote, commitNote } from "../note";
+import { getStock } from "../stock";
 
 describe("Warehouse tests", () => {
 	it("creates a new warehouse, using only id, with default fields", async () => {
@@ -111,6 +112,42 @@ describe("Warehouse tests", () => {
 		// Verify the warehouse is deleted
 		res = await getAllWarehouses(db);
 		expect(res).toEqual([]);
+	});
+
+	it("deleting a warehouse removes its stock symmetrically, leaving no phantom negative stock", async () => {
+		const db = await getRandomDb();
+
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse A" });
+		await upsertWarehouse(db, { id: 2, displayName: "Warehouse B" });
+
+		// Same ISBN stocked in both warehouses
+		await createInboundNote(db, 1, 1);
+		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 10, warehouseId: 1 });
+		await commitNote(db, 1);
+
+		await createInboundNote(db, 2, 2);
+		await addVolumesToNote(db, 2, { isbn: "1111111111", quantity: 5, warehouseId: 2 });
+		await commitNote(db, 2);
+
+		// A committed sale sourced from warehouse 1. Its book_transaction carries warehouse_id = 1
+		// while the (outbound) note has warehouse_id IS NULL, so it counts as -3 against warehouse 1.
+		// Warehouse 1 nets 10 - 3 = 7; warehouse 2 holds 5.
+		await createOutboundNote(db, 3);
+		await addVolumesToNote(db, 3, { isbn: "1111111111", quantity: 3, warehouseId: 1 });
+		await commitNote(db, 3);
+
+		await deleteWarehouse(db, 1);
+
+		const stock = await getStock(db);
+
+		// All of warehouse 1's legs (the +10 inbound AND the -3 outbound) must be removed together.
+		// Only warehouse 2's 5 should remain.
+		expect(stock).toEqual([expect.objectContaining({ isbn: "1111111111", warehouseId: 2, quantity: 5 })]);
+
+		// The bug: the outbound leg is reassigned to the sentinel warehouse 0 instead of being
+		// removed, leaving a phantom { warehouseId: 0, quantity: -3 } behind.
+		expect(stock.some((s) => s.quantity < 0)).toBe(false);
+		expect(stock.some((s) => s.warehouseId === 0)).toBe(false);
 	});
 
 	it("reflects the total stock in each respective warehouse", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { getRandomDb } from "./lib";
 
 import { upsertWarehouse, getAllWarehouses, getWarehouseById, getWarehouseIdSeq, deleteWarehouse } from "../warehouse";
-import { addVolumesToNote, createAndCommitReconciliationNote, createInboundNote, createOutboundNote, commitNote } from "../note";
+import { addVolumesToNote, createAndCommitReconciliationNote, createInboundNote, createOutboundNote, commitNote, getNoteEntries } from "../note";
 import { getStock } from "../stock";
 
 describe("Warehouse tests", () => {
@@ -148,6 +148,30 @@ describe("Warehouse tests", () => {
 		// removed, leaving a phantom { warehouseId: 0, quantity: -3 } behind.
 		expect(stock.some((s) => s.quantity < 0)).toBe(false);
 		expect(stock.some((s) => s.warehouseId === 0)).toBe(false);
+	});
+
+	it("deleting a warehouse unassigns (rather than deletes) draft outbound lines pointing to it", async () => {
+		const db = await getRandomDb();
+
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse A" });
+
+		await createInboundNote(db, 1, 1);
+		await addVolumesToNote(db, 1, { isbn: "1111111111", quantity: 10, warehouseId: 1 });
+		await commitNote(db, 1);
+
+		// An open (uncommitted) outbound note with a line sourced from warehouse 1
+		await createOutboundNote(db, 2);
+		await addVolumesToNote(db, 2, { isbn: "1111111111", quantity: 3, warehouseId: 1 });
+
+		await deleteWarehouse(db, 1);
+
+		// The draft line survives, but is unassigned (sentinel warehouse 0) so the user can re-pick.
+		// Deleting it outright would silently discard work-in-progress.
+		const entries = await getNoteEntries(db, 2);
+		expect(entries).toEqual([expect.objectContaining({ isbn: "1111111111", quantity: 3, warehouseId: 0 })]);
+
+		// Drafts don't count toward stock, so nothing should be left over.
+		expect(await getStock(db)).toEqual([]);
 	});
 
 	it("reflects the total stock in each respective warehouse", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
@@ -3,7 +3,14 @@ import { describe, it, expect } from "vitest";
 import { getRandomDb } from "./lib";
 
 import { upsertWarehouse, getAllWarehouses, getWarehouseById, getWarehouseIdSeq, deleteWarehouse } from "../warehouse";
-import { addVolumesToNote, createAndCommitReconciliationNote, createInboundNote, createOutboundNote, commitNote, getNoteEntries } from "../note";
+import {
+	addVolumesToNote,
+	createAndCommitReconciliationNote,
+	createInboundNote,
+	createOutboundNote,
+	commitNote,
+	getNoteEntries
+} from "../note";
 import { getStock } from "../stock";
 
 describe("Warehouse tests", () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -166,11 +166,13 @@ async function _getWarehouseById(db: TXAsync, id: number) {
 
 export function deleteWarehouse(db: DBAsync, id: number): Promise<void> {
 	return db.tx(async (txDb) => {
-		await txDb.exec("DELETE FROM book_transaction WHERE note_id IN (SELECT id FROM note WHERE warehouse_id = ?)", [id]);
-		await txDb.exec(
-			"UPDATE book_transaction SET warehouse_id = 0 WHERE warehouse_id = ? AND note_id IN (SELECT id FROM note WHERE warehouse_id IS NULL)",
-			[id]
-		);
+		// Remove every transaction leg tagged to this warehouse. Both the positive
+		// (inbound/reconciliation) and negative (outbound) legs carry warehouse_id = id, so
+		// deleting by warehouse_id neutralises the warehouse's entire stock contribution
+		// symmetrically. The previous code deleted only the inbound legs and reassigned the
+		// outbound legs to the sentinel warehouse 0, leaving phantom negative stock behind.
+		await txDb.exec("DELETE FROM book_transaction WHERE warehouse_id = ?", [id]);
+		// Drop the (now-empty) notes owned by this warehouse, then the warehouse itself.
 		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);
 	});

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -166,12 +166,19 @@ async function _getWarehouseById(db: TXAsync, id: number) {
 
 export function deleteWarehouse(db: DBAsync, id: number): Promise<void> {
 	return db.tx(async (txDb) => {
-		// Remove every transaction leg tagged to this warehouse. Both the positive
+		// Remove every committed transaction leg tagged to this warehouse. Both the positive
 		// (inbound/reconciliation) and negative (outbound) legs carry warehouse_id = id, so
 		// deleting by warehouse_id neutralises the warehouse's entire stock contribution
 		// symmetrically. The previous code deleted only the inbound legs and reassigned the
 		// outbound legs to the sentinel warehouse 0, leaving phantom negative stock behind.
-		await txDb.exec("DELETE FROM book_transaction WHERE warehouse_id = ?", [id]);
+		await txDb.exec("DELETE FROM book_transaction WHERE warehouse_id = ? AND note_id IN (SELECT id FROM note WHERE committed = 1)", [id]);
+		// Legs of draft notes owned by this warehouse (inbound) disappear along with their notes.
+		await txDb.exec("DELETE FROM book_transaction WHERE note_id IN (SELECT id FROM note WHERE warehouse_id = ?)", [id]);
+		// Any leg still tagged to this warehouse belongs to a draft note someone may be actively
+		// editing (e.g. an open outbound note): keep the line, just unassign it (sentinel
+		// warehouse 0) so the user can pick another warehouse. Drafts don't count toward stock,
+		// and commit validation rejects unassigned legs, so this can't reintroduce phantom stock.
+		await txDb.exec("UPDATE book_transaction SET warehouse_id = 0 WHERE warehouse_id = ?", [id]);
 		// Drop the (now-empty) notes owned by this warehouse, then the warehouse itself.
 		await txDb.exec("DELETE FROM note WHERE warehouse_id = ?", [id]);
 		await txDb.exec("DELETE FROM warehouse WHERE id = ?", [id]);


### PR DESCRIPTION
## Problem

`deleteWarehouse` removed only the **inbound** transaction legs (selected by note ownership) and then **reassigned the orphaned outbound legs to the sentinel warehouse `0`**. Those surviving negative legs surfaced as phantom **negative stock** attributed to warehouse 0.

## Fix

Both the positive (inbound / reconciliation) and negative (outbound) legs of a warehouse carry `book_transaction.warehouse_id = id`:

| note type | `note.warehouse_id` | `bt.warehouse_id` | stock sign |
|---|---|---|---|
| inbound to X | `X` | `X` | `+qty` |
| reconciliation touching X | `NULL` | `X` | `+qty` |
| outbound sold from X | `NULL` | `X` | `−qty` |

So for **committed** notes, deleting by `warehouse_id` removes the warehouse's entire stock contribution symmetrically — every `(isbn, warehouse)` group goes away together, nothing is re-tagged, and no negative quantity can be synthesised on warehouse 0 (or anywhere else). Multi-warehouse outbound/reconciliation notes keep their other-warehouse legs.

**Draft notes are the exception**: lines in an open note someone may be actively editing (e.g. an in-progress outbound note) are kept but unassigned (sentinel warehouse `0`) instead of deleted, preserving the previous UX for work-in-progress. This can't reintroduce phantom stock — drafts don't count toward stock (`getStock` filters on `committed = 1`) and commit validation rejects unassigned lines (`NoWarehouseSelectedError`).

```sql
DELETE FROM book_transaction WHERE warehouse_id = ?
  AND note_id IN (SELECT id FROM note WHERE committed = 1);  -- committed + and − legs, symmetrically
DELETE FROM book_transaction
  WHERE note_id IN (SELECT id FROM note WHERE warehouse_id = ?);  -- legs of draft notes owned by the warehouse
UPDATE book_transaction SET warehouse_id = 0 WHERE warehouse_id = ?;  -- draft lines elsewhere: unassign, don't delete
DELETE FROM note      WHERE warehouse_id = ?;
DELETE FROM warehouse WHERE id = ?;
```

## Tests

- **Regression** (red before the fix, green after): same ISBN stocked in two warehouses plus a committed outbound sourced from the deleted warehouse → after deletion only the other warehouse's stock survives, with no negative quantity and nothing on warehouse 0.
- **Draft preservation**: a line in an open outbound note pointing at the deleted warehouse survives as unassigned (`warehouseId: 0`) and contributes no stock.

The pre-existing e2e test "should show transaction with no assigned warehouse after the assigned warehouse is deleted" still passes — draft-note UX is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
