### PR TITLE
fix(e2e): wait for dropdown control before reading it (warehouse_flow flake)

### DIFF
--- a/apps/e2e/helpers/dropdown.ts
+++ b/apps/e2e/helpers/dropdown.ts
@@ -1,5 +1,6 @@
 import type { DashboardNode } from "./types";
 import { selector, testIdSelector } from "./utils";
+import { assertionTimeout } from "@/constants";
 
 type DropdownInterface = DashboardNode<{
 	open(): Promise<void>;
@@ -25,17 +26,22 @@ export function getDropdown(parent: DashboardNode): DropdownInterface {
 	const isOpen = () => control.getAttribute("data-open").then((value) => value === "true");
 
 	const open = async () => {
+		// The control lives in a list row that can be detached/re-rendered while its data settles (e.g.
+		// right after an in-app navigation or a burst of writes). Wait for it to be present first, so a
+		// mid-render interaction fails fast (and is retried) instead of letting the unbounded
+		// getAttribute/click below auto-wait the entire per-test timeout budget -> "Test timeout exceeded".
+		await control.waitFor({ state: "visible", timeout: assertionTimeout });
 		// Noop if the dropdown is already open
 		if (await isOpen()) return;
 		await control.click();
-		return container.waitFor();
+		return container.waitFor({ timeout: assertionTimeout });
 	};
 
 	const close = async () => {
 		// Noop if the dropdown is already closed
 		if (!(await isOpen())) return;
 		await control.click();
-		return container.waitFor({ state: "detached" });
+		return container.waitFor({ state: "detached", timeout: assertionTimeout });
 	};
 
 	const opened = <F extends () => Promise<any>>(fn: F): F =>


### PR DESCRIPTION
Fixes the recurring `warehouse_flow` e2e flake (`viewStock` → **"Test timeout of 30000ms exceeded"**) that has been blocking PRs (e.g. #1251 needed shard re-runs).

## Root cause (render-vs-action race, not the app)
`apps/e2e/helpers/dropdown.ts` `open()` read `control.getAttribute("data-open")` on a warehouse-list row's `[data-testid=dropdown-control]` **with no per-action timeout**. That control is double-gated in `inventory/warehouses/+page.svelte` (`{#if !initialized}` then `{#if !warehouses?.length}`), so the row is detached while the list (re)loads. The list tears down and rebuilds its rows on every `load()`/`invalidate` — and the flaky tests drive a row's dropdown **immediately after** an in-app "Manage inventory" navigation or a burst of `dbHandle` writes, with no settle wait (`warehouse_flow.spec.ts:354/367/377`). A mid-render read then **auto-waited the entire 30s test budget**, surfacing as a test timeout instead of a fast, retryable locator error.

This is long-standing: the same tests flaked at **1 worker** on PR #1249's run (before the 2-workers-per-shard change), so it predates both the stock cache and #1254 — the 2-worker CI just *amplified* it by widening the render window under CPU contention (2 chromium + Caddy + launcher + sync-server on a 2-vCPU runner).

## Fix (this PR — pure test-helper, low risk)
Wait for the control to be visible (bounded by `assertionTimeout` = 15s in CI) before reading/clicking it, and bound the menu open/close waits the same way. When the row is already present (the common case) the wait returns instantly — passing runs are unaffected; a mid-render interaction now fails fast and is absorbed by `retries:1` instead of burning the 30s budget. Hardens **every** dropdown action suite-wide.

## Recommended follow-ups (not in this PR — your call on the trade-offs)
1. **Settle-wait in the 3 flaky tests** — add `entityList("warehouse-list").waitFor()` before driving a row after navigation (mirrors the passing tests). *test-code, low risk.* Mostly redundant with this PR but explicit.
2. **Bound sub-test timeouts globally** — `use.actionTimeout` + `expect.timeout` = `assertionTimeout` in `playwright.config.ts`, so the same 30s-budget-burn class can't recur in any helper. *playwright-config; caveat: a genuinely slow-but-correct action could fail at 15s under heavy contention, then retry.*
3. **Reduce list re-render churn** — debounce the `onRange → invalidate("warehouse:list")` callback + keyed `{#each}` in `warehouses/+page.svelte`, so a write burst causes one reload, not N row tear-downs. *app-code, medium effort; also a real UX win.*
4. **Runner sizing** — the 2-workers-per-shard change assumed a 4-vCPU runner, but this public repo's `ubuntu-latest` is **2 vCPU**, so 2 chromium workers oversubscribe. Either right-size the runner or re-evaluate whether 2 workers nets a win after this fix. *ci-config.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)