### PR TITLE
fix(web-client): make OPFS move fallback create its destination (D-331)

### DIFF
--- a/apps/web-client/src/lib/db/cr-sqlite/core/utils.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/core/utils.ts
@@ -188,7 +188,7 @@ export function wrapFileHandle(dirHandle: FileSystemDirectoryHandle, fileHandle:
 		// Case params = [destDirHandle, destName?]
 		const destDir = params[0] as FileSystemDirectoryHandle;
 		// If dest name not provided, use the same name as current file
-		const dest = params[0] || srcHandle.name;
+		const dest = (params[1] as string) || srcHandle.name;
 		return moveImpl(srcDir, srcHandle, destDir, dest);
 	};
 
@@ -214,7 +214,7 @@ async function moveImpl(
 	const srcFile = await srcHandle.getFile();
 	const srcBuf = await srcFile.arrayBuffer();
 
-	const destHandle = await destDir.getFileHandle(destName);
+	const destHandle = await destDir.getFileHandle(destName, { create: true });
 	const destWritable = await destHandle.createWritable();
 
 	await destWritable.write(srcBuf);


### PR DESCRIPTION
On browsers without native `FileSystemFileHandle.move` (Firefox/Safari), the [`moveImpl` fallback](https://github.com/librocco/librocco/blob/b31ecd9bf95aa8f28e0cfd05cfd29c091d5e1b82/apps/web-client/src/lib/db/cr-sqlite/core/utils.ts#L203-L226) always rejected with NotFoundError: it opened the destination with the default `{ create: false }`, while both call sites ([snapshot swap in sync.ts](https://github.com/librocco/librocco/blob/b31ecd9bf95aa8f28e0cfd05cfd29c091d5e1b82/apps/web-client/src/lib/app/sync.ts#L384-L389), [state import in debug-export.ts](https://github.com/librocco/librocco/blob/b31ecd9bf95aa8f28e0cfd05cfd29c091d5e1b82/apps/web-client/src/lib/utils/debug-export.ts#L89-L90)) delete the destination immediately before moving. Net effect: the initial-sync DB snapshot optimization silently degraded to full CRDT sync on those browsers, and the debug state-archive import deleted the live DB then failed to replace it.

## What changed

- `destDir.getFileHandle(destName, { create: true })` — one line; matches the function's own step comment ("1. create dest") and native `move()` semantics (which overwrites).
- Drive-by: the `[destDir, destName?]` overload used `params[0]` (the directory handle) as the destination *name*; now `params[1]`. That branch has no current callers but could never have worked.

## Tests

prettier + eslint + tsc clean. No unit harness exists for these utils (OPFS APIs need a browser); the failure mode and fix were traced through both call sites, and the e2e sync spec (Firefox-pinned) exercises the snapshot path.

Closes D-331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)