### PR TITLE
fix(web-client): use non-disposing goto for same-route navigations (D-328)

### DIFF
--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -15,7 +15,7 @@
 	import ArrowLeft from "$lucide/arrow-left";
 	import ArrowRight from "$lucide/arrow-right";
 
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { browser } from "$app/environment";
 
 	import type { PageData } from "./$types";
@@ -43,7 +43,9 @@
 		// Unsubscribe on unmount
 		disposer?.();
 	});
-	$: goto = racefreeGoto(disposer);
+	// NOTE: the only navigation from this page is same-route (just the [date] param changes), so the component is
+	// reused and 'onMount' doesn't rerun. Use the plain (non-disposing) 'goto': 'racefreeGoto' would tear down the
+	// DB subscription above, permanently stopping live updates for the view (D-328).
 
 	const handlePrint = () => {
 		window.print();

--- a/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
+++ b/apps/web-client/src/routes/history/isbn/[isbn]/+page.svelte
@@ -24,7 +24,7 @@
 
 	import { createSearchDropdown } from "./actions";
 
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto } from "$lib/utils/navigation";
 	import { searchBooks } from "$lib/db/cr-sqlite/books";
 
 	import { appPath } from "$lib/paths";
@@ -52,7 +52,9 @@
 		// Unsubscribe on unmount
 		disposer?.();
 	});
-	$: goto = racefreeGoto(disposer);
+	// NOTE: both navigations from this page are same-route (just the [isbn] param changes), so the component is
+	// reused and 'onMount' doesn't rerun. Use the plain (non-disposing) 'goto': 'racefreeGoto' would tear down the
+	// DB subscription above, permanently stopping live updates for the view (D-328).
 
 	const createMetaString = ({ authors, year, publisher }: Pick<BookData, "authors" | "year" | "publisher">) =>
 		[authors, year, publisher].filter(Boolean).join(", ");

--- a/apps/web-client/src/routes/history/notes/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.svelte
@@ -14,7 +14,7 @@
 	import { HistoryPage } from "$lib/controllers";
 
 	import { formatters as dateFormatters } from "@librocco/shared/i18n-formatters";
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import { appPath } from "$lib/paths";
 	import LL from "@librocco/shared/i18n-svelte";
@@ -38,7 +38,9 @@
 		// Unsubscribe on unmount
 		disposer?.();
 	});
-	$: goto = racefreeGoto(disposer);
+	// NOTE: the only navigation from this page is same-route (just the [date] param changes), so the component is
+	// reused and 'onMount' doesn't rerun. Use the plain (non-disposing) 'goto': 'racefreeGoto' would tear down the
+	// DB subscription above, permanently stopping live updates for the view (D-328).
 
 	const isEqualDateValue = (a?: DateValue, b?: DateValue): boolean => {
 		if (!a || !b) return false;

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
@@ -11,7 +11,7 @@
 
 	import type { PastTransactionItem } from "$lib/db/cr-sqlite/types";
 
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto } from "$lib/utils/navigation";
 
 	import type { PageData } from "./$types";
 
@@ -23,7 +23,6 @@
 
 	import { appPath } from "$lib/paths";
 	import LL from "@librocco/shared/i18n-svelte";
-	import type { LocalizedString } from "typesafe-i18n";
 
 	import { app } from "$lib/app";
 	import { getDbRx } from "$lib/app/db";
@@ -44,16 +43,14 @@
 		disposer?.();
 	});
 
-	$: goto = racefreeGoto(disposer);
+	// NOTE: all navigations from this page are same-route (only the date range / [[noteType]] params change), so the
+	// component is reused and 'onMount' doesn't rerun. Use the plain (non-disposing) 'goto': 'racefreeGoto' would
+	// tear down the DB subscription above, permanently stopping live updates for the view (D-328).
 
 	$: t = $LL.history_page.warehouse_tab.note_table;
 	$: tCommon = $LL.common;
 
-	let tt: { [option: string]: () => LocalizedString };
-	LL.subscribe((LL) => {
-		// Update the translation object
-		tt = LL.history_page.warehouse_tab.note_table.filter_options;
-	});
+	$: tt = $LL.history_page.warehouse_tab.note_table.filter_options;
 
 	// #region date picker
 	const isEqualDateValue = (a?: DateValue, b?: DateValue): boolean => {
@@ -87,7 +84,8 @@
 	};
 
 	// #region dropdown
-	const options = [
+	// Reactive (not a const): 'tt' is only assigned reactively, and the labels should react to language changes
+	$: options = [
 		{
 			label: tt.all(),
 			value: ""

--- a/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
+++ b/apps/web-client/src/routes/orders/suppliers/orders/+page.svelte
@@ -4,7 +4,7 @@
 	import { createDialog } from "@melt-ui/svelte";
 	import { defaults } from "sveltekit-superforms";
 	import { zod } from "sveltekit-superforms/adapters";
-	import { racefreeGoto } from "$lib/utils/navigation";
+	import { goto as navigate, racefreeGoto } from "$lib/utils/navigation";
 
 	import Settings from "$lucide/settings";
 	import Plus from "$lucide/plus";
@@ -47,7 +47,8 @@
 	let disposer: () => void;
 	onMount(() => {
 		if ($page.url.hash.split("?filter=").length <= 1) {
-			goto(`${$page.url.hash}?filter=unordered`);
+			// Same-route navigation (only the hash query changes) - use the plain (non-disposing) 'navigate'
+			navigate(`${$page.url.hash}?filter=unordered`);
 		}
 		const disposer1 = getDbRx(app).onRange(["book"], () => invalidate("books:data"));
 		const disposer2 = getDbRx(app).onRange(["supplier", "supplier_publisher"], () => invalidate("suppliers:data"));
@@ -96,12 +97,15 @@
 		const s = params.get("filter")?.split("/")[0];
 		orderStatusFilter = isOrderStatus(s) ? s : "unordered";
 	}
+	// NOTE: this is a same-route navigation (only the hash query changes), so the component is reused and
+	// 'onMount' doesn't rerun. Use the plain (non-disposing) 'navigate' here: 'racefreeGoto' would tear down
+	// the DB subscriptions above, permanently stopping live updates for the lists (D-328).
 	function setFilter(status: OrderStatus) {
 		const [base, search = ""] = $page.url.hash.split("?");
 		const params = new URLSearchParams(search);
 		params.set("filter", status);
 		// Let URL drive the reactive state; no need to pre-set `orderStatusFilter`.
-		goto(`${base}?${params.toString()}`);
+		navigate(`${base}?${params.toString()}`);
 	}
 
 	async function handleReconcile(event: CustomEvent<{ supplierOrderIds: number[] }>) {


### PR DESCRIPTION
Six same-route navigations used the disposing `racefreeGoto`, which tears down the page's DB subscriptions before navigating. Since only params/query change, SvelteKit reuses the component and `onMount` never reruns, so after the first filter/date/ISBN change the page permanently stopped reflecting DB changes (e.g. commits from another device) until a full reload.

## What changed

- History pages ([date](https://github.com/librocco/librocco/blob/d1e57ce06f8e54ea0340557d8a78bd90436357b5/apps/web-client/src/routes/history/date/%5Bdate%5D/%2Bpage.svelte#L43-L48), [notes](https://github.com/librocco/librocco/blob/d1e57ce06f8e54ea0340557d8a78bd90436357b5/apps/web-client/src/routes/history/notes/%5Bdate%5D/%2Bpage.svelte#L38-L43), [isbn](https://github.com/librocco/librocco/blob/d1e57ce06f8e54ea0340557d8a78bd90436357b5/apps/web-client/src/routes/history/isbn/%5Bisbn%5D/%2Bpage.svelte#L52-L57), [warehouse](https://github.com/librocco/librocco/blob/d1e57ce06f8e54ea0340557d8a78bd90436357b5/apps/web-client/src/routes/history/warehouse/%5BwarehouseId%5D/%5Bfrom%5D/%5Bto%5D/%5B%5BnoteType%5D%5D/%2Bpage.svelte#L43-L48)): every navigation is same-route, so the plain `goto` replaces `racefreeGoto` wholesale.
- [Supplier-orders page](https://github.com/librocco/librocco/blob/d1e57ce06f8e54ea0340557d8a78bd90436357b5/apps/web-client/src/routes/orders/suppliers/orders/%2Bpage.svelte#L100-L109): filter tabs (and the onMount default-filter redirect) switch to the plain goto aliased as `navigate`; the three cross-route navs keep `racefreeGoto`. Mirrors the D-322 fix on the inbound page.
- Drive-by on the warehouse history page: a never-unsubscribed `LL.subscribe` becomes reactive `$LL` usage, which makes the filter `options` list reactive (`$:`) as a required companion (and the labels now follow locale changes).

## Why it's correct

- `racefreeGoto` exists for cross-route navigation, where `onDestroy`/remount handle resubscription; on same-route navs nothing recreates the subscriptions it kills. The inbound page already uses exactly this split (D-322, #1260).
- Each page still disposes its subscriptions in `onDestroy` on real unmount; nothing else referenced the removed `$: goto = racefreeGoto(disposer)` bindings.

## Tests

prettier + eslint clean on the five files; svelte-check adds no new errors (remaining errors are pre-existing on main in untouched inventory pages). Manually traced every `goto` call site on the five pages for same-route vs cross-route classification.

Closes D-328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)