### PR TITLE
ci(e2e): trim e2e overhead (browser install, browser cache, e2e sourcemaps)

### DIFF
--- a/.github/workflow.templates/cache.lib.yml
+++ b/.github/workflow.templates/cache.lib.yml
@@ -9,3 +9,14 @@ with:
     ./common/temp/node_modules/
   key: ${{ runner.os }}-modules-node20-v3-${{ hashFiles('**/pnpm-lock.yaml') }}
 #@ end
+
+#@ def cache_playwright():
+name: Cache Playwright browsers
+uses: actions/cache@v4
+with:
+  path: ~/.cache/ms-playwright
+  #! Keyed on the lockfile so the cache busts when @playwright/test is bumped.
+  #! `playwright install` is idempotent and tops up any missing browser, so a
+  #! stale hit is always safe (never masks a newly-added browser).
+  key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+#@ end

--- a/.github/workflow.templates/fix-playwright.yml
+++ b/.github/workflow.templates/fix-playwright.yml
@@ -160,7 +160,7 @@ jobs:
           mv preview build/
 
       - name: Download playwright browsers
-        run: cd apps/e2e && npx playwright install
+        run: cd apps/e2e && npx playwright install chromium firefox
 
       - name: Install uv (Python package manager)
         uses: astral-sh/setup-uv@v7

--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -1,5 +1,6 @@
 #@ load("github.lib.yml", "checkout")
 #@ load("cache.lib.yml", "cache_node")
+#@ load("cache.lib.yml", "cache_playwright")
 #@ load("rush.lib.yml", "rush_add_path")
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
@@ -40,8 +41,9 @@ jobs:
           mkdir preview
           mv build/* preview/
           mv preview build/
+      -  #@ cache_playwright()
       - name: Download playwright browsers
-        run: cd apps/e2e && npx playwright install
+        run: cd apps/e2e && npx playwright install chromium firefox
       - name: Install uv (Python package manager)
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflow.templates/test-job.lib.yml
+++ b/.github/workflow.templates/test-job.lib.yml
@@ -1,12 +1,13 @@
 #@ load("github.lib.yml", "checkout")
 #@ load("cache.lib.yml", "cache_node")
+#@ load("cache.lib.yml", "cache_playwright")
 #@ load("rush.lib.yml", "rush_add_path")
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
 
 #@ def test_script(workdir, install_playwright):
 #@  if install_playwright:
-#@    return "cd "+workdir+" && npx playwright install && rushx test:ci"
+#@    return "cd "+workdir+" && npx playwright install chromium firefox && rushx test:ci"
 #@  else:
 #@    return "cd "+workdir+" && rushx test:ci"
 #@  end
@@ -29,6 +30,9 @@ steps:
 -  #@ rush_add_path()
 -  #@ rush_install()
 -  #@ rush_build()
+#@ if install_playwright:
+-  #@ cache_playwright()
+#@ end
 - name: Run tests
   run: #@ test_script(workdir, install_playwright)
 #@ if reporter!=None:

--- a/.github/workflow.templates/vfs-benchmark.yml
+++ b/.github/workflow.templates/vfs-benchmark.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build the app
         run: cd apps/web-client && rushx build:e2e
       - name: Download playwright browsers
-        run: cd apps/e2e && npx playwright install
+        run: cd apps/e2e && npx playwright install chromium firefox
       - name: Run Playwright tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
         run: cd apps/e2e && rushx test:vfs:ci
         env:

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -1,5 +1,6 @@
 #@ load("github.lib.yml", "checkout")
 #@ load("cache.lib.yml", "cache_node")
+#@ load("cache.lib.yml", "cache_playwright")
 #@ load("rush.lib.yml", "rush_add_path")
 #@ load("rush.lib.yml", "rush_install")
 #@ load("rush.lib.yml", "rush_build")
@@ -48,8 +49,9 @@ jobs:
           mkdir preview
           mv build/* preview/
           mv preview build/
+      -  #@ cache_playwright()
       - name: Download playwright browsers
-        run: cd apps/e2e && npx playwright install
+        run: cd apps/e2e && npx playwright install chromium firefox
       - name: Install uv (Python package manager)
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/fix-playwright.yml
+++ b/.github/workflows/fix-playwright.yml
@@ -141,7 +141,7 @@ jobs:
         mv build/* preview/
         mv preview build/
     - name: Download playwright browsers
-      run: cd apps/e2e && npx playwright install
+      run: cd apps/e2e && npx playwright install chromium firefox
     - name: Install uv (Python package manager)
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -68,8 +68,13 @@ jobs:
         mkdir preview
         mv build/* preview/
         mv preview build/
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Download playwright browsers
-      run: cd apps/e2e && npx playwright install
+      run: cd apps/e2e && npx playwright install chromium firefox
     - name: Install uv (Python package manager)
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/vfs-benchmark.yml
+++ b/.github/workflows/vfs-benchmark.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build the app
       run: cd apps/web-client && rushx build:e2e
     - name: Download playwright browsers
-      run: cd apps/e2e && npx playwright install
+      run: cd apps/e2e && npx playwright install chromium firefox
     - name: Run Playwright tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
       run: cd apps/e2e && rushx test:vfs:ci
       env:

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -94,8 +94,13 @@ jobs:
           echo "Build failed with exit code: $exit_code"
           exit $exit_code
         fi
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Run tests
-      run: cd apps/web-client && npx playwright install && rushx test:ci
+      run: cd apps/web-client && npx playwright install chromium firefox && rushx test:ci
   e2e-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -153,8 +158,13 @@ jobs:
         mkdir preview
         mv build/* preview/
         mv preview build/
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
     - name: Download playwright browsers
-      run: cd apps/e2e && npx playwright install
+      run: cd apps/e2e && npx playwright install chromium firefox
     - name: Install uv (Python package manager)
       uses: astral-sh/setup-uv@v7
       with:

--- a/apps/web-client/vite.config.js
+++ b/apps/web-client/vite.config.js
@@ -89,7 +89,10 @@ const config = {
 		}
 	},
 	build: {
-		sourcemap: true
+		// Sourcemaps are only consumed by Sentry on prod/preview builds (gated on
+		// SENTRY_AUTH_TOKEN). e2e never reads them — debugging uses Playwright trace +
+		// video — so skip them for the e2e build to save build time and disk.
+		sourcemap: process.env.PUBLIC_IS_E2E === "true" ? false : true
 	}
 	// TODO: Uncomment this when we figure out how to make it work
 	// preview: {


### PR DESCRIPTION
First of three stacked PRs reducing e2e CI runtime. Low-risk overhead trims; no test-behaviour change. Edits target the ytt templates in `.github/workflow.templates/`; generated workflows regenerated.

- **Restrict `playwright install` to `chromium firefox`** everywhere. webkit is commented out in `playwright.config.ts` and used nowhere, so its binary was downloaded for nothing every run.
- **Cache `~/.cache/ms-playwright`** (new `cache_playwright()` in `cache.lib.yml`), keyed on the lockfile so it busts on a `@playwright/test` bump. `install` is idempotent and tops up any missing browser, so a stale hit is always safe.
- **Skip vite sourcemaps for `build:e2e`** (gated on `PUBLIC_IS_E2E`). e2e never reads them — debugging uses Playwright trace + video. Prod/preview maps (the only Sentry consumers) are unchanged.

Mostly a bandwidth/cleanliness win; the runtime levers are in the two stacked PRs on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)