### PR TITLE
fix(web-client): history page filter/stat/redirect fixes (D-333)

### DIFF
--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -127,7 +127,7 @@
 				</div>
 
 				<h2 id="stats-total" class="px-4 py-4 pt-8 text-xl font-semibold">
-					{t.transactions.title()}: <span data-property="transactions">{stats.totalOutboundBookCount}</span>
+					{t.transactions.title()}: <span data-property="transactions">{bookList.length}</span>
 				</h2>
 
 				<div id="history-table" class="w-full">

--- a/apps/web-client/src/routes/history/notes/[date]/+page.ts
+++ b/apps/web-client/src/routes/history/notes/[date]/+page.ts
@@ -20,7 +20,7 @@ const _load = async ({ params: { date }, parent, depends }: Parameters<PageLoad>
 
 	// Validate the date - if not valid, redirect to default
 	if (!date || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(date)) {
-		redirect(307, appPath("history/date", new Date().toISOString().slice(0, 10)));
+		redirect(307, appPath("history/notes/date", new Date().toISOString().slice(0, 10)));
 	}
 
 	// Prepare the date for usage with date picker

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
@@ -161,11 +161,11 @@
 				<div id="inbound-outbound-filter" class="inline-block">
 					<div class="mt-1 flex items-center divide-x divide-base-300 overflow-hidden rounded-md border">
 						{#each options as { label, value }}
-							{@const active = value === filter}
+							{@const active = value === (filter ?? "")}
 							<button
 								on:click={selectFilter(value)}
 								class="{active ? 'btn-primary' : 'btn-neutral'} btn-sm btn border-none px-3 py-1"
-								class:selected={filter === value}
+								class:selected={active}
 							>
 								{label}
 							</button>


### PR DESCRIPTION
Three small confirmed bugs on history pages, one commit each in spirit but bundled as they're all two-line fixes:

## What changed

- [Warehouse history filter](https://github.com/librocco/librocco/blob/3c1328cf3de562e441e2f9636c3586a66f1b2eb3/apps/web-client/src/routes/history/warehouse/%5BwarehouseId%5D/%5Bfrom%5D/%5Bto%5D/%5B%5BnoteType%5D%5D/%2Bpage.svelte#L163-L165): the "All" button never rendered active — `value === filter` compared `""` with `undefined` (the load function returns `undefined` when the optional [[noteType]] segment is absent). Normalize with `filter ?? ""`; the `class:selected` binding now uses the same normalized flag.
- [Daily-summary heading](https://github.com/librocco/librocco/blob/3c1328cf3de562e441e2f9636c3586a66f1b2eb3/apps/web-client/src/routes/history/date/%5Bdate%5D/%2Bpage.svelte#L129-L131): "Transactions: N" used `stats.totalOutboundBookCount` (sales only), so purchase-only days showed "Transactions: 0" above a populated list. Now shows `bookList.length`, the count of the rows rendered directly below it.
- [Past-notes invalid-date redirect](https://github.com/librocco/librocco/blob/3c1328cf3de562e441e2f9636c3586a66f1b2eb3/apps/web-client/src/routes/history/notes/%5Bdate%5D/%2Bpage.ts#L21-L24): went to the daily-summary tab; now stays on the notes tab (matching `history/+layout.ts`'s default for the bare /history/notes route).

## Tests

prettier + eslint clean; svelte-check adds no new errors. The e2e warehouse-filter test clicks buttons by text and asserts row contents, not active styling — unaffected.

Closes D-333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)