### PR TITLE
fix(web-client): clear in-flight book fetch on rejection so retry works (D-335)

### DIFF
--- a/apps/web-client/src/lib/plugins/book-fetcher-plugin.ts
+++ b/apps/web-client/src/lib/plugins/book-fetcher-plugin.ts
@@ -115,10 +115,16 @@ export class BookFetcherPluginController implements LibroccoPlugin<BookFetcherPl
 		this.#fetchingISBNS.set(isbn, res);
 		this.#fetchedISBNS.set(isbn, res);
 
-		// Clear the memoized ongoing fetch once the fetch is complete
-		res.all().then(() => {
-			this.#fetchingISBNS.delete(isbn);
-		});
+		// Clear the memoized ongoing fetch once the fetch settles - also on rejection, otherwise the ISBN stays in the
+		// in-flight map forever and every subsequent call (including explicit retries) keeps returning the stale, failed result.
+		// The catch only terminates this internal housekeeping chain (preventing an unhandled rejection):
+		// callers still observe failures through the returned 'res'.
+		res
+			.all()
+			.catch(() => {})
+			.finally(() => {
+				this.#fetchingISBNS.delete(isbn);
+			});
 
 		return res;
 	}


### PR DESCRIPTION
A failed book-data fetch (routine while offline) permanently poisoned retries for that ISBN: the in-flight memo was cleared with [`res.all().then(...)`](https://github.com/librocco/librocco/blob/8ee32ad4ed64d62101c19e23a37b6379d425580b/apps/web-client/src/lib/plugins/book-fetcher-plugin.ts#L118-L121), which never runs on rejection, so the ISBN stayed in `#fetchingISBNS` for the session. The BookForm "fetch" button (`retryIfAlreadyAttempted: true`) hit that stale entry and silently did nothing, and the rejection was unhandled.

## What changed

[`book-fetcher-plugin.ts`](https://github.com/librocco/librocco/blob/5f038d1f350a5593aa97eb8ef14590bf4af743be/apps/web-client/src/lib/plugins/book-fetcher-plugin.ts#L118-L127): `res.all().catch(() => {}).finally(() => this.#fetchingISBNS.delete(isbn))`. The catch terminates only this internal housekeeping chain; callers still observe failures through the returned `res`.

## What this does NOT change

Failed results stay memoized in `#fetchedISBNS` for default (non-retry) callers — that's the documented "attempted" semantic. Only the in-flight leak and the unhandled rejection are fixed; explicit retries now actually refetch.

## Tests

prettier/eslint/tsc clean. No unit harness exists for this plugin; the retry path was traced through `fetchBookData`'s memo checks.

Closes D-335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)