### PR TITLE
Add read-only sync server query endpoint

### DIFF
--- a/apps/sync-server/README.md
+++ b/apps/sync-server/README.md
@@ -30,6 +30,24 @@ Backup runs are reused per schema target version, so repeated failed restarts do
 - `SCHEMA_FOLDER`: schema folder path (default `./schemas`)
 - `SCHEMA_NAME`: schema file name in `SCHEMA_FOLDER` (default `init`)
 - `IS_DEV=true`: enables dev-only RPC endpoints
+- `READONLY_QUERY_API=false`: disables `POST /:dbname/readonly-query` (enabled by default)
 - `SKIP_HEALTH_CHECK=true`: disables startup health checks
 - `STARTUP_MIGRATION_BACKUP_FOLDER`: optional explicit backup folder (default `DB_FOLDER/.startup-migration-backups`)
 - `STARTUP_MIGRATION_MAX_BACKUP_RUNS`: number of backup run directories to retain (default `5`)
+
+## Read-only query API
+
+The read-only query API is enabled by default and is available at:
+
+```http
+POST /:dbname/readonly-query
+Content-Type: application/json
+
+{
+  "sql": "SELECT * FROM book WHERE updated_at > ? ORDER BY updated_at ASC",
+  "bind": [1234567890]
+}
+```
+
+The endpoint only accepts SQLite reader statements and executes them with `PRAGMA query_only = ON`.
+It exists for external integrations that need authoritative reads through the sync server's active DB connection without enabling the dev-only generic `/exec` endpoint.

--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -13,6 +13,11 @@ import { extensionPath } from "@vlcn.io/crsqlite";
 
 import { performStartupHealthCheck, checkDatabaseHealth, checkAllDatabases } from "./db-health.js";
 import { migrateDatabasesOnStartup } from "./startup-migrations.js";
+import {
+	readonlyDatabaseExists,
+	runReadonlyQuery,
+	sendReadonlyQueryError
+} from "./readonly-query.js";
 
 const IS_DEV = process.env.IS_DEV === "true";
 const SKIP_HEALTH_CHECK = process.env.SKIP_HEALTH_CHECK === "true";
@@ -20,6 +25,7 @@ const PORT = process.env.PORT || 3000;
 const DB_FOLDER = path.resolve(process.env.DB_FOLDER || "./test-dbs");
 const SCHEMA_FOLDER = path.resolve(process.env.SCHEMA_FOLDER || "./schemas");
 const SCHEMA_NAME = process.env.SCHEMA_NAME || "init";
+const READONLY_QUERY_API = (process.env.READONLY_QUERY_API ?? "true") === "true";
 const STARTUP_MIGRATION_BACKUP_FOLDER = process.env.STARTUP_MIGRATION_BACKUP_FOLDER
 	? path.resolve(process.env.STARTUP_MIGRATION_BACKUP_FOLDER)
 	: undefined;
@@ -179,6 +185,30 @@ app.post("/:dbname/exec", async (req, res) => {
 	});
 });
 
+app.post("/:dbname/readonly-query", async (req, res) => {
+	if (!READONLY_QUERY_API) {
+		return res.status(403).json({ message: "Read-only query API is disabled" });
+	}
+
+	const { sql, bind = [] } = req.body ?? {};
+	if (typeof sql !== "string" || !sql.trim()) {
+		return res.status(400).json({ message: "sql must be a non-empty string" });
+	}
+	if (!Array.isArray(bind)) {
+		return res.status(400).json({ message: "bind must be an array" });
+	}
+	if (!readonlyDatabaseExists(DB_FOLDER, req.params.dbname)) {
+		return res.status(404).json({ message: `Database not found: ${req.params.dbname}` });
+	}
+
+	try {
+		const rows = await useReadonlyDb(req.params.dbname, (db) => runReadonlyQuery(db, sql, bind));
+		return res.json({ rows });
+	} catch (err) {
+		return sendReadonlyQueryError(res, err, { dbname: req.params.dbname, sql });
+	}
+});
+
 app.get("/:dbname/meta", async (req, res) => {
 	const dbname = req.params.dbname;
 
@@ -295,6 +325,19 @@ async function runStartupMigrations(): Promise<void> {
 	} finally {
 		await startupDbCache.destroy();
 	}
+}
+
+async function useReadonlyDb<T>(dbname: string, cb: (db: any) => T): Promise<T> {
+	let result: T | undefined;
+	await dbCache.use(dbname, SCHEMA_NAME, (idb: IDB) => {
+		result = cb(idb.getDB());
+	});
+
+	if (result === undefined) {
+		throw new Error(`Database callback did not return a result for ${dbname}`);
+	}
+
+	return result;
 }
 
 function parsePositiveInteger(rawValue: string | undefined): number | undefined {

--- a/apps/sync-server/src/readonly-query.test.ts
+++ b/apps/sync-server/src/readonly-query.test.ts
@@ -1,0 +1,120 @@
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	ReadonlyQueryClientError,
+	readonlyDatabaseExists,
+	runReadonlyQuery,
+	sendReadonlyQueryError
+} from "./readonly-query.js";
+
+const TEST_DIR = "/tmp/readonly-query-test-vitest";
+
+function cleanup() {
+	if (fs.existsSync(TEST_DIR)) {
+		fs.rmSync(TEST_DIR, { recursive: true });
+	}
+	fs.mkdirSync(TEST_DIR, { recursive: true });
+}
+
+function createResponse() {
+	const response = {
+		statusCode: 200,
+		body: undefined as unknown,
+		status(code: number) {
+			this.statusCode = code;
+			return this;
+		},
+		json(body: unknown) {
+			this.body = body;
+			return this;
+		}
+	};
+
+	return response;
+}
+
+describe("readonly query helpers", () => {
+	beforeEach(() => {
+		cleanup();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("checks that the database file exists before cache access", () => {
+		expect(readonlyDatabaseExists(TEST_DIR, "missing.sqlite3")).toBe(false);
+
+		fs.writeFileSync(path.join(TEST_DIR, "current.sqlite3"), "");
+
+		expect(readonlyDatabaseExists(TEST_DIR, "current.sqlite3")).toBe(true);
+	});
+
+	it("runs read statements", () => {
+		const db = new Database(":memory:");
+		db.exec("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT); INSERT INTO book (title) VALUES ('A');");
+
+		const rows = runReadonlyQuery(db, "SELECT title FROM book", []);
+
+		expect(rows).toEqual([{ title: "A" }]);
+		db.close();
+	});
+
+	it("rejects non-reader statements as client errors", () => {
+		const db = new Database(":memory:");
+		db.exec("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT);");
+
+		expect(() => runReadonlyQuery(db, "INSERT INTO book (title) VALUES ('B')", [])).toThrow(ReadonlyQueryClientError);
+
+		db.close();
+	});
+
+	it("blocks reader statements that attempt writes", () => {
+		const db = new Database(":memory:");
+		db.exec("CREATE TABLE book (id INTEGER PRIMARY KEY, title TEXT); INSERT INTO book (title) VALUES ('A');");
+
+		expect(() => runReadonlyQuery(db, "UPDATE book SET title = 'B' RETURNING title", [])).toThrow(
+			ReadonlyQueryClientError
+		);
+		expect(db.prepare("SELECT title FROM book").pluck().get()).toBe("A");
+
+		db.close();
+	});
+
+	it("returns client errors as 400 with the underlying message", () => {
+		const res = createResponse();
+		const logger = { info: vi.fn(), error: vi.fn() };
+
+		sendReadonlyQueryError(
+			res as never,
+			new ReadonlyQueryClientError("near \"SELCT\": syntax error", { code: "SQLITE_ERROR" }),
+			{ dbname: "current.sqlite3", sql: "SELCT * FROM book" },
+			logger
+		);
+
+		expect(res.statusCode).toBe(400);
+		expect(res.body).toEqual({ message: 'near "SELCT": syntax error', code: "SQLITE_ERROR" });
+		expect(logger.info).toHaveBeenCalledOnce();
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it("returns server errors as 500 with a generic client body and server log", () => {
+		const res = createResponse();
+		const logger = { info: vi.fn(), error: vi.fn() };
+
+		sendReadonlyQueryError(
+			res as never,
+			new Error("schema version mismatch"),
+			{ dbname: "current.sqlite3", sql: "SELECT * FROM book" },
+			logger
+		);
+
+		expect(res.statusCode).toBe(500);
+		expect(res.body).toEqual({ message: "Read-only query failed" });
+		expect(logger.error).toHaveBeenCalledOnce();
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+});

--- a/apps/sync-server/src/readonly-query.ts
+++ b/apps/sync-server/src/readonly-query.ts
@@ -1,0 +1,115 @@
+import type { Response } from "express";
+import fs from "fs";
+import path from "path";
+
+interface Statement {
+	reader: boolean;
+	all: (...bind: unknown[]) => unknown[];
+}
+
+interface ReadonlyDatabase {
+	prepare: (sql: string) => Statement;
+	pragma: (sql: string) => unknown;
+}
+
+interface ReadonlyQueryLogger {
+	info: (message: string) => void;
+	error: (message: string) => void;
+}
+
+export class ReadonlyQueryClientError extends Error {
+	code: unknown;
+
+	constructor(message: string, options?: { code?: unknown; cause?: unknown }) {
+		super(message, { cause: options?.cause });
+		this.name = "ReadonlyQueryClientError";
+		this.code = options?.code;
+	}
+}
+
+export function getReadonlyDbPath(dbFolder: string, dbname: string): string {
+	return path.resolve(dbFolder, dbname);
+}
+
+export function readonlyDatabaseExists(dbFolder: string, dbname: string): boolean {
+	return fs.existsSync(getReadonlyDbPath(dbFolder, dbname));
+}
+
+export function runReadonlyQuery(db: ReadonlyDatabase, sql: string, bind: unknown[]): unknown[] {
+	let stmt: Statement;
+	try {
+		stmt = db.prepare(sql);
+	} catch (err) {
+		throw toReadonlyQueryClientError(err);
+	}
+
+	if (!stmt.reader) {
+		throw new ReadonlyQueryClientError("Only read statements are allowed");
+	}
+
+	db.pragma("query_only = ON");
+	try {
+		try {
+			return stmt.all(...bind);
+		} catch (err) {
+			throw toReadonlyQueryClientError(err);
+		}
+	} finally {
+		db.pragma("query_only = OFF");
+	}
+}
+
+export function sendReadonlyQueryError(
+	res: Response,
+	err: unknown,
+	context: { dbname: string; sql: string },
+	logger: ReadonlyQueryLogger = console
+) {
+	if (err instanceof ReadonlyQueryClientError) {
+		logger.info(
+			`Read-only query rejected for "${context.dbname}": ${formatErrorForLog(err)} sql=${truncateSql(context.sql)}`
+		);
+
+		return res.status(400).json({
+			message: err.message,
+			...(err.code != null ? { code: err.code } : {})
+		});
+	}
+
+	logger.error(`Read-only query failed for "${context.dbname}": ${formatErrorForLog(err)}`);
+	return res.status(500).json({ message: "Read-only query failed" });
+}
+
+function toReadonlyQueryClientError(err: unknown): ReadonlyQueryClientError {
+	return new ReadonlyQueryClientError(getErrorMessage(err), {
+		code: getErrorCode(err),
+		cause: err
+	});
+}
+
+function getErrorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function getErrorCode(err: unknown): unknown {
+	if (err == null || typeof err !== "object" || !("code" in err)) {
+		return undefined;
+	}
+
+	return err.code;
+}
+
+function formatErrorForLog(err: unknown): string {
+	if (!(err instanceof Error)) {
+		return String(err);
+	}
+
+	const code = getErrorCode(err);
+	const codePart = code != null ? ` code=${String(code)}` : "";
+	return `${err.message}${codePart}\n${err.stack ?? ""}`;
+}
+
+function truncateSql(sql: string): string {
+	const normalized = sql.replace(/\s+/g, " ").trim();
+	return normalized.length > 200 ? `${normalized.slice(0, 200)}...` : normalized;
+}


### PR DESCRIPTION
## Summary
- add `POST /:dbname/readonly-query` for integrations that need authoritative reads through the sync server DB connection
- enable the endpoint by default, with `READONLY_QUERY_API=false` available to disable it
- return 404 for missing database files before using the sync cache
- reject non-reader/write-attempting statements and run accepted queries under SQLite `PRAGMA query_only = ON`
- classify client query errors as 400, server/cache failures as 500, and log failures server-side
- document the endpoint and environment variable

## Verification
- `source ~/.nvm/nvm.sh && nvm use && node common/scripts/install-run-rush.js install`
- `source ~/.nvm/nvm.sh && nvm use && node ../../common/scripts/install-run-rushx.js test:ci` in `apps/sync-server` (32 tests passed)
- `source ~/.nvm/nvm.sh && nvm use && node common/scripts/install-run-rush.js build --to @librocco/sync-server` (build completed with existing bundle-size warnings; Rush exits non-zero on warnings)
