### PR TITLE
fix(web-client): repair warehouse and archived-note CSV exports (D-329)

### DIFF
--- a/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
+++ b/apps/web-client/src/routes/history/notes/archive/[id]/+page.svelte
@@ -82,8 +82,8 @@
 				{ displayLabel: t.column_headers.year(), key: "year" },
 				{ displayLabel: t.column_headers.price(), key: "price" },
 				{ displayLabel: t.column_headers.category(), key: "category" },
-				{ displayLabel: t.column_headers.edited_by(), key: "edited_by" },
-				{ displayLabel: t.column_headers.out_of_print(), key: "out_of_print" }
+				{ displayLabel: t.column_headers.edited_by(), key: "editedBy" },
+				{ displayLabel: t.column_headers.out_of_print(), key: "outOfPrint" }
 			],
 			filename: `${displayName.replace(" ", "-")}-${Date.now()}`
 		});

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount, onDestroy } from "svelte";
 	import { fade, fly } from "svelte/transition";
-	import { readable, writable } from "svelte/store";
+	import { writable } from "svelte/store";
 	import { download, generateCsv, mkConfig } from "export-to-csv";
 	import { invalidate } from "$app/navigation";
 
@@ -89,8 +89,8 @@
 				{ displayLabel: tColumnHeaders.year(), key: "year" },
 				{ displayLabel: tColumnHeaders.price(), key: "price" },
 				{ displayLabel: tColumnHeaders.category(), key: "category" },
-				{ displayLabel: tColumnHeaders.edited_by(), key: "edited_by" },
-				{ displayLabel: tColumnHeaders.out_of_print(), key: "out_of_print" }
+				{ displayLabel: tColumnHeaders.edited_by(), key: "editedBy" },
+				{ displayLabel: tColumnHeaders.out_of_print(), key: "outOfPrint" }
 			],
 			filename: `${displayName.replace(" ", "-")}-${Date.now()}`
 		});
@@ -98,8 +98,6 @@
 		const gen = generateCsv(csvConfig)(entries);
 		download(csvConfig)(gen);
 	};
-	const csvEntries = readable([] as any[]);
-
 	// #endregion csv
 
 	// #region warehouse-actions
@@ -200,7 +198,7 @@
 				{/if}
 			</div>
 			<div class="flex justify-between">
-				{#if $csvEntries?.length}
+				{#if entries?.length}
 					<button class="items-center gap-2 rounded-md bg-teal-500 py-[9px] pl-[15px] pr-[17px] text-white" on:click={handleExportCsv}>
 						<span class="aria-hidden"> {tLabels.export_to_csv()} </span>
 					</button>


### PR DESCRIPTION
The warehouse detail page's "Export to CSV" button could never render: it was gated on a [dead `csvEntries = readable([])` store](https://github.com/librocco/librocco/blob/8ee32ad4ed64d62101c19e23a37b6379d425580b/apps/web-client/src/routes/inventory/warehouses/%5Bid%5D/%2Bpage.svelte#L101) that stayed empty forever (regression of the shipped D-228 feature). Separately, both this page and the archived-note page exported the 'Edited by'/'Out of print' columns permanently empty because the CSV keys were snake_case while the rows carry camelCase fields; `export-to-csv` silently substitutes `""` for missing keys.

## What changed

- Gate the export button on the real [`entries`](https://github.com/librocco/librocco/blob/b5365257f1f21c0df8921ba3a108a8eac29e33cf/apps/web-client/src/routes/inventory/warehouses/%5Bid%5D/%2Bpage.svelte#L201) (the same variable the page already uses for its empty-state and table), delete the dead store.
- [Warehouse page](https://github.com/librocco/librocco/blob/b5365257f1f21c0df8921ba3a108a8eac29e33cf/apps/web-client/src/routes/inventory/warehouses/%5Bid%5D/%2Bpage.svelte#L92-L93) and [archived-note page](https://github.com/librocco/librocco/blob/b5365257f1f21c0df8921ba3a108a8eac29e33cf/apps/web-client/src/routes/history/notes/archive/%5Bid%5D/%2Bpage.svelte#L85-L86): CSV keys `edited_by`/`out_of_print` become `editedBy`/`outOfPrint`, matching the row shape (and the warehouses list page, which already uses the correct keys for the same data).

## Tests

prettier + eslint clean; svelte-check adds no new errors. The existing e2e CSV test covers only the warehouses list page export (which was already correct); the fixed button uses the page's established `entries` reactivity, proven by the adjacent `{#if !entries?.length}` empty-state gate.

Closes D-329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)