### PR TITLE
ci(e2e): run tests across 2 workers per shard (was serial)

### DIFF
--- a/.github/workflow.templates/playwright-matrix.yml
+++ b/.github/workflow.templates/playwright-matrix.yml
@@ -67,6 +67,10 @@ jobs:
           echo "All services ready!"
       - name: Run Playwright tests
         run: cd apps/e2e && rushx test:ci
+        #! Match the per-shard worker count so this flakiness harness validates
+        #! the real PLAYWRIGHT_WORKERS config used by the e2e-test job.
+        env:
+          PLAYWRIGHT_WORKERS: "2"
       - name: Stop services
         if: always()
         run: |

--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -77,6 +77,10 @@ jobs:
         run: cd apps/e2e && rushx test:ci --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           SHARD_INDEX: "${{ matrix.shardIndex }}"
+          #! Parallelise tests within each shard (whole files; sync.spec.ts stays serial).
+          #! 2, not 3: 3 over-subscribed the 4-vCPU runner and tripped timeouts on
+          #! data-heavy tests. 2 leaves headroom for Caddy + sync-server + node host.
+          PLAYWRIGHT_WORKERS: "2"
       - name: Stop services
         if: always()
         run: |

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -98,6 +98,8 @@ jobs:
         echo "All services ready!"
     - name: Run Playwright tests
       run: cd apps/e2e && rushx test:ci
+      env:
+        PLAYWRIGHT_WORKERS: "2"
     - name: Stop services
       if: always()
       run: |

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -190,6 +190,7 @@ jobs:
       run: cd apps/e2e && rushx test:ci --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       env:
         SHARD_INDEX: ${{ matrix.shardIndex }}
+        PLAYWRIGHT_WORKERS: "2"
     - name: Stop services
       if: always()
       run: |

--- a/apps/e2e/constants.ts
+++ b/apps/e2e/constants.ts
@@ -4,6 +4,14 @@ export const IS_CI = /^(?:1|true|on)$/i.test(process.env.CI?.trim() ?? "");
 export const VFS_TEST = process.env.VFS_TEST === "true";
 export const SHARD_INDEX = process.env.PLAYWRIGHT_SHARD_INDEX;
 export const FULLY_PARALLEL = process.env.PLAYWRIGHT_FULLY_PARALLEL === "true";
+/**
+ * Number of parallel Playwright workers in CI. Opt-in via PLAYWRIGHT_WORKERS;
+ * defaults to 1 to preserve serial behaviour everywhere it isn't explicitly set
+ * (e.g. the VFS benchmark, which must not run tests concurrently). With
+ * fullyParallel=false, workers parallelise whole spec FILES, so the only file
+ * that touches the shared sync server (sync.spec.ts) stays pinned to one worker.
+ */
+export const CI_WORKERS = Number(process.env.PLAYWRIGHT_WORKERS) || 1;
 
 export function getPort(): Promise<number> {
 	const testSocket = new net.Socket();

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 import type { Config } from "@playwright/test";
 
-import { IS_CI, VFS_TEST, SHARD_INDEX, baseURL, FULLY_PARALLEL } from "./constants";
+import { IS_CI, VFS_TEST, SHARD_INDEX, baseURL, FULLY_PARALLEL, CI_WORKERS } from "./constants";
 
 const reporter: Config["reporter"] = [["list"]];
 // Produce a merge‑able blob report when running in CI
@@ -61,10 +61,15 @@ const baseConfig: Config = {
 	forbidOnly: IS_CI,
 	/* Retry for local test run (normally, the tests ran using the UI will not be flaky, but headless tests might take a toll on the CPU, resulting in flaky tests) */
 	retries: 1,
-	timeout: 15000,
+	// Per-test timeout. Higher in CI: with parallel workers, data-heavy tests
+	// (e.g. progressive list loading) slow under CPU contention; the extra ceiling
+	// is headroom only — it never delays a passing test.
+	timeout: IS_CI ? 30000 : 15000,
 	globalTimeout: 55 * 60 * 1000, // 55 minutes of global timeout - the github job has a 60 minutes limit
-	/* Opt out of parallel tests on CI. */
-	workers: IS_CI ? 1 : undefined,
+	/* In CI, parallelise across PLAYWRIGHT_WORKERS workers (default 1). With
+	 * fullyParallel=false this parallelises whole spec files, keeping each file —
+	 * notably sync.spec.ts, the only file using the shared sync server — serial. */
+	workers: IS_CI ? CI_WORKERS : undefined,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: reporter,
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -81,15 +86,31 @@ const baseConfig: Config = {
 	}
 };
 
+// sync.spec.ts drives a single process-global sync server (start/stop via circus),
+// so it must run as exactly ONE task — never duplicated across browser projects, or
+// parallel workers would race on stopping/starting that shared server. Pin it to a
+// single browser (firefox, which has historically surfaced real sync regressions)
+// and exclude it from the per-browser projects.
+const SYNC_SPEC = /sync\.spec\.ts/;
+const syncProject = {
+	name: "sync",
+	testMatch: SYNC_SPEC,
+	use: { ...devices["Desktop FireFox"], locale: locales[0] }
+};
+
 const defaultConfig: Config = {
 	...baseConfig,
 	reporter,
-	projects: browsers
-		.flatMap((browser) => locales.map((locale) => ({ ...browser, locale })))
-		.map(({ name, device, locale }) => ({
-			name,
-			use: { ...device, locale }
-		}))
+	projects: [
+		...browsers
+			.flatMap((browser) => locales.map((locale) => ({ ...browser, locale })))
+			.map(({ name, device, locale }) => ({
+				name,
+				testIgnore: SYNC_SPEC,
+				use: { ...device, locale }
+			})),
+		syncProject
+	]
 };
 
 const vfsList = [


### PR DESCRIPTION
Second of three stacked PRs. **Stacked on #1253** — review/merge that first.

In CI each shard ran Playwright with a single worker, so tests executed serially on one core. Make the worker count opt-in via `PLAYWRIGHT_WORKERS` (read through `constants.ts`; defaults to 1 so unset consumers — notably the VFS benchmark — keep serial behaviour) and set it to **2** for the e2e-test job and the `playwright-matrix` harness.

**Why 2, not 3:** an initial run at 3 workers cut a shard's *execution* substantially but over-subscribed the 4-vCPU runner (browsers + Caddy + sync-server + node host), tripping the 15s per-test timeout on a few data-heavy "progressively load entries" tests (search_flow, warehouse_flow, history). At **2 workers + a 30s CI per-test timeout** (headroom only — never delays a passing test) the full suite is green: 6/6 shards passed, e2e jobs ~3.25–6.1 min.

`fullyParallel` stays false, so workers parallelise whole spec **files** (tests within a file stay serial). Non-sync tests are DB-isolated (unique browser-side DB each), so they parallelise safely.

**The catch this fixes:** `sync.spec.ts` drives a single process-global sync server (start/stop via circus) and previously ran on **both** browser projects — two file-tasks that, under >1 worker, would race on that shared server. Fix: pin `sync.spec.ts` to one dedicated `sync` project (firefox, which has historically caught real sync regressions) and `testIgnore` it from the per-browser projects. Net: `sync.spec.ts` now runs on firefox only instead of both browsers; all other specs still run on both.

Note: this reduces e2e *execution* time. The e2e job's wall time in the Actions UI is dominated by runner-queue wait, not execution — that's a separate (runner-capacity / concurrency) concern, but fewer runner-minutes here helps it indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)