### PR TITLE
feat(web-client): make inbound notes list filterable by warehouse (deep-linkable)

### DIFF
--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -83,15 +83,58 @@ test("should filter the inbound note list by warehouse (filter reflected in the 
 	await page.waitForURL(/#\/inventory\/inbound\/\?warehouse=1$/);
 	await inNoteList.assertElements([{ name: "Warehouse 1 / Purchase 1" }]);
 
-	// Deep-load the filtered URL (with a full page reload): the filter is applied from the URL
-	await page.goto(appHash("inbound") + "?warehouse=2");
-	await page.reload();
-	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }]);
-
 	// Switch back to "All warehouses": all notes are shown again
 	await page.getByTestId("warehouse-filter-select").selectOption("");
 	await page.waitForURL(/#\/inventory\/inbound\/$/);
 	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+});
+
+test("should apply the warehouse filter from a deep link on a hard (full document) load", async ({ page }) => {
+	const dashboard = getDashboard(page);
+
+	const content = dashboard.content();
+	const inNoteList = content.entityList("inbound-list");
+
+	// Two warehouses ("Warehouse 1" is created in beforeEach), each with an uncommitted note
+	// Instead of `dbHandle` this test uses `(await getDbHandle(page))` so it works after a page reload
+	await (await getDbHandle(page)).evaluate(upsertWarehouse, { id: 2, displayName: "Warehouse 2" });
+	await (await getDbHandle(page)).evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "Purchase 1" });
+	await (await getDbHandle(page)).evaluate(createInboundNote, { id: 2, warehouseId: 2, displayName: "Purchase 2" });
+
+	// 'page.goto' to a URL differing only in hash is a same-document navigation, so the subsequent
+	// reload is what makes this a true document load - it runs the app.html trailing-slash
+	// normalizer, which rewrites the URL to "?warehouse=2/" (regression: the filter used to be
+	// silently dropped because "2/" failed to parse)
+	await page.goto(appHash("inbound") + "?warehouse=2");
+	await page.reload();
+
+	// The filter survives the rewrite: the list is filtered and the select reflects the warehouse
+	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }]);
+	await expect(page.getByTestId("warehouse-filter-select")).toHaveValue("2");
+});
+
+test("should keep the list reacting to db updates after changing the warehouse filter", async ({ page }) => {
+	const dashboard = getDashboard(page);
+
+	const content = dashboard.content();
+	const inNoteList = content.entityList("inbound-list");
+
+	// Two warehouses ("Warehouse 1" is created in beforeEach), each with an uncommitted note
+	const dbHandle = await getDbHandle(page);
+	await dbHandle.evaluate(upsertWarehouse, { id: 2, displayName: "Warehouse 2" });
+	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "Purchase 1" });
+	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 2, displayName: "Purchase 2" });
+
+	// Navigate to the inbound list and filter by Warehouse 1 (a same-route navigation - the component is reused)
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await page.getByTestId("warehouse-filter-select").selectOption("1");
+	await page.waitForURL(/#\/inventory\/inbound\/\?warehouse=1$/);
+	await inNoteList.assertElements([{ name: "Warehouse 1 / Purchase 1" }]);
+
+	// The list should pick up DB changes without any further navigation (regression: the filter
+	// navigation used to tear down the DB subscription, permanently freezing the list)
+	await dbHandle.evaluate(createInboundNote, { id: 3, warehouseId: 1, displayName: "Purchase 3" });
+	await inNoteList.assertElements([{ name: "Warehouse 1 / Purchase 3" }, { name: "Warehouse 1 / Purchase 1" }]);
 });
 
 test("should delete the note on delete button click (after confirming the prompt)", async ({ page }) => {

--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -62,6 +62,38 @@ test("should display notes, namespaced to warehouses, in the inbound note list",
 	]);
 });
 
+test("should filter the inbound note list by warehouse (filter reflected in the URL)", async ({ page }) => {
+	const dashboard = getDashboard(page);
+
+	const content = dashboard.content();
+	const inNoteList = content.entityList("inbound-list");
+
+	// Two warehouses ("Warehouse 1" is created in beforeEach), each with an uncommitted note
+	// Instead of `dbHandle` this test uses `(await getDbHandle(page))` so it works after a page reload
+	await (await getDbHandle(page)).evaluate(upsertWarehouse, { id: 2, displayName: "Warehouse 2" });
+	await (await getDbHandle(page)).evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "Purchase 1" });
+	await (await getDbHandle(page)).evaluate(createInboundNote, { id: 2, warehouseId: 2, displayName: "Purchase 2" });
+
+	// Navigate to the inbound list - no filter: all notes are shown
+	await page.getByRole("link", { name: "Purchases", exact: true }).click();
+	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+
+	// Filter by Warehouse 1 using the select - only its notes are shown and the filter is reflected in the URL (hash query)
+	await page.getByTestId("warehouse-filter-select").selectOption("1");
+	await page.waitForURL(/#\/inventory\/inbound\/\?warehouse=1$/);
+	await inNoteList.assertElements([{ name: "Warehouse 1 / Purchase 1" }]);
+
+	// Deep-load the filtered URL (with a full page reload): the filter is applied from the URL
+	await page.goto(appHash("inbound") + "?warehouse=2");
+	await page.reload();
+	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }]);
+
+	// Switch back to "All warehouses": all notes are shown again
+	await page.getByTestId("warehouse-filter-select").selectOption("");
+	await page.waitForURL(/#\/inventory\/inbound\/$/);
+	await inNoteList.assertElements([{ name: "Warehouse 2 / Purchase 2" }, { name: "Warehouse 1 / Purchase 1" }]);
+});
+
 test("should delete the note on delete button click (after confirming the prompt)", async ({ page }) => {
 	const dashboard = getDashboard(page);
 

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -88,6 +88,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "New Purchase (3)",
+				warehouseId: 2,
 				warehouseName: "Warehouse 2",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -96,6 +97,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -104,6 +106,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -117,6 +120,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "New Purchase (3)",
+				warehouseId: 2,
 				warehouseName: "Warehouse 2",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -125,6 +129,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -138,6 +143,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "New Purchase (3)",
+				warehouseId: 2,
 				warehouseName: "Warehouse 2",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -146,11 +152,47 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
 				totalBooks: 0
 			}
+		]);
+	});
+
+	it("filters inbound notes by warehouse (when provided)", async () => {
+		const db = await getRandomDb();
+
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+		await upsertWarehouse(db, { id: 2, displayName: "Warehouse 2" });
+
+		await createInboundNote(db, 1, 1);
+		await createInboundNote(db, 1, 2);
+		await createInboundNote(db, 2, 3);
+
+		// No filter - all (uncommitted) notes are returned
+		expect(await getActiveInboundNotes(db)).toEqual([
+			expect.objectContaining({ id: 3, warehouseId: 2, warehouseName: "Warehouse 2" }),
+			expect.objectContaining({ id: 2, warehouseId: 1, warehouseName: "Warehouse 1" }),
+			expect.objectContaining({ id: 1, warehouseId: 1, warehouseName: "Warehouse 1" })
+		]);
+
+		// Filtering by warehouse returns only that warehouse's notes
+		expect(await getActiveInboundNotes(db, 1)).toEqual([
+			expect.objectContaining({ id: 2, warehouseId: 1, warehouseName: "Warehouse 1" }),
+			expect.objectContaining({ id: 1, warehouseId: 1, warehouseName: "Warehouse 1" })
+		]);
+		expect(await getActiveInboundNotes(db, 2)).toEqual([expect.objectContaining({ id: 3, warehouseId: 2, warehouseName: "Warehouse 2" })]);
+
+		// A warehouse with no (uncommitted) notes yields an empty list
+		expect(await getActiveInboundNotes(db, 3)).toEqual([]);
+
+		// Explicit 'null' filter behaves the same as no filter
+		expect(await getActiveInboundNotes(db, null)).toEqual([
+			expect.objectContaining({ id: 3 }),
+			expect.objectContaining({ id: 2 }),
+			expect.objectContaining({ id: 1 })
 		]);
 	});
 
@@ -301,6 +343,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -315,6 +358,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -323,6 +367,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -337,6 +382,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -345,6 +391,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -359,6 +406,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "New Purchase (3)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -367,6 +415,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -375,6 +424,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -391,6 +441,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "Purchase 3",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -399,6 +450,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "Purchase 2",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -407,6 +459,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -421,6 +474,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 4,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -429,6 +483,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "Purchase 3",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -437,6 +492,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "Purchase 2",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -445,6 +501,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -460,6 +517,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 6,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -468,6 +526,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 4,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -476,6 +535,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "Purchase 3",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -484,6 +544,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "Purchase 2",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -492,6 +553,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -507,6 +569,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 7,
 				displayName: "New Purchase (3)",
+				warehouseId: 2,
 				warehouseName: "Warehouse 2",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -515,6 +578,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 6,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -523,6 +587,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 4,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -531,6 +596,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 3,
 				displayName: "Purchase 3",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -539,6 +605,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "Purchase 2",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -547,6 +614,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "Purchase 1",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -567,6 +635,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -575,6 +644,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -587,6 +657,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 2,
 				displayName: "New Purchase (2)",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),
@@ -631,6 +702,7 @@ describe("Inbound note tests", () => {
 			{
 				id: 1,
 				displayName: "New Purchase",
+				warehouseId: 1,
 				warehouseName: "Warehouse 1",
 				updatedAt: expect.any(Date),
 				createdAt: expect.any(Date),

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -134,13 +134,15 @@ export function createOutboundNote(db: DBAsync, noteId: number): Promise<void> {
  * Only returns notes that have not been committed (draft state).
  *
  * @param {DB} db - Database connection
+ * @param {number | null} [warehouseId] - Optional warehouse ID to filter the notes by
  * @returns {Promise<InboundNoteListItem[]>} Array of inbound notes
  */
-async function _getActiveInboundNotes(db: TXAsync): Promise<InboundNoteListItem[]> {
+async function _getActiveInboundNotes(db: TXAsync, warehouseId?: number | null): Promise<InboundNoteListItem[]> {
 	const query = `
 		SELECT
 			note.id,
 			note.display_name AS displayName,
+			note.warehouse_id AS warehouseId,
 			warehouse.display_name AS warehouseName,
 			note.updated_at,
 			note.created_at,
@@ -149,6 +151,7 @@ async function _getActiveInboundNotes(db: TXAsync): Promise<InboundNoteListItem[
 		INNER JOIN warehouse ON note.warehouse_id = warehouse.id
 		LEFT JOIN book_transaction ON note.id = book_transaction.note_id
 		WHERE note.committed = 0
+		${warehouseId ? "AND note.warehouse_id = ?" : ""}
 		GROUP BY note.id
 		ORDER BY note.updated_at DESC
 	`;
@@ -156,11 +159,12 @@ async function _getActiveInboundNotes(db: TXAsync): Promise<InboundNoteListItem[
 	const res = await db.execO<{
 		id: number;
 		displayName: string;
+		warehouseId: number;
 		warehouseName: string;
 		updated_at: number;
 		created_at: number;
 		totalBooks: number;
-	}>(query);
+	}>(query, warehouseId ? [warehouseId] : []);
 
 	// TODO: update total books when we add note volume stock functionality
 	return res.map(({ updated_at, created_at, ...el }) => ({

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -223,6 +223,7 @@ export type Warehouse = {
 export type InboundNoteListItem = {
 	id: number;
 	displayName: string;
+	warehouseId: number;
 	warehouseName: string;
 	updatedAt: Date;
 	createdAt: Date;

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -38,7 +38,7 @@
 		description: string;
 	}
 
-	$: ({ notes, plugins } = data);
+	$: ({ notes, warehouses, warehouseFilter, plugins } = data);
 
 	$: t = $LL.inventory_page.purchase_tab;
 	$: tPurchase = $LL.purchase_note;
@@ -80,6 +80,13 @@
 		const db = await getDb(app);
 		await deleteNote(db, id);
 	};
+
+	// Navigate to the (warehouse) filtered/unfiltered list. The filter is kept in the (hash) query
+	// string so the filtered list can be deep-linked (e.g. from the warehouse pages).
+	const handleWarehouseFilterChange = (e: Event) => {
+		const value = (e.currentTarget as HTMLSelectElement).value;
+		return goto(appPath("inbound") + (value ? `?warehouse=${value}` : ""));
+	};
 </script>
 
 <InventoryManagementPage {handleCreateWarehouse} {app} {plugins}>
@@ -90,6 +97,22 @@
 			</div>
 		</div>
 	{:else}
+		<div class="flex items-center gap-x-2 px-4">
+			<label for={testId("warehouse-filter-select")} class="text-sm font-medium text-base-content">{t.filter.label()}</label>
+			<select
+				id={testId("warehouse-filter-select")}
+				data-testid={testId("warehouse-filter-select")}
+				class="select-bordered select select-sm"
+				value={warehouseFilter ?? ""}
+				on:change={handleWarehouseFilterChange}
+			>
+				<option value="">{t.filter.all_warehouses()}</option>
+				{#each warehouses as warehouse}
+					<option value={warehouse.id}>{warehouse.displayName || `Warehouse - ${warehouse.id}`}</option>
+				{/each}
+			</select>
+		</div>
+
 		<!-- Start entity list contaier -->
 
 		<!-- 'entity-list-container' class is used for styling, as well as for e2e test selector(s). If changing, expect the e2e to break - update accordingly -->
@@ -172,7 +195,6 @@
 	{/if}
 </InventoryManagementPage>
 
->
 <ConfirmDialog
 	{dialog}
 	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}

--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -17,7 +17,7 @@
 
 	import { PlaceholderBox, Dialog } from "$lib/components";
 
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto as navigate, racefreeGoto } from "$lib/utils/navigation";
 
 	import { formatters as dateFormatters } from "@librocco/shared/i18n-formatters";
 
@@ -83,9 +83,13 @@
 
 	// Navigate to the (warehouse) filtered/unfiltered list. The filter is kept in the (hash) query
 	// string so the filtered list can be deep-linked (e.g. from the warehouse pages).
+	//
+	// NOTE: this is a same-route navigation (only the hash query changes), so the component is reused and
+	// 'onMount' doesn't rerun. Use the plain (non-disposing) 'goto' here: 'racefreeGoto' would tear down
+	// the DB subscription above, permanently stopping live updates for the list.
 	const handleWarehouseFilterChange = (e: Event) => {
 		const value = (e.currentTarget as HTMLSelectElement).value;
-		return goto(appPath("inbound") + (value ? `?warehouse=${value}` : ""));
+		return navigate(appPath("inbound") + (value ? `?warehouse=${value}` : ""));
 	};
 </script>
 

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -20,7 +20,9 @@ const _load = async ({ url, depends, parent }: Parameters<PageLoad>[0]) => {
 	// Reading 'url.hash' also registers a URL dependency - the load reruns whenever the hash
 	// (including its query part) changes.
 	const hashParams = new URLSearchParams(url.hash.split("?")[1] ?? "");
-	const warehouseFilter = Number(hashParams.get("warehouse")) || null;
+	// NOTE: parseInt (rather than Number) tolerates the trailing slash app.html appends on a full
+	// document load ("?warehouse=2" gets rewritten to "?warehouse=2/" - parseInt("2/") === 2)
+	let warehouseFilter = parseInt(hashParams.get("warehouse") ?? "", 10) || null;
 
 	if (!browser) {
 		return { notes: [], warehouses: [] as Warehouse[], warehouseFilter };
@@ -28,8 +30,16 @@ const _load = async ({ url, depends, parent }: Parameters<PageLoad>[0]) => {
 
 	const db = await getDb(app);
 
-	const notes = await getActiveInboundNotes(db, warehouseFilter);
 	const warehouses: Warehouse[] = await getAllWarehouses(db, { skipTotals: true });
+
+	// Fall back to the unfiltered list if the requested warehouse doesn't exist (e.g. a stale deep
+	// link to a warehouse deleted elsewhere) - otherwise the select would render blank above a
+	// (misleadingly) empty list
+	if (warehouseFilter && !warehouses.some(({ id }) => id === warehouseFilter)) {
+		warehouseFilter = null;
+	}
+
+	const notes = await getActiveInboundNotes(db, warehouseFilter);
 
 	return { notes, warehouses, warehouseFilter };
 };

--- a/apps/web-client/src/routes/inventory/inbound/+page.ts
+++ b/apps/web-client/src/routes/inventory/inbound/+page.ts
@@ -1,27 +1,37 @@
 import { browser } from "$app/environment";
 
 import { getActiveInboundNotes } from "$lib/db/cr-sqlite/note";
+import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
 
 import type { PageLoad } from "./$types";
+import type { Warehouse } from "$lib/db/cr-sqlite/types";
 
 import { timed } from "$lib/utils/timer";
 
 import { app } from "$lib/app";
 import { getDb } from "$lib/app/db";
 
-const _load = async ({ depends, parent }: Parameters<PageLoad>[0]) => {
+const _load = async ({ url, depends, parent }: Parameters<PageLoad>[0]) => {
 	await parent();
 	depends("inbound:list");
 
+	// NOTE: the app uses hash-based routing, so the query string lives INSIDE the hash
+	// (e.g. "#/inventory/inbound/?warehouse=2") and 'url.searchParams' is always empty here.
+	// Reading 'url.hash' also registers a URL dependency - the load reruns whenever the hash
+	// (including its query part) changes.
+	const hashParams = new URLSearchParams(url.hash.split("?")[1] ?? "");
+	const warehouseFilter = Number(hashParams.get("warehouse")) || null;
+
 	if (!browser) {
-		return { notes: [] };
+		return { notes: [], warehouses: [] as Warehouse[], warehouseFilter };
 	}
 
 	const db = await getDb(app);
 
-	const notes = await getActiveInboundNotes(db);
+	const notes = await getActiveInboundNotes(db, warehouseFilter);
+	const warehouses: Warehouse[] = await getAllWarehouses(db, { skipTotals: true });
 
-	return { notes };
+	return { notes, warehouses, warehouseFilter };
 };
 
 export const load: PageLoad = timed(_load);

--- a/pkg/shared/src/i18n/de/index.json
+++ b/pkg/shared/src/i18n/de/index.json
@@ -160,6 +160,10 @@
 			"labels": {
 				"button_edit": "",
 				"button_delete": ""
+			},
+			"filter": {
+				"label": "Nach Lager filtern",
+				"all_warehouses": "Alle Lager"
 			}
 		},
 		"warehouses_tab": {

--- a/pkg/shared/src/i18n/en/index.json
+++ b/pkg/shared/src/i18n/en/index.json
@@ -160,6 +160,10 @@
 			"labels": {
 				"button_edit": "Edit",
 				"button_delete": "Delete"
+			},
+			"filter": {
+				"label": "Filter by warehouse",
+				"all_warehouses": "All warehouses"
 			}
 		},
 		"warehouses_tab": {

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -168,6 +168,10 @@ const inventory_page = {
 		labels: {
 			button_edit: "Edit",
 			button_delete: "Delete"
+		},
+		filter: {
+			label: "Filter by warehouse",
+			all_warehouses: "All warehouses"
 		}
 	},
 	warehouses_tab: {

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -455,6 +455,16 @@ type RootTranslation = {
 				 */
 				button_delete: string
 			}
+			filter: {
+				/**
+				 * F​i​l​t​e​r​ ​b​y​ ​w​a​r​e​h​o​u​s​e
+				 */
+				label: string
+				/**
+				 * A​l​l​ ​w​a​r​e​h​o​u​s​e​s
+				 */
+				all_warehouses: string
+			}
 		}
 		warehouses_tab: {
 			/**
@@ -3620,6 +3630,16 @@ export type TranslationFunctions = {
 				 * Delete
 				 */
 				button_delete: () => LocalizedString
+			}
+			filter: {
+				/**
+				 * Filter by warehouse
+				 */
+				label: () => LocalizedString
+				/**
+				 * All warehouses
+				 */
+				all_warehouses: () => LocalizedString
 			}
 		}
 		warehouses_tab: {

--- a/pkg/shared/src/i18n/it/index.json
+++ b/pkg/shared/src/i18n/it/index.json
@@ -160,6 +160,10 @@
 			"labels": {
 				"button_edit": "Modifica",
 				"button_delete": "Elimina"
+			},
+			"filter": {
+				"label": "Filtra per magazzino",
+				"all_warehouses": "Tutti i magazzini"
 			}
 		},
 		"warehouses_tab": {

--- a/pkg/shared/src/testing.ts
+++ b/pkg/shared/src/testing.ts
@@ -74,6 +74,7 @@ export type TestId =
 	| "db-action-delete"
 	| "customer-search-form"
 	| "text-editable-form"
+	| "warehouse-filter-select"
 	| "force-withdrawal-button"
 	| "tooltip-container"
 	| "tooltip-trigger";


### PR DESCRIPTION
Adds a warehouse filter to the global inbound (purchase) notes list, kept in the URL as a hash-internal query (`#/inventory/inbound/?warehouse=<id>`) so the filtered list can be deep-linked (D-323 links to it from the warehouse pages).

**The load-bearing detail: with hash routing, `url.searchParams` is always empty in `load`.** The query string lives inside `url.hash`, so the param is [parsed manually from the hash](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/routes/inventory/inbound/%2Bpage.ts#L18-L25); reading `url.hash` is also what registers the URL dependency that reruns the load when the filter changes.

## What changed

- [`_getActiveInboundNotes`](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/lib/db/cr-sqlite/note.ts#L140-L156) takes an optional `warehouseId` filter and returns `warehouseId` per row (`InboundNoteListItem` extended accordingly)
- `inbound/+page.ts` parses the filter from the hash, loads the warehouse list (`skipTotals: true`) for the select, returns `{ notes, warehouses, warehouseFilter }`
- [`inbound/+page.svelte`](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/routes/inventory/inbound/%2Bpage.svelte#L104-L119): labeled daisyUI select above the list; changing it navigates to `appPath("inbound") + "?warehouse=<id>"` (empty value clears the filter)
- new `TestId` `"warehouse-filter-select"`; i18n strings under `inventory_page.purchase_tab.filter` (en/it/de) + regenerated typesafe-i18n artifacts
- drive-by: removed a stray `>` that rendered as literal text after the page container

## Why it's correct

- SvelteKit's hash route matching strips the `?`-part of the hash, so `#/inventory/inbound/?warehouse=2` still matches the list route; the single-note route `/inventory/inbound/[id]` is untouched (the filter is a query param, not a path segment)
- `parseInt(...) || null` degrades junk deep links (`?warehouse=abc`, `?warehouse=0`) to the unfiltered list

## Review hardening

Fixes from review (commit f308449):

- **Same-route filter navigation no longer kills live updates.** The filter `<select>` used the page's `racefreeGoto(disposer)`, whose disposer tears down the `onRange` subscription that is the only source of `invalidate("inbound:list")`. Since the filter change is a same-route navigation (component reused, `onMount` never reruns), one filter interaction permanently froze the list. The handler now uses the plain non-disposing [`goto`](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/routes/inventory/inbound/%2Bpage.svelte#L84-L93); `racefreeGoto` stays for leave-page navigation.
- **Deep links survive a hard load.** `app.html` appends a trailing slash on full document loads (`?warehouse=2` → `?warehouse=2/`), and `Number("2/")` is `NaN` — the filter was silently dropped. The parser now uses [`parseInt`](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/routes/inventory/inbound/%2Bpage.ts#L23-L25) (`parseInt("2/") === 2`).
- **Unknown/stale warehouse id falls back to the unfiltered list** ([here](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/routes/inventory/inbound/%2Bpage.ts#L35-L40)) instead of rendering a blank select over an empty list (e.g. `?warehouse=999` after the warehouse was deleted elsewhere).
- Two new e2e regression tests (below) covering both majors.

## Tests

- unit ([note.test.ts](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts#L164-L197)): filter returns only that warehouse's notes, no/null filter returns all, `warehouseId` present in rows; 51/51 pass locally
- e2e ([inbound_flow.spec.ts](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/e2e/integration/inbound_flow.spec.ts#L65-L138)): select filters the visible list and updates the URL; [hard (full document) load](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/e2e/integration/inbound_flow.spec.ts#L92-L114) of a filtered deep link keeps the filter through the trailing-slash rewrite (list + select value asserted); [list keeps reacting to DB writes](https://github.com/librocco/librocco/blob/f308449d16696858d03223ffd0539282f0d8ef26/apps/e2e/integration/inbound_flow.spec.ts#L116-L138) after a filter change (disposer regression)

Closes D-322 — https://linear.app/code-myriad/issue/D-322/inbound-make-notes-list-filterable-by-warehouse-linkable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
