### PR TITLE
fix(web-client): unshadow SyncTransportController.close (D-334)

### DIFF
--- a/apps/web-client/src/lib/workers/sync-transport-control.ts
+++ b/apps/web-client/src/lib/workers/sync-transport-control.ts
@@ -212,7 +212,6 @@ export class SyncTransportController implements Transport {
 		this.announcePresence = this.#transport.announcePresence.bind(this.#transport);
 		this.sendChanges = this._sendChanges.bind(this);
 		this.rejectChanges = this.#transport.rejectChanges.bind(this.#transport);
-		this.close = this.#transport.close.bind(this.#transport);
 
 		// Hijack the transport's (internal) mutable methods and expose the same interface
 		// safe from override


### PR DESCRIPTION
`SyncTransportController`'s prototype [`close()`](https://github.com/librocco/librocco/blob/fa1997c58ef6042eb361eaef64e8645a508a724d/apps/web-client/src/lib/workers/sync-transport-control.ts#L322-L325) — which stops the ChangesProcessor before closing the transport — was dead code: the constructor assigned `this.close = this.#transport.close.bind(...)`, and own properties shadow prototype methods. Every caller (SyncedDB.stop → stopAndFinalize) got the raw transport close, so queued change chunks kept applying against a DB being finalized at sync stop.

## What changed

One deletion: the constructor's `this.close = ...` line. The prototype `close()` takes over (it already delegates to the captured `#transport`), so `ChangesProcessor.stop()` now actually runs at sync stop.

## Why it's safe

- The other constructor-bound methods (`announcePresence`, `sendChanges`, `rejectChanges`) have explicit field declarations and stay as-is; `close` had no field declaration, so the prototype method cleanly satisfies the Transport interface (tsc clean).
- The newly-live path strictly *reduces* post-close work (queued chunks are dropped instead of applied); the in-flight chunk behaves as before. Progress listeners receive one extra `{active: false}` event at stop, which is the correct signal.
- Nothing relies on the bound-function identity (no removeEventListener-style usage of `.close`).

## Tests

prettier/eslint/tsc clean; workers unit tests pass (9/9). No existing test constructs the controller; the e2e sync specs exercise stop/handoff and assert nothing about close-time internals.

Closes D-334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)