### PR TITLE
feat(web-client): deep-link warehouse purchase-note badges to the note(s)

### DIFF
--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -324,19 +324,21 @@ test("should display active purchase note counts per warehouse", async ({ page }
 	const dbHandle = await getDbHandle(page);
 	const warehouseList = content.entityList("warehouse-list");
 
-	// Create two warehouses
+	// Create three warehouses
 	await dbHandle.evaluate(upsertWarehouse, { id: 1, displayName: "Warehouse 1" });
 	await dbHandle.evaluate(upsertWarehouse, { id: 2, displayName: "Warehouse 2" });
+	await dbHandle.evaluate(upsertWarehouse, { id: 3, displayName: "Warehouse 3" });
 
-	// Create 2 draft inbound notes in warehouse 1; one in warehouse 2 (notes stay uncommitted)
+	// Create 2 draft inbound notes in warehouse 1; one in warehouse 2; none in warehouse 3 (notes stay uncommitted)
 	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1 });
 	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1 });
 	await dbHandle.evaluate(createInboundNote, { id: 3, warehouseId: 2 });
 
-	// Warehouse 1 shows "2 purchase notes"; warehouse 2 shows "1 purchase note"
+	// Warehouse 1 shows "2 purchase notes"; warehouse 2 shows "1 purchase note"; warehouse 3 shows the muted "0 purchase notes" pill
 	await warehouseList.assertElements([
 		{ name: "Warehouse 1", numPurchaseNotes: 2 },
-		{ name: "Warehouse 2", numPurchaseNotes: 1 }
+		{ name: "Warehouse 2", numPurchaseNotes: 1 },
+		{ name: "Warehouse 3", numPurchaseNotes: 0 }
 	]);
 
 	// Multiple drafts: the badge links to the warehouse-filtered inbound list

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -328,15 +328,29 @@ test("should display active purchase note counts per warehouse", async ({ page }
 	await dbHandle.evaluate(upsertWarehouse, { id: 1, displayName: "Warehouse 1" });
 	await dbHandle.evaluate(upsertWarehouse, { id: 2, displayName: "Warehouse 2" });
 
-	// Create 2 draft inbound notes in warehouse 1; none in warehouse 2 (notes stay uncommitted)
+	// Create 2 draft inbound notes in warehouse 1; one in warehouse 2 (notes stay uncommitted)
 	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1 });
 	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1 });
+	await dbHandle.evaluate(createInboundNote, { id: 3, warehouseId: 2 });
 
-	// Warehouse 1 shows "2 purchase notes"; warehouse 2 shows the muted ghost pill "0 purchase notes"
+	// Warehouse 1 shows "2 purchase notes"; warehouse 2 shows "1 purchase note"
 	await warehouseList.assertElements([
 		{ name: "Warehouse 1", numPurchaseNotes: 2 },
-		{ name: "Warehouse 2", numPurchaseNotes: 0 }
+		{ name: "Warehouse 2", numPurchaseNotes: 1 }
 	]);
+
+	// Multiple drafts: the badge links to the warehouse-filtered inbound list
+	await expect(warehouseList.item(0).locator('a[data-property="numPurchaseNotes"]')).toHaveAttribute(
+		"href",
+		/#\/inventory\/inbound\/\?warehouse=1$/
+	);
+	// A single draft: the badge deep-links straight to the note
+	await expect(warehouseList.item(1).locator('a[data-property="numPurchaseNotes"]')).toHaveAttribute("href", /#\/inventory\/inbound\/3\/$/);
+
+	// Click-through (single draft): lands on the note page
+	await warehouseList.item(1).locator('a[data-property="numPurchaseNotes"]').click();
+	await dashboard.view("inbound-note").waitFor();
+	await page.waitForURL(/#\/inventory\/inbound\/3\/$/);
 });
 
 test("should display active purchase note count on the warehouse detail page", async ({ page }) => {
@@ -357,10 +371,14 @@ test("should display active purchase note count on the warehouse detail page", a
 	const counter = page.locator('a[data-property="numPurchaseNotes"]');
 	await counter.getByText("2 purchase notes", { exact: true }).waitFor();
 
-	// Click the counter: lands on the inbound (purchase notes) list
+	// Multiple drafts: the counter links to the warehouse-filtered inbound list
+	await expect(counter).toHaveAttribute("href", /#\/inventory\/inbound\/\?warehouse=1$/);
+
+	// Click the counter: lands on the inbound (purchase notes) list, filtered to warehouse 1
 	await counter.click();
 	await dashboard.view("inventory").waitFor();
 	await content.entityList("inbound-list").waitFor();
+	await page.waitForURL(/#\/inventory\/inbound\/\?warehouse=1$/);
 
 	// Warehouse 2 has zero drafts: counter is present but muted (not an anchor) and reads "0 purchase notes"
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -377,7 +395,14 @@ test("should display active purchase note count on the warehouse detail page", a
 	await content.entityList("warehouse-list").item(0).dropdown().viewStock();
 	await dashboard.view("warehouse").waitFor();
 
-	await page.locator('a[data-property="numPurchaseNotes"]').getByText("1 purchase note", { exact: true }).waitFor();
+	const singleCounter = page.locator('a[data-property="numPurchaseNotes"]');
+	await singleCounter.getByText("1 purchase note", { exact: true }).waitFor();
+
+	// A single draft: the counter deep-links straight to the remaining note (id = 2)
+	await expect(singleCounter).toHaveAttribute("href", /#\/inventory\/inbound\/2\/$/);
+	await singleCounter.click();
+	await dashboard.view("inbound-note").waitFor();
+	await page.waitForURL(/#\/inventory\/inbound\/2\/$/);
 });
 
 test("should export warehouses as csv", async ({ page }) => {

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -12,6 +12,8 @@ import {
 	deleteNote,
 	getActiveInboundNotes,
 	getActiveOutboundNotes,
+	getInboundNoteCountsByWarehouse,
+	getInboundNoteCountForWarehouse,
 	getNoteById,
 	commitNote,
 	addVolumesToNote,
@@ -194,6 +196,44 @@ describe("Inbound note tests", () => {
 			expect.objectContaining({ id: 2 }),
 			expect.objectContaining({ id: 1 })
 		]);
+	});
+
+	it("counts uncommitted inbound notes per warehouse (exposing the note id when there's exactly one)", async () => {
+		const db = await getRandomDb();
+
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+		await upsertWarehouse(db, { id: 2, displayName: "Warehouse 2" });
+		await upsertWarehouse(db, { id: 3, displayName: "Warehouse 3" });
+
+		// Warehouse 1 has two drafts, warehouse 2 has one, warehouse 3 has none
+		await createInboundNote(db, 1, 1);
+		await createInboundNote(db, 1, 2);
+		await createInboundNote(db, 2, 3);
+
+		// Outbound note (noise) - shouldn't be counted anywhere
+		await createOutboundNote(db, 4);
+
+		// Map variant: zero-draft warehouses are omitted, singleNoteId is set only for exactly one draft
+		expect(await getInboundNoteCountsByWarehouse(db)).toEqual(
+			new Map([
+				[1, { count: 2, singleNoteId: null }],
+				[2, { count: 1, singleNoteId: 3 }]
+			])
+		);
+
+		// Scoped variant mirrors the map (and returns a zero count for warehouses with no drafts)
+		expect(await getInboundNoteCountForWarehouse(db, 1)).toEqual({ count: 2, singleNoteId: null });
+		expect(await getInboundNoteCountForWarehouse(db, 2)).toEqual({ count: 1, singleNoteId: 3 });
+		expect(await getInboundNoteCountForWarehouse(db, 3)).toEqual({ count: 0, singleNoteId: null });
+
+		// Committing a note removes it from the counts: warehouse 1 drops to a single
+		// (linkable) draft, warehouse 2 drops out of the map entirely
+		await commitNote(db, 1);
+		await commitNote(db, 3);
+
+		expect(await getInboundNoteCountsByWarehouse(db)).toEqual(new Map([[1, { count: 1, singleNoteId: 2 }]]));
+		expect(await getInboundNoteCountForWarehouse(db, 1)).toEqual({ count: 1, singleNoteId: 2 });
+		expect(await getInboundNoteCountForWarehouse(db, 2)).toEqual({ count: 0, singleNoteId: null });
 	});
 
 	it("commits an inbound note (updating committed_at for both the note and all associated book transactions)", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -37,6 +37,7 @@
 import type {
 	DBAsync,
 	TXAsync,
+	InboundNoteCount,
 	InboundNoteListItem,
 	VolumeStock,
 	NoteEntriesItem,
@@ -208,44 +209,52 @@ async function _getActiveOutboundNotes(db: TXAsync): Promise<OutboundNoteListIte
 }
 
 /**
- * Returns a map of warehouseId -> count of uncommitted inbound notes for that warehouse.
- * Warehouses with zero drafts are omitted from the map (callers should default to 0).
+ * Returns a map of warehouseId -> count of uncommitted inbound notes for that warehouse
+ * (along with the note's id when there's exactly one draft - used for deep-linking straight
+ * to the note). Warehouses with zero drafts are omitted from the map (callers should default
+ * to a zero count).
  *
  * @param {DB} db - Database connection
- * @returns {Promise<Map<number, number>>} Map from warehouse ID to active inbound note count
+ * @returns {Promise<Map<number, InboundNoteCount>>} Map from warehouse ID to active inbound note count (+ single note id)
  */
-async function _getInboundNoteCountsByWarehouse(db: TXAsync): Promise<Map<number, number>> {
+async function _getInboundNoteCountsByWarehouse(db: TXAsync): Promise<Map<number, InboundNoteCount>> {
 	const query = `
-		SELECT note.warehouse_id AS warehouseId, COUNT(*) AS count
+		SELECT
+			note.warehouse_id AS warehouseId,
+			COUNT(*) AS count,
+			CASE WHEN COUNT(*) = 1 THEN MAX(note.id) ELSE NULL END AS singleNoteId
 		FROM note
 		INNER JOIN warehouse ON note.warehouse_id = warehouse.id
 		WHERE note.committed = 0
 		GROUP BY note.warehouse_id
 	`;
 
-	const rows = await db.execO<{ warehouseId: number; count: number }>(query);
-	return new Map(rows.map(({ warehouseId, count }) => [warehouseId, count]));
+	const rows = await db.execO<{ warehouseId: number; count: number; singleNoteId: number | null }>(query);
+	return new Map(rows.map(({ warehouseId, count, singleNoteId }) => [warehouseId, { count, singleNoteId }]));
 }
 
 /**
- * Returns the count of uncommitted inbound notes for a single warehouse. Scoped,
- * count-only variant of {@link _getInboundNoteCountsByWarehouse} for detail pages
- * that only need one warehouse's number.
+ * Returns the count of uncommitted inbound notes for a single warehouse (along with the note's
+ * id when there's exactly one draft - used for deep-linking straight to the note). Scoped
+ * variant of {@link _getInboundNoteCountsByWarehouse} for detail pages that only need one
+ * warehouse's number.
  *
  * @param {DB} db - Database connection
  * @param {number} warehouseId - Warehouse to scope the count to
- * @returns {Promise<number>} Count of active inbound notes for the warehouse
+ * @returns {Promise<InboundNoteCount>} Count of active inbound notes for the warehouse (+ single note id)
  */
-async function _getInboundNoteCountForWarehouse(db: TXAsync, warehouseId: number): Promise<number> {
+async function _getInboundNoteCountForWarehouse(db: TXAsync, warehouseId: number): Promise<InboundNoteCount> {
 	const query = `
-		SELECT COUNT(*) AS count
+		SELECT
+			COUNT(*) AS count,
+			CASE WHEN COUNT(*) = 1 THEN MAX(id) ELSE NULL END AS singleNoteId
 		FROM note
 		WHERE committed = 0
 		AND warehouse_id = ?
 	`;
 
-	const [[count]] = await db.execA<[number]>(query, [warehouseId]);
-	return count ?? 0;
+	const [res] = await db.execO<{ count: number; singleNoteId: number | null }>(query, [warehouseId]);
+	return res ?? { count: 0, singleNoteId: null };
 }
 
 /**

--- a/apps/web-client/src/lib/db/cr-sqlite/types.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/types.ts
@@ -238,6 +238,15 @@ export type OutboundNoteListItem = {
 	totalBooks: number;
 };
 
+/**
+ * Count of uncommitted inbound notes for a warehouse. When there's exactly one such note,
+ * 'singleNoteId' holds its id (so the UI can link straight to it), otherwise it's null.
+ */
+export type InboundNoteCount = {
+	count: number;
+	singleNoteId: number | null;
+};
+
 export type VolumeStock = {
 	isbn: string;
 	quantity: number;

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -170,7 +170,15 @@
 			{:else}
 				{#each warehouses as { id, displayName, discount }}
 					{@const href = appPath("warehouses", id)}
-					{@const numPurchaseNotes = inboundNoteCountsByWarehouse?.get(id) ?? 0}
+					{@const { count: numPurchaseNotes, singleNoteId: singlePurchaseNoteId } = inboundNoteCountsByWarehouse?.get(id) ?? {
+						count: 0,
+						singleNoteId: null
+					}}
+					<!-- A single draft links straight to the note, multiple drafts link to the warehouse-filtered inbound list -->
+					{@const purchaseNotesHref =
+						numPurchaseNotes === 1 && singlePurchaseNoteId
+							? appPath("inbound", singlePurchaseNoteId)
+							: `${appPath("inbound")}?warehouse=${id}`}
 
 					<div class="group entity-list-row">
 						<div class="flex flex-col gap-y-2 self-start">
@@ -193,7 +201,7 @@
 
 								{#if numPurchaseNotes > 0}
 									<a
-										href={appPath("inbound")}
+										href={purchaseNotesHref}
 										class="badge-primary badge badge-sm px-1.5 py-2.5 hover:underline focus:underline"
 										data-property="numPurchaseNotes"
 									>

--- a/apps/web-client/src/routes/inventory/warehouses/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.ts
@@ -3,7 +3,7 @@ import { getAllWarehouses } from "$lib/db/cr-sqlite/warehouse";
 import { getInboundNoteCountsByWarehouse } from "$lib/db/cr-sqlite/note";
 
 import type { PageLoad } from "./$types";
-import type { Warehouse } from "$lib/db/cr-sqlite/types";
+import type { InboundNoteCount, Warehouse } from "$lib/db/cr-sqlite/types";
 
 import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 
@@ -22,7 +22,7 @@ const _load = async ({ depends, parent }: Parameters<PageLoad>[0]) => {
 	stockCache.disableRefresh();
 
 	if (!browser) {
-		return { warehouses: [] as Warehouse[], inboundNoteCountsByWarehouse: new Map<number, number>() };
+		return { warehouses: [] as Warehouse[], inboundNoteCountsByWarehouse: new Map<number, InboundNoteCount>() };
 	}
 
 	const db = await getDb(app);

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -44,7 +44,11 @@
 
 	export let data: PageData;
 
-	$: ({ plugins, displayName, publisherList, id, numPurchaseNotes } = data);
+	$: ({ plugins, displayName, publisherList, id, numPurchaseNotes, singlePurchaseNoteId } = data);
+
+	// A single draft links straight to the note, multiple drafts link to the warehouse-filtered inbound list
+	$: purchaseNotesHref =
+		numPurchaseNotes === 1 && singlePurchaseNoteId ? appPath("inbound", singlePurchaseNoteId) : `${appPath("inbound")}?warehouse=${id}`;
 
 	let entries: GetStockResponseItem[] = [];
 	$: data.entries.then((e) => (entries = e));
@@ -179,7 +183,7 @@
 			<div class="mt-2">
 				{#if numPurchaseNotes > 0}
 					<a
-						href={appPath("inbound")}
+						href={purchaseNotesHref}
 						class="badge-primary badge badge-sm px-1.5 py-2.5 hover:underline focus:underline"
 						data-property="numPurchaseNotes"
 					>

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.ts
@@ -33,6 +33,7 @@ const _load = async ({ params, depends, parent }: Parameters<PageLoad>[0]) => {
 			displayName: "N/A",
 			discount: 0,
 			numPurchaseNotes: 0,
+			singlePurchaseNoteId: null as number | null,
 			publisherList: [] as string[],
 			entries: new Promise<GetStockResponseItem[]>(() => {})
 		};
@@ -50,7 +51,7 @@ const _load = async ({ params, depends, parent }: Parameters<PageLoad>[0]) => {
 	}
 
 	const publisherList = await getPublisherList(db);
-	const numPurchaseNotes = await getInboundNoteCountForWarehouse(db, id);
+	const { count: numPurchaseNotes, singleNoteId: singlePurchaseNoteId } = await getInboundNoteCountForWarehouse(db, id);
 
 	// Re-enable the stock cache refreshing to execute in the background
 	stockCache.enableRefresh(db);
@@ -69,7 +70,7 @@ const _load = async ({ params, depends, parent }: Parameters<PageLoad>[0]) => {
 			return [...iter];
 		});
 
-	return { ...warehouse, numPurchaseNotes, publisherList, entries };
+	return { ...warehouse, numPurchaseNotes, singlePurchaseNoteId, publisherList, entries };
 };
 
 export const load: PageLoad = timed(_load);


### PR DESCRIPTION
**Stacked on #1260** (D-322, the warehouse-filterable inbound list); base is `fix/d322-inbound-warehouse-filter`, merge that first.

Makes the purchase-notes badge on the warehouses list and warehouse detail pages link somewhere useful: **exactly one draft → straight to that note** (`/inventory/inbound/<id>/`), **multiple drafts → the warehouse-filtered inbound list** (`/inventory/inbound/?warehouse=<id>`). Previously both always pointed at the unfiltered global list.

## What changed

- [`_getInboundNoteCountsByWarehouse`](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/web-client/src/lib/db/cr-sqlite/note.ts#L220-L234) and [`_getInboundNoteCountForWarehouse`](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/web-client/src/lib/db/cr-sqlite/note.ts#L246-L259) now return `{ count, singleNoteId }` (new `InboundNoteCount` type); `singleNoteId` is `CASE WHEN COUNT(*) = 1 THEN MAX(note.id) ELSE NULL END`, so it's set only for exactly one uncommitted note
- their only consumers, `warehouses/+page.ts` and `warehouses/[id]/+page.ts`, pass the extra field through; badge hrefs computed in [`warehouses/+page.svelte`](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/web-client/src/routes/inventory/warehouses/%2Bpage.svelte#L173-L181) and [`warehouses/[id]/+page.svelte`](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/web-client/src/routes/inventory/warehouses/%5Bid%5D/%2Bpage.svelte#L49-L51)
- count semantics are unchanged (badge text, zero-draft ghost pill, map omitting zero-draft warehouses all behave as before)

## Review hardening

- Restored the zero-count ghost-pill assertion the badge-counts e2e test had dropped (Warehouse 2 was repurposed from 0 to 1 drafts): a third, draft-less warehouse now asserts `{ name: "Warehouse 3", numPurchaseNotes: 0 }`, keeping 2/1/0 coverage in one pass.

## Tests

- unit ([note.test.ts](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts#L201-L238)): `singleNoteId` null for 0 or >1 drafts, set for exactly 1; committed notes drop out; 52/52 pass locally
- e2e ([warehouse_flow.spec.ts](https://github.com/librocco/librocco/blob/6f41f9fb7bd23fa7de7df55d8c845f47051f2833/apps/e2e/integration/warehouse_flow.spec.ts#L321-L408)): badge `href` assertions for both cases on both pages + click-through navigation (single → inbound-note view, multiple → inbound list with `?warehouse=` in the URL); zero-draft pill asserted on the list page

Closes D-323 — https://linear.app/code-myriad/issue/D-323/warehouses-purchase-note-badge-should-deep-link-to-the-notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
