### PR TITLE
ci(e2e): pre-install Python to fix sync-server startup flake

### DIFF
--- a/.github/workflow.templates/fix-playwright.yml
+++ b/.github/workflow.templates/fix-playwright.yml
@@ -169,6 +169,20 @@ jobs:
           enable-cache: true
           working-directory: python-apps/launcher
 
+      - name: Pre-install Python interpreter (retry transient download failures)
+        working-directory: python-apps/launcher
+        run: |
+          # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+          # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+          # here, up front and with retries (and cached), so the launcher start is offline-fast.
+          for i in 1 2 3 4 5; do
+            if uv python install; then echo "Python interpreter ready"; exit 0; fi
+            echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+            sleep $((i * 5))
+          done
+          echo "Failed to install the Python interpreter after 5 attempts"
+          exit 1
+
       - name: Clean stale test DBs (fix schema mismatch)
         run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
 

--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -48,6 +48,19 @@ jobs:
           version: "0.10.11"
           enable-cache: true
           working-directory: python-apps/launcher
+      - name: Pre-install Python interpreter (retry transient download failures)
+        working-directory: python-apps/launcher
+        run: |
+          # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+          # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+          # here, up front and with retries (and cached), so the launcher start is offline-fast.
+          for i in 1 2 3 4 5; do
+            if uv python install; then echo "Python interpreter ready"; exit 0; fi
+            echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+            sleep $((i * 5))
+          done
+          echo "Failed to install the Python interpreter after 5 attempts"
+          exit 1
       - name: Clean stale test DBs (fix schema mismatch)
         run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
       - name: Start headless launcher in background

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -56,6 +56,19 @@ jobs:
           version: "0.10.7"
           enable-cache: true
           working-directory: python-apps/launcher
+      - name: Pre-install Python interpreter (retry transient download failures)
+        working-directory: python-apps/launcher
+        run: |
+          # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+          # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+          # here, up front and with retries (and cached), so the launcher start is offline-fast.
+          for i in 1 2 3 4 5; do
+            if uv python install; then echo "Python interpreter ready"; exit 0; fi
+            echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+            sleep $((i * 5))
+          done
+          echo "Failed to install the Python interpreter after 5 attempts"
+          exit 1
       - name: Clean stale test DBs (fix schema mismatch)
         run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
       - name: Start headless launcher in background

--- a/.github/workflows/fix-playwright.yml
+++ b/.github/workflows/fix-playwright.yml
@@ -148,6 +148,19 @@ jobs:
         version: 0.10.11
         enable-cache: true
         working-directory: python-apps/launcher
+    - name: Pre-install Python interpreter (retry transient download failures)
+      working-directory: python-apps/launcher
+      run: |
+        # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+        # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+        # here, up front and with retries (and cached), so the launcher start is offline-fast.
+        for i in 1 2 3 4 5; do
+          if uv python install; then echo "Python interpreter ready"; exit 0; fi
+          echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+          sleep $((i * 5))
+        done
+        echo "Failed to install the Python interpreter after 5 attempts"
+        exit 1
     - name: Clean stale test DBs (fix schema mismatch)
       run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
     - name: Start headless launcher in background

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -76,6 +76,19 @@ jobs:
         version: 0.10.11
         enable-cache: true
         working-directory: python-apps/launcher
+    - name: Pre-install Python interpreter (retry transient download failures)
+      working-directory: python-apps/launcher
+      run: |
+        # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+        # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+        # here, up front and with retries (and cached), so the launcher start is offline-fast.
+        for i in 1 2 3 4 5; do
+          if uv python install; then echo "Python interpreter ready"; exit 0; fi
+          echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+          sleep $((i * 5))
+        done
+        echo "Failed to install the Python interpreter after 5 attempts"
+        exit 1
     - name: Clean stale test DBs (fix schema mismatch)
       run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
     - name: Start headless launcher in background

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -161,6 +161,19 @@ jobs:
         version: 0.10.7
         enable-cache: true
         working-directory: python-apps/launcher
+    - name: Pre-install Python interpreter (retry transient download failures)
+      working-directory: python-apps/launcher
+      run: |
+        # uv otherwise downloads the standalone CPython lazily when the launcher starts; a transient
+        # GitHub 504 there leaves the sync server unstarted and fails "Wait for services". Fetch it
+        # here, up front and with retries (and cached), so the launcher start is offline-fast.
+        for i in 1 2 3 4 5; do
+          if uv python install; then echo "Python interpreter ready"; exit 0; fi
+          echo "uv python install failed (attempt $i/5); retrying in $((i * 5))s"
+          sleep $((i * 5))
+        done
+        echo "Failed to install the Python interpreter after 5 attempts"
+        exit 1
     - name: Clean stale test DBs (fix schema mismatch)
       run: rm -rf apps/sync-server/test-dbs && mkdir -p apps/sync-server/test-dbs
     - name: Start headless launcher in background


### PR DESCRIPTION
## Symptom

e2e jobs intermittently failed at **Wait for services to be ready** with `exit code 124` — the `:3000` sync-server readiness `curl` timed out and **no tests ran**. Seen on PR #1251 (shard 6 failed this way 3× in a row; shards 3/4 hit it too and cleared on rerun).

## Root cause (a flake, confirmed from the launcher log)

```
error: Request failed after 3 retries
  Caused by: Failed to download .../cpython-3.13.12+...tar.gz
  Caused by: HTTP status server error (504 Gateway Timeout)
```

`uv run` downloads the standalone CPython interpreter **lazily, when the headless launcher starts**. A transient GitHub 504 on that download (after uv's own 3 retries) means Python never starts → the launcher never starts → the sync server never comes up → the 30s readiness curl fails. Purely a transient upstream-network flake, unrelated to any app code.

## Fix

Fetch the interpreter **up front, with retries (and the uv cache)**, right after `setup-uv` — so the timing-critical launcher start no longer triggers a network download. Applied to both:
- `web-client-ci.yml` (the per-PR e2e shard matrix)
- `playwright-matrix.yml` (the 36-way flakiness matrix)

## Validation

Pushed as a `playwright-matrix/**` branch to run the **36-way matrix** (the repo's flakiness stress-test). Results to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)