### PR TITLE
ci(e2e): run the non-sync suite on chromium only at PR time

### DIFF
--- a/.github/workflow.templates/web-client-ci.yml
+++ b/.github/workflow.templates/web-client-ci.yml
@@ -81,6 +81,9 @@ jobs:
           #! 2, not 3: 3 over-subscribed the 4-vCPU runner and tripped timeouts on
           #! data-heavy tests. 2 leaves headroom for Caddy + sync-server + node host.
           PLAYWRIGHT_WORKERS: "2"
+          #! Run the non-sync suite on chromium only at PR time; both browsers run
+          #! nightly via playwright-matrix. sync.spec.ts always runs on firefox.
+          PLAYWRIGHT_BROWSERS: "chromium"
       - name: Stop services
         if: always()
         run: |

--- a/.github/workflows/web-client-ci.yml
+++ b/.github/workflows/web-client-ci.yml
@@ -191,6 +191,7 @@ jobs:
       env:
         SHARD_INDEX: ${{ matrix.shardIndex }}
         PLAYWRIGHT_WORKERS: "2"
+        PLAYWRIGHT_BROWSERS: chromium
     - name: Stop services
       if: always()
       run: |

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -9,47 +9,30 @@ if (IS_CI) {
 	reporter.push(["blob"]);
 }
 
-const browsers = [
-	{
-		name: "chromium",
-		device: devices["Desktop Chrome"]
-	},
-	{
-		name: "firefox",
-		device: devices["Desktop FireFox"]
-	}
+// Available browser projects. webkit is omitted because some tests fail on it in
+// CI (scan input, enter form submission) — TODO: re-enable once those are fixed.
+const availableBrowsers: Record<string, (typeof devices)[string]> = {
+	chromium: devices["Desktop Chrome"],
+	firefox: devices["Desktop FireFox"]
 
-	// Skipped as some tests are failing on webkit in CI. The functionality is there and we wish to still
-	// run those tests, and have the ability for PRs to be green.
-	// TODO: Uncomment this when we have time to fix the tests failing on webkit:
-	// - scan input
-	// - enter form submission
-	//
-	// {
-	// 	name: "webkit",
-	// 	device: devices["Desktop Safari"]
-	// }
+	// webkit: devices["Desktop Safari"],
+	/* Mobile viewports: */
+	// "Mobile Chrome": devices["Pixel 5"],
+	// "Mobile Safari": devices["iPhone 12"],
+	/* Branded browsers: */
+	// "Microsoft Edge": devices["Desktop Edge"],
+	// "Google Chrome": devices["Desktop Chrome"],
+};
 
-	/* Test against mobile viewports. */
-	// {
-	//   name: 'Mobile Chrome',
-	//   device: devices['Pixel 5']
-	// },
-	// {
-	//   name: 'Mobile Safari',
-	//   device: devices['iPhone 12']
-	// },
-
-	/* Test against branded browsers. */
-	// {
-	//   name: 'Microsoft Edge',
-	//   device: devices['Desktop Edge']
-	// },
-	// {
-	//   name: 'Google Chrome',
-	//   device: devices['Desktop Chrome']
-	// },
-];
+// Which browsers the (non-sync) suite runs on. Defaults to both, so nightly
+// playwright-matrix, the VFS benchmark and local runs keep full coverage. PR
+// runs set PLAYWRIGHT_BROWSERS=chromium to halve per-shard test time; the
+// firefox-only "sync" project (below) keeps sync coverage on firefox regardless.
+const BROWSERS = (process.env.PLAYWRIGHT_BROWSERS ?? "chromium,firefox")
+	.split(",")
+	.map((s) => s.trim())
+	.filter(Boolean);
+const browsers = BROWSERS.map((name) => ({ name, device: availableBrowsers[name] }));
 
 const locales = ["en"];
 


### PR DESCRIPTION
Final piece of the e2e speedup work (follows #1253 + #1254, both merged). Re-opened from #1255, which GitHub auto-closed when its stacked base branch was deleted on merge; rebased onto main.

Every non-sync test ran on both chromium and firefox, doubling per-shard test time. Make the browser set env-driven (`PLAYWRIGHT_BROWSERS`, default `chromium,firefox` so nightly `playwright-matrix`, the VFS benchmark and local runs keep full coverage) and set `PLAYWRIGHT_BROWSERS=chromium` on the per-PR e2e-test job.

`sync.spec.ts` is unaffected — it runs on its own firefox `sync` project regardless of this setting (#1254), so sync coverage stays on firefox (the browser that has caught real sync regressions) even on PRs. firefox-specific regressions in non-sync flows now surface in the nightly matrix run rather than at PR time.

Team-approved coverage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)