### PR TITLE
fix(web-client): skip auto-print for books not in catalog (D-321)

### DIFF
--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
@@ -391,11 +391,10 @@
 							await handleAddTransaction(isbn);
 
 							if ($autoPrintLabels) {
-								try {
-									getBookData(db, isbn).then(handlePrintLabel);
-									// Success
-								} catch (err) {
-									// Show error
+								// Only print if the book has fetched metadata ('updatedAt' set): isbn-only rows would print blank labels
+								const book = await getBookData(db, isbn);
+								if (book?.updatedAt) {
+									await handlePrintLabel(book);
 								}
 							}
 						}


### PR DESCRIPTION
With auto-print labels on, scanning an ISBN that isn't in the catalog yet printed a **blank label** (empty title/author, price 0). Fix: only auto-print when the book row has fetched metadata — gated on `updatedAt`, the canonical "metadata was fetched" marker ([`upsertBook` sets it only when more than the isbn is provided](https://github.com/librocco/librocco/blob/a0c07d5b2a56ad35a5184678489ee637df041fb9/apps/web-client/src/lib/db/cr-sqlite/books.ts#L42), and `handleAddTransaction` already uses it the same way).

Closes D-321 — https://linear.app/code-myriad/issue/D-321/inbound-skip-auto-print-for-books-not-in-catalog-blank-label

**Deliberately skip-only** (decision recorded in the issue): we do not defer printing until the background book-fetcher resolves — the scan simply doesn't print when metadata is missing.

Change ([inbound `[id]/+page.svelte` scanner `onUpdated`](https://github.com/librocco/librocco/blob/a0c07d5b2a56ad35a5184678489ee637df041fb9/apps/web-client/src/routes/inventory/inbound/%5Bid%5D/%2Bpage.svelte#L387-L401)): `getBookData` is now awaited and `handlePrintLabel` called only if `book?.updatedAt`. The previous `try { promise.then(...) } catch` could never catch anything (promise not awaited) and had no metadata guard.

Coverage: typecheck (svelte-check, 0 errors) + `lint:strict` pass; no component-test harness exists for this route, so the guard has no automated test — verified by code-path inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)