### PR TITLE
fix(web-client): unswap delete-dialog title/description on list pages (D-330)

### DIFF
--- a/apps/web-client/src/routes/inventory/inbound/+page.svelte
+++ b/apps/web-client/src/routes/inventory/inbound/+page.svelte
@@ -203,8 +203,8 @@
 
 <ConfirmDialog
 	{dialog}
-	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
-	title={$LL.common.delete_dialog.description()}
+	title={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
+	description={$LL.common.delete_dialog.description()}
 	onConfirm={() => {
 		handleDeleteNote(noteToDelete.id);
 		resetDialogState();

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -190,6 +190,6 @@
 	}}
 	onCancel={resetDialogState}
 	labels={{ confirm: "Confirm", cancel: "Cancel" }}
-	title={$LL.common.delete_dialog.description()}
-	description={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
+	title={$LL.common.delete_dialog.title({ entity: noteToDelete?.displayName })}
+	description={$LL.common.delete_dialog.description()}
 />


### PR DESCRIPTION
The delete-note ConfirmDialogs on the [inbound list](https://github.com/librocco/librocco/blob/d23af750c9328d65050ddb126eba10913d07ca71/apps/web-client/src/routes/inventory/inbound/%2Bpage.svelte#L204-L208) and [outbound list](https://github.com/librocco/librocco/blob/d23af750c9328d65050ddb126eba10913d07ca71/apps/web-client/src/routes/outbound/%2Bpage.svelte#L186-L195) pages had `title` and `description` crossed: the heading showed "Once you delete this note, you will not be able to access it again" and the body showed "Permanently delete {entity}?". Swapped to match the note detail pages, which use the same keys correctly.

The e2e delete tests assert both strings are visible (not their placement), so they pass unchanged. prettier + eslint clean.

Closes D-330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)