### PR TITLE
fix(web-client): let window.print() paginate past a single page (D-327)

### DIFF
--- a/apps/web-client/src/routes/+layout.svelte
+++ b/apps/web-client/src/routes/+layout.svelte
@@ -441,14 +441,15 @@
 <svelte:window on:error={handleClientSideError} />
 
 <div class="flex h-full bg-base-100 lg:divide-x lg:divide-base-content">
-	<div class="hidden h-full w-72 lg:block">
+	<div id="sidebar" class="hidden h-full w-72 lg:block">
 		<Sidebar />
 	</div>
 
 	<!-- flex flex-1 flex-col justify-items-center overflow-y-auto -->
-	<main class="h-full w-full overflow-hidden">
+	<main id="main" class="h-full w-full overflow-hidden">
 		{#if !$mobileNavOpen}
 			<button
+				id="mobile-nav-trigger"
 				use:melt={$mobileNavTrigger}
 				class="btn-ghost btn-square btn fixed left-3 top-2 z-[200] lg:hidden"
 				aria-label={tLayout.mobile_nav.trigger.aria_label()}
@@ -632,7 +633,27 @@
 		height: 100%;
 		padding: 0;
 	}
+	/*
+	 * On screen the app is a fixed-viewport shell: html/body/main are pinned to 100% height and
+	 * inner containers scroll. In paged media that pins the whole document to a single page and
+	 * everything past it is clipped, so window.print() output must escape the height/overflow chain.
+	 * Inner percentage heights (h-full) resolve to auto once these are lifted.
+	 */
 	@media print {
+		/* !important: body { height; overflow-y } is also set in global.css and the
+		   bundle order of that sheet vs this component's CSS is not guaranteed */
+		:global(html),
+		:global(body) {
+			height: auto !important;
+			overflow: visible !important;
+		}
+
+		#main {
+			height: auto;
+			overflow: visible;
+		}
+
+		#sidebar,
 		#mobile-nav-trigger {
 			display: none;
 		}


### PR DESCRIPTION
Every `window.print()` flow (purchase/sale notes, history pages, warehouse stock) silently lost everything past page 1: the app shell pins `html`/`body`/`main` to viewport height with hidden overflow, which in paged media clips the document to one page. This lifts that chain under `@media print` only. **It does not change lazy table rendering: rows not yet rendered on screen still don't print** (pre-existing, much less severe than losing all pages but the first).

## What changed

- [`@media print` block in the root layout](https://github.com/librocco/librocco/blob/19e85e6cddbeb82b2e1848d58f35a27a5ba2086c/apps/web-client/src/routes/+layout.svelte#L636-L660): `html`/`body`/`#main` get `height: auto; overflow: visible` in print.
- Sidebar is hidden in print, and the hamburger button gets back its `mobile-nav-trigger` id: the print rule targeting it shipped in b9f9c5f3 ("Printable Inbound table") but the id was lost in a later refactor, so the button printed over the top-left of every page.

## Why it's correct

- Inner `h-full` wrappers (PageLayout, per-page scroll containers) need no changes: percentage heights resolve to `auto` once no ancestor has a definite height, so the whole chain unpins from the three root overrides alone.
- `!important` on the `html`/`body` overrides because [`global.css` also sets `body { height; overflow-y }`](https://github.com/librocco/librocco/blob/19e85e6cddbeb82b2e1848d58f35a27a5ba2086c/apps/web-client/src/routes/global.css#L1-L6) and the bundle order of that sheet vs component CSS isn't guaranteed.
- Print-only media query, so on-screen layout is untouched (verified by screenshot before/after).

## Tests

Manual verification on a seeded 100-line purchase note, headless Chromium `page.pdf()`: **1 page before, 5 pages after** (all rendered rows, sidebar/header/hamburger excluded). No automated test: asserting PDF page counts needs Chromium-only print infrastructure we don't have in CI.

Closes D-327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)