### PR TITLE
feat(web-client): per-note auto-print labels + visible header toggle (D-320, D-324)

### DIFF
--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -509,13 +509,15 @@ test("auto-print posts a label for scanned books with metadata and skips books w
 	await expect(toggle).toBeChecked();
 
 	// Scan an unknown isbn: the transaction is added, but no label is printed (no fetched metadata - it would print blank)
+	// NOTE: the "inbound-note" view matters: it matches quantity against the editable input's data-value
+	// (the "warehouse" view matches text content, which never appears in this table)
 	await content.scanField().add("9999999999");
-	await content.table("warehouse").assertRows([{ isbn: "9999999999", quantity: 1 }]);
+	await content.table("inbound-note").assertRows([{ isbn: "9999999999", quantity: 1 }]);
 	expect(printRequests.length).toBe(0);
 
 	// Scan the seeded book: exactly one label POST, for the seeded isbn
 	await content.scanField().add(book1.isbn);
-	await content.table("warehouse").assertRows([
+	await content.table("inbound-note").assertRows([
 		{ isbn: book1.isbn, quantity: 1 },
 		{ isbn: "9999999999", quantity: 1 }
 	]);

--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -437,3 +437,89 @@ test("editing a purchase note does not change its createdAt timestamp", async ({
 	expect(after.createdAt).toBe(before.createdAt);
 	expect(after.updatedAt).toBeGreaterThan(before.updatedAt);
 });
+
+test("auto-print labels toggle is scoped per note", async ({ page }) => {
+	const dashboard = getDashboard(page);
+	const content = dashboard.content();
+
+	// Create two notes to work with
+	const dbHandle = await getDbHandle(page);
+	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "Purchase 1" });
+	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1, displayName: "Purchase 2" });
+
+	const toggle = page.getByTestId("auto-print-labels-toggle");
+
+	// Navigate to note A (Purchase 1) and turn auto-print ON
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+	await content.entityList("inbound-list").item(1).edit();
+	await page.getByRole("heading", { name: "Purchase 1" }).first().waitFor();
+
+	await expect(toggle).not.toBeChecked();
+	await toggle.click();
+	await expect(toggle).toBeChecked();
+
+	// Note B (Purchase 2) is unaffected - the setting is scoped per note
+	await page.getByRole("link", { name: "Manage inventory" }).click();
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+	await content.entityList("inbound-list").item(0).edit();
+	await page.getByRole("heading", { name: "Purchase 2" }).first().waitFor();
+
+	await expect(toggle).not.toBeChecked();
+
+	// Back on note A the setting is still ON (persisted across navigation)
+	await page.getByRole("link", { name: "Manage inventory" }).click();
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+	await content.entityList("inbound-list").item(1).edit();
+	await page.getByRole("heading", { name: "Purchase 1" }).first().waitFor();
+
+	await expect(toggle).toBeChecked();
+});
+
+test("auto-print posts a label for scanned books with metadata and skips books without metadata", async ({ page }) => {
+	const dashboard = getDashboard(page);
+	const content = dashboard.content();
+
+	const dbHandle = await getDbHandle(page);
+	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "Purchase 1" });
+	// Seed a book WITH metadata (helper sets 'updated_at' when more than the isbn is provided)
+	await dbHandle.evaluate(upsertBook, book1);
+
+	// Point the label printer to a same-origin URL (no CORS) and intercept it, counting the POSTs
+	// NOTE: this is set before navigating to the note page - the device settings store hydrates from localStorage on page mount
+	await page.evaluate(() =>
+		window.localStorage.setItem("librocco:settings", JSON.stringify({ labelPrinterUrl: "/print-label", receiptPrinterUrl: "" }))
+	);
+	const printRequests: string[] = [];
+	await page.route("**/print-label", (route) => {
+		printRequests.push(route.request().postData());
+		return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+	});
+
+	// Navigate to the note and turn auto-print ON
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await content.entityList("inbound-list").assertElements([{ name: "Warehouse 1 / Purchase 1" }]);
+	await content.entityList("inbound-list").item(0).edit();
+	await page.getByRole("heading", { name: "Purchase 1" }).first().waitFor();
+
+	const toggle = page.getByTestId("auto-print-labels-toggle");
+	await toggle.click();
+	await expect(toggle).toBeChecked();
+
+	// Scan an unknown isbn: the transaction is added, but no label is printed (no fetched metadata - it would print blank)
+	await content.scanField().add("9999999999");
+	await content.table("warehouse").assertRows([{ isbn: "9999999999", quantity: 1 }]);
+	expect(printRequests.length).toBe(0);
+
+	// Scan the seeded book: exactly one label POST, for the seeded isbn
+	await content.scanField().add(book1.isbn);
+	await content.table("warehouse").assertRows([
+		{ isbn: book1.isbn, quantity: 1 },
+		{ isbn: "9999999999", quantity: 1 }
+	]);
+	await expect.poll(() => printRequests.length, { timeout: assertionTimeout }).toBe(1);
+	// Had the unknown-isbn scan printed, ITS request would have arrived first and this assertion would fail
+	expect(JSON.parse(printRequests[0]).isbn).toBe(book1.isbn);
+});

--- a/apps/web-client/src/lib/constants.ts
+++ b/apps/web-client/src/lib/constants.ts
@@ -2,7 +2,7 @@ import { PUBLIC_IS_E2E, PUBLIC_IS_DEBUG, PUBLIC_LOG_LEVEL, PUBLIC_IS_DEMO, PUBLI
 import type { Locales } from "@librocco/shared";
 
 export const LOCAL_STORAGE_SETTINGS = "librocco:settings";
-export const LOCAL_STORAGE_APP_SETTINGS = "librocco:app_settings";
+export const LOCAL_STORAGE_AUTO_PRINT_LABELS = "librocco:auto_print_labels";
 
 export const IS_E2E = PUBLIC_IS_E2E === "true";
 export const IS_DEBUG = PUBLIC_IS_DEBUG === "true";

--- a/apps/web-client/src/lib/stores/__tests__/auto-print-labels.test.ts
+++ b/apps/web-client/src/lib/stores/__tests__/auto-print-labels.test.ts
@@ -1,0 +1,82 @@
+import { get } from "svelte/store";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getAutoPrintLabelsStore, removeAutoPrintLabelsSetting } from "$lib/stores/app";
+import { LOCAL_STORAGE_AUTO_PRINT_LABELS } from "$lib/constants";
+
+const storageKey = (noteId: number) => `${LOCAL_STORAGE_AUTO_PRINT_LABELS}:${noteId}`;
+
+// NOTE: svelte-local-storage-store caches stores per key in a module-level map, so the cache survives across tests.
+// Each test uses its own note id(s) to stay independent; localStorage is cleaned up after each test.
+const usedNoteIds: number[] = [];
+let nextNoteId = 910_000;
+const freshNoteId = () => {
+	const id = nextNoteId++;
+	usedNoteIds.push(id);
+	return id;
+};
+
+describe("auto-print-labels store", () => {
+	afterEach(() => {
+		while (usedNoteIds.length) {
+			removeAutoPrintLabelsSetting(usedNoteIds.pop());
+		}
+	});
+
+	it("keeps stores for different note ids independent", () => {
+		const noteA = freshNoteId();
+		const noteB = freshNoteId();
+
+		const storeA = getAutoPrintLabelsStore(noteA);
+		const storeB = getAutoPrintLabelsStore(noteB);
+
+		storeA.set(true);
+
+		expect(get(storeA)).toBe(true);
+		expect(get(storeB)).toBe(false);
+		expect(localStorage.getItem(storageKey(noteA))).toBe("true");
+		expect(localStorage.getItem(storageKey(noteB))).toBe(null);
+
+		storeA.toggle();
+		expect(get(storeA)).toBe(false);
+		expect(get(storeB)).toBe(false);
+	});
+
+	it("removeAutoPrintLabelsSetting resets both localStorage and the live (cached) store value", () => {
+		const noteId = freshNoteId();
+
+		const store = getAutoPrintLabelsStore(noteId);
+		let current: boolean;
+		const unsubscribe = store.subscribe((value) => (current = value));
+
+		store.set(true);
+		expect(current).toBe(true);
+		expect(localStorage.getItem(storageKey(noteId))).toBe("true");
+
+		removeAutoPrintLabelsSetting(noteId);
+
+		// The localStorage key is gone...
+		expect(localStorage.getItem(storageKey(noteId))).toBe(null);
+		// ...AND the in-memory (cached) store was reset: a same-tab removeItem fires no storage event and the
+		// library's subscribe-time hydration only overwrites the value when getItem returns non-null, so without
+		// an explicit reset the cached writable would keep holding `true`
+		expect(current).toBe(false);
+		expect(get(getAutoPrintLabelsStore(noteId))).toBe(false);
+
+		unsubscribe();
+	});
+
+	it("a store re-obtained for the same (recycled) note id after removal reads false", () => {
+		const noteId = freshNoteId();
+
+		// Simulate a note with auto-print ON being committed/deleted...
+		getAutoPrintLabelsStore(noteId).set(true);
+		removeAutoPrintLabelsSetting(noteId);
+
+		// ...and a new note recycling the same id (note ids are MAX(id) + 1, deletes are hard deletes)
+		const reobtained = getAutoPrintLabelsStore(noteId);
+
+		expect(get(reobtained)).toBe(false);
+		expect(localStorage.getItem(storageKey(noteId))).toBe(null);
+	});
+});

--- a/apps/web-client/src/lib/stores/app.ts
+++ b/apps/web-client/src/lib/stores/app.ts
@@ -11,12 +11,22 @@ import { readableFromStream } from "$lib/utils/streams";
 
 import WorkerInterface from "$lib/workers/WorkerInterface";
 
-import { LOCAL_STORAGE_APP_SETTINGS, LOCAL_STORAGE_SETTINGS } from "$lib/constants";
+import { LOCAL_STORAGE_AUTO_PRINT_LABELS, LOCAL_STORAGE_SETTINGS } from "$lib/constants";
 import { deviceSettingsSchema } from "$lib/forms/schemas";
 
-const autoPrintLabelsInner = persisted(LOCAL_STORAGE_APP_SETTINGS, false);
-const toggleAutoprintLabels = () => autoPrintLabelsInner.update((v) => !v);
-export const autoPrintLabels = Object.assign(autoPrintLabelsInner, { toggle: toggleAutoprintLabels });
+// The auto-print-labels setting is deliberately scoped per note AND per workstation (localStorage, not synced via CRDT)
+const autoPrintLabelsKey = (noteId: number) => `${LOCAL_STORAGE_AUTO_PRINT_LABELS}:${noteId}`;
+
+export const getAutoPrintLabelsStore = (noteId: number) => {
+	const store = persisted(autoPrintLabelsKey(noteId), false);
+	return Object.assign(store, { toggle: () => store.update((v) => !v) });
+};
+
+/** Removes the (localStorage persisted) auto-print-labels setting for a note (cleanup when the note is committed/deleted) */
+export const removeAutoPrintLabelsSetting = (noteId: number) => {
+	if (!browser) return;
+	localStorage.removeItem(autoPrintLabelsKey(noteId));
+};
 
 const { data: defaultSettings } = defaults(zod(deviceSettingsSchema));
 export const deviceSettingsStore = persisted<typeof defaultSettings>(LOCAL_STORAGE_SETTINGS, defaultSettings);

--- a/apps/web-client/src/lib/stores/app.ts
+++ b/apps/web-client/src/lib/stores/app.ts
@@ -22,9 +22,16 @@ export const getAutoPrintLabelsStore = (noteId: number) => {
 	return Object.assign(store, { toggle: () => store.update((v) => !v) });
 };
 
-/** Removes the (localStorage persisted) auto-print-labels setting for a note (cleanup when the note is committed/deleted) */
+/**
+ * Removes the (localStorage persisted) auto-print-labels setting for a note (cleanup when the note is committed/deleted).
+ *
+ * NOTE: svelte-local-storage-store caches stores per key (module-level map) and a same-tab `removeItem` fires no storage
+ * event, so the cached writable would keep holding `true`. Since note ids get recycled (id seq = MAX(id) + 1, deletes are
+ * hard deletes), we reset the cached store first - otherwise a new note reusing the id would start with auto-print ON.
+ */
 export const removeAutoPrintLabelsSetting = (noteId: number) => {
 	if (!browser) return;
+	getAutoPrintLabelsStore(noteId).set(false);
 	localStorage.removeItem(autoPrintLabelsKey(noteId));
 };
 

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -22,6 +22,7 @@
 	import { formatters as dateFormatters } from "@librocco/shared/i18n-formatters";
 
 	import { appPath } from "$lib/paths";
+	import { removeAutoPrintLabelsSetting } from "$lib/stores/app";
 	import { deleteNote } from "$lib/db/cr-sqlite/note";
 	import { getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
 	import { InventoryManagementPage } from "$lib/controllers";
@@ -79,6 +80,7 @@
 	const handleDeleteNote = async (id: number) => {
 		const db = await getDb(app);
 		await deleteNote(db, id);
+		removeAutoPrintLabelsSetting(id);
 	};
 </script>
 

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
@@ -287,14 +287,14 @@
 				</div>
 
 				<div class="ml-auto flex items-center gap-x-2">
-					<label class="flex cursor-pointer items-center gap-x-2" title={tInbound.labels.auto_print_book_labels()}>
+					<label class="flex cursor-pointer items-center gap-x-2" title={tInbound.labels.auto_print_book_labels_note()}>
 						<Printer class="text-base-content/70" aria-hidden size={20} />
-						<span class="hidden text-sm text-base-content sm:inline">{tInbound.labels.auto_print_book_labels()}</span>
+						<span class="hidden text-sm text-base-content sm:inline">{tInbound.labels.auto_print_book_labels_note()}</span>
 						<input
 							type="checkbox"
 							class="toggle-success toggle"
 							data-testid={testId("auto-print-labels-toggle")}
-							aria-label={tInbound.labels.auto_print_book_labels()}
+							aria-label={tInbound.labels.auto_print_book_labels_note()}
 							checked={$autoPrintLabels}
 							on:change={autoPrintLabels.toggle}
 						/>

--- a/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/[id]/+page.svelte
@@ -40,7 +40,7 @@
 
 	import { type DialogContent } from "$lib/types";
 	import { createExtensionAvailabilityStore } from "$lib/stores";
-	import { autoPrintLabels, deviceSettingsStore } from "$lib/stores/app";
+	import { deviceSettingsStore, getAutoPrintLabelsStore, removeAutoPrintLabelsSetting } from "$lib/stores/app";
 
 	import { createIntersectionObserver, createTable } from "$lib/actions";
 
@@ -66,6 +66,9 @@
 	export let data: PageData;
 
 	$: ({ plugins, id: noteId, warehouseId, warehouseName, displayName, updatedAt, publisherList } = data);
+
+	// Auto-print is scoped per note and per workstation (localStorage, not synced)
+	$: autoPrintLabels = getAutoPrintLabelsStore(noteId);
 
 	$: t = $LL.inventory_page.purchase_tab;
 	$: tInbound = $LL.purchase_note;
@@ -97,12 +100,14 @@
 	const handleCommitSelf = async (closeDialog: () => void) => {
 		const db = await getDb(app);
 		await commitNote(db, noteId);
+		removeAutoPrintLabelsSetting(noteId);
 		closeDialog();
 	};
 
 	const handleDeleteSelf = async (closeDialog: () => void) => {
 		const db = await getDb(app);
 		await deleteNote(db, noteId);
+		removeAutoPrintLabelsSetting(noteId);
 		closeDialog();
 	};
 
@@ -282,6 +287,19 @@
 				</div>
 
 				<div class="ml-auto flex items-center gap-x-2">
+					<label class="flex cursor-pointer items-center gap-x-2" title={tInbound.labels.auto_print_book_labels()}>
+						<Printer class="text-base-content/70" aria-hidden size={20} />
+						<span class="hidden text-sm text-base-content sm:inline">{tInbound.labels.auto_print_book_labels()}</span>
+						<input
+							type="checkbox"
+							class="toggle-success toggle"
+							data-testid={testId("auto-print-labels-toggle")}
+							aria-label={tInbound.labels.auto_print_book_labels()}
+							checked={$autoPrintLabels}
+							on:change={autoPrintLabels.toggle}
+						/>
+					</label>
+
 					<button
 						class="btn-primary btn-sm btn hidden xs:block"
 						use:melt={$confirmDialogTrigger}
@@ -334,19 +352,6 @@
 							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300"
 						>
 							<Printer class="text-base-content/70" aria-hidden size={20} /><span class="text-base-content">{tInbound.labels.print()}</span>
-						</div>
-						<div
-							{...item}
-							use:item.action
-							on:m-click={autoPrintLabels.toggle}
-							class="flex w-full items-center gap-2 px-4 py-3 text-sm font-normal leading-5 text-base-content data-[highlighted]:bg-base-300 {$autoPrintLabels
-								? '!bg-success text-success-content'
-								: ''}"
-						>
-							<Printer class="text-base-content/70" size={20} aria-hidden />
-							<span class="text-base-content">
-								{tInbound.labels.auto_print_book_labels()}
-							</span>
 						</div>
 						<div
 							{...item}

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -33,6 +33,7 @@
 	import { defaultDialogConfig } from "$lib/components/Melt";
 	import { invalidate as invalidateStockCache } from "$lib/db/cr-sqlite/stock_cache";
 
+	import { removeAutoPrintLabelsSetting } from "$lib/stores/app";
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
 	import { getStock } from "$lib/db/cr-sqlite/stock";
 	import { deleteWarehouse, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
@@ -118,6 +119,10 @@
 	const handleCreateInboundNote = (warehouseId: number) => async () => {
 		const db = await getDb(app);
 		const id = await getNoteIdSeq(db);
+		// Note ids get recycled (id seq = MAX(id) + 1): clear any stale auto-print flag left behind by a
+		// previous note with the same id (e.g. one deleted from another workstation - cleanup there can't reach
+		// this workstation's localStorage)
+		removeAutoPrintLabelsSetting(id);
 		await createInboundNote(db, warehouseId, id);
 		await goto(appPath("inbound", id));
 	};

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -20,7 +20,7 @@
 	import { Page } from "$lib/controllers";
 	import { BookForm, bookSchema, type BookFormSchema } from "$lib/forms";
 	import { createExtensionAvailabilityStore } from "$lib/stores";
-	import { deviceSettingsStore } from "$lib/stores/app";
+	import { deviceSettingsStore, removeAutoPrintLabelsSetting } from "$lib/stores/app";
 
 	import { racefreeGoto } from "$lib/utils/navigation";
 
@@ -106,6 +106,10 @@
 	const handleCreateInboundNote = async () => {
 		const db = await getDb(app);
 		const noteId = await getNoteIdSeq(db);
+		// Note ids get recycled (id seq = MAX(id) + 1): clear any stale auto-print flag left behind by a
+		// previous note with the same id (e.g. one deleted from another workstation - cleanup there can't reach
+		// this workstation's localStorage)
+		removeAutoPrintLabelsSetting(noteId);
 		await createInboundNote(db, id, noteId); // Id here is warehouseId ^^^
 		await goto(appPath("inbound", noteId));
 	};

--- a/pkg/shared/src/i18n/de/index.json
+++ b/pkg/shared/src/i18n/de/index.json
@@ -412,6 +412,7 @@
 			"commit": "",
 			"print": "",
 			"auto_print_book_labels": "",
+			"auto_print_book_labels_note": "Etiketten automatisch drucken (diese Notiz)",
 			"delete": "",
 			"edit_row": "",
 			"print_book_label": "",

--- a/pkg/shared/src/i18n/en/index.json
+++ b/pkg/shared/src/i18n/en/index.json
@@ -410,6 +410,7 @@
 			"commit": "Commit",
 			"print": "Print",
 			"auto_print_book_labels": "Auto print book labels",
+			"auto_print_book_labels_note": "Auto-print labels (this note)",
 			"delete": "Delete",
 			"edit_row": "Edit row",
 			"print_book_label": "Print book label",

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -220,6 +220,7 @@ const purchase_note = {
 		commit: "Commit",
 		print: "Print",
 		auto_print_book_labels: "Auto print book labels",
+		auto_print_book_labels_note: "Auto-print labels (this note)",
 		delete: "Delete",
 		edit_row: "Edit row",
 		print_book_label: "Print book label",

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -1171,6 +1171,10 @@ type RootTranslation = {
 			 */
 			auto_print_book_labels: string
 			/**
+			 * A​u​t​o​-​p​r​i​n​t​ ​l​a​b​e​l​s​ ​(​t​h​i​s​ ​n​o​t​e​)
+			 */
+			auto_print_book_labels_note: string
+			/**
 			 * D​e​l​e​t​e
 			 */
 			'delete': string
@@ -4317,6 +4321,10 @@ export type TranslationFunctions = {
 			 * Auto print book labels
 			 */
 			auto_print_book_labels: () => LocalizedString
+			/**
+			 * Auto-print labels (this note)
+			 */
+			auto_print_book_labels_note: () => LocalizedString
 			/**
 			 * Delete
 			 */

--- a/pkg/shared/src/i18n/it/index.json
+++ b/pkg/shared/src/i18n/it/index.json
@@ -410,6 +410,7 @@
 			"commit": "Conferma",
 			"print": "Stampa",
 			"auto_print_book_labels": "Stampa automatica etichette libri",
+			"auto_print_book_labels_note": "Stampa automatica etichette (questa nota)",
 			"delete": "Elimina",
 			"edit_row": "Modifica riga",
 			"print_book_label": "Stampa etichetta libro",

--- a/pkg/shared/src/testing.ts
+++ b/pkg/shared/src/testing.ts
@@ -57,6 +57,7 @@ export type TestId =
 	| "collect-row"
 	| "delete-row"
 	| "print-book-label"
+	| "auto-print-labels-toggle"
 	| "book-form"
 	| "custom-item-form"
 	| "calendar-picker-control"


### PR DESCRIPTION
**Stacked on #1258** (D-321, base branch `fix/d321-skip-autoprint-unknown-books`) — merge that first, then retarget/merge this.

Closes D-320 — https://linear.app/code-myriad/issue/D-320/inbound-auto-print-labels-toggle-is-global-should-be-per-note
Closes D-324 — https://linear.app/code-myriad/issue/D-324/inbound-surface-auto-print-labels-toggle-outside-the-menu

The key design decision: the auto-print flag stays in **localStorage, scoped per workstation AND per note id — deliberately NOT synced** (no DB column, no CRDT). Enabling auto-print on one note no longer turns it on for every other note on that workstation, and it never leaks to other workstations.

- **D-320** — [`getAutoPrintLabelsStore(noteId)`](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/lib/stores/app.ts#L17-L36) replaces the global store; key is `librocco:auto_print_labels:<noteId>` (constant in `constants.ts`). The note page [derives it reactively from `noteId`](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/routes/inventory/inbound/%5Bid%5D/%2Bpage.svelte#L70-L71) (`persisted()` caches per key, so the reactive re-derivation is allocation/listener-safe). `removeAutoPrintLabelsSetting(noteId)` is called on note commit and delete so finished notes don't leave keys behind. Stale entries under the old `librocco:app_settings` key are harmless leftovers (worst case: one workstation re-enables the toggle once); the dead constant is removed.
- **D-324** — the ⋯-menu item (state visible only as a green highlight) is **replaced** by an [always-visible labeled daisyUI toggle in the note header actions](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/routes/inventory/inbound/%5Bid%5D/%2Bpage.svelte#L289-L301): Printer icon + switch always visible, text label shown from `sm` up; label/`aria-label`/`title` use a new `auto_print_book_labels_note` i18n key ("Auto-print labels (this note)", en/it/de) so the per-note scope is explicit in the UI. `data-testid` `auto-print-labels-toggle` added to the shared [`TestId` union](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/pkg/shared/src/testing.ts#L60).

Checks: `rush build`, web-client typecheck (svelte-check 0 errors; 1 pre-existing unrelated a11y warning in settings), `lint:strict`, and `note.test.ts` unit suite (50/50 pass, under xvfb).

### Review hardening

- [`removeAutoPrintLabelsSetting`](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/lib/stores/app.ts#L25-L36) now resets the cached store before `removeItem`: svelte-local-storage-store caches writables per key and same-tab `removeItem` fires no storage event, so the in-memory value stayed `true` — and since note ids are recycled (`MAX(id) + 1`, hard deletes), a new note reusing the id would have started with auto-print ON.
- The inbound **list** page's delete path now also [cleans up the flag](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/routes/inventory/inbound/%2Bpage.svelte#L80-L84) (previously only the note page's own commit/delete did).
- Both inbound-note creation sites clear the flag for the freshly allocated id ([warehouses list](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/routes/inventory/warehouses/%2Bpage.svelte#L119-L128), [warehouse page](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/routes/inventory/warehouses/%5Bid%5D/%2Bpage.svelte#L106-L115)) — belt-and-braces against id reuse from paths local cleanup can't reach (a note deleted on another workstation: the flag is local-only, so the remote delete can never clear this workstation's key).
- New i18n key `purchase_note.labels.auto_print_book_labels_note` (old key untouched) makes the toggle's per-note scope explicit per the D-324 spec.
- Coverage: [unit tests](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/web-client/src/lib/stores/__tests__/auto-print-labels.test.ts) for per-note independence and removal semantics (verified to fail if the cached-store reset is reverted); [e2e](https://github.com/librocco/librocco/blob/f3822a477a0e69deb1019dce70e98dbde74c7c55/apps/e2e/integration/inbound_flow.spec.ts#L441-L521) for per-note toggle scoping across navigation plus printer-POST interception (zero label POSTs for a metadata-less scan, exactly one for a seeded book — also covers #1258's guard).

Known limitation (accepted): orphan keys can still accumulate for notes finished on other workstations whose ids are never reused locally — a handful of tiny localStorage entries, not worth a startup sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
