### PR TITLE
fix(i18n): user-visible copy fixes across en/it/de + locale sync pruning (D-332)

### DIFF
--- a/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.svelte
+++ b/apps/web-client/src/lib/components-new/ReconciliationOrderSummary/ReconciliationOrderSummary.svelte
@@ -73,10 +73,10 @@
 						<th scope="col" class="text-muted-foreground px-2 py-1.5 text-left text-xs uppercase tracking-wide">{t.table.title()}</th>
 						<th scope="col" class="text-muted-foreground px-2 py-1.5 text-left text-xs uppercase tracking-wide">{t.table.authors()}</th>
 						<th scope="col" class="text-muted-foreground w-20 px-2 py-1.5 text-left text-xs uppercase tracking-wide"
-							>{t.table.quantity()}</th
+							>{t.step1.table.order_quantity()}</th
 						>
 						<th scope="col" class="text-muted-foreground w-20 px-2 py-1.5 text-left text-xs uppercase tracking-wide"
-							>{t.table.quantity()}</th
+							>{t.step1.table.delivered()}</th
 						>
 						<th scope="col" class="text-muted-foreground w-20 px-2 py-1.5 text-left text-xs uppercase tracking-wide"
 							>{t.step2.order_summary.status()}</th

--- a/apps/web-client/src/routes/history/date/[date]/+page.svelte
+++ b/apps/web-client/src/routes/history/date/[date]/+page.svelte
@@ -105,7 +105,7 @@
 							<span data-property="inbound-cover-price">{stats.totalInboundCoverPrice.toFixed(2)}</span>
 						</div>
 						<div class="badge badge-green m-2 p-2 font-bold">
-							{t.stats.total_purchase_cover_price()}:
+							{t.stats.total_purchase_discounted_price()}:
 							<span data-property="inbound-discounted-price">{stats.totalInboundDiscountedPrice.toFixed(2)}</span>
 						</div>
 					</div>

--- a/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
+++ b/apps/web-client/src/routes/history/warehouse/[warehouseId]/[from]/[to]/[[noteType]]/+page.svelte
@@ -200,7 +200,7 @@
 							<div class="col-span-8 grid items-center gap-x-4 md:grid-cols-1 lg:col-span-7 lg:grid-cols-7 xl:col-span-8 xl:grid-cols-8">
 								<p data-property="isbn" class="col-span-2 overflow-hidden">{txn.isbn}</p>
 
-								<p data-property="title" class="col-span-3 overflow-hidden">{txn.title || "Unkonwn Title"}</p>
+								<p data-property="title" class="col-span-3 overflow-hidden">{txn.title || tCommon.placeholders.unknown_title()}</p>
 
 								<p data-property="authors" class="col-span-2 overflow-hidden xl:col-span-3">{txn.authors || ""}</p>
 							</div>

--- a/pkg/shared/src/i18n/de/index.json
+++ b/pkg/shared/src/i18n/de/index.json
@@ -254,9 +254,7 @@
 		}
 	},
 	"suppliers_page": {
-		"title": {
-			"suppliers": ""
-		},
+		"title": "",
 		"placeholder": {
 			"title": "",
 			"description": ""
@@ -632,7 +630,7 @@
 			},
 			"order_summary": {
 				"order_id": "Bestellung #{id}",
-				"books_undelivered": "{count} Buch{{er}} nicht geliefert",
+				"books_undelivered": "{count} {{Buch|Bücher}} nicht geliefert",
 				"complete": "Vollständig",
 				"status": "Status",
 				"missing": "{count} fehlend"

--- a/pkg/shared/src/i18n/en/index.json
+++ b/pkg/shared/src/i18n/en/index.json
@@ -218,7 +218,7 @@
 				"description": "Create a new customer order to get started"
 			},
 			"scan_title": "Scan to add books",
-			"scan_description": "Plugin your barcode scanner and pull the trigger"
+			"scan_description": "Plug in your barcode scanner and pull the trigger"
 		},
 		"new_customer_dialog": {
 			"title": "new customer form dialog",
@@ -379,7 +379,7 @@
 			"any_warehouse": "Any warehouse",
 			"no_warehouses": "No available warehouses",
 			"scan_title": "Scan to select books from...",
-			"scan_description": "Plugin your barcode scanner and pull the trigger"
+			"scan_description": "Plug in your barcode scanner and pull the trigger"
 		},
 		"alerts": {
 			"insufficient_quantity": "The warehouse you're attempting to assign to has no more available quantity, click Force Withdrawal to select another warehouse",
@@ -423,7 +423,7 @@
 		},
 		"placeholder": {
 			"scan_title": "Scan to add books",
-			"scan_description": "Plugin your barcode scanner and pull the trigger"
+			"scan_description": "Plug in your barcode scanner and pull the trigger"
 		}
 	},
 	"settings_page": {
@@ -472,7 +472,7 @@
 	},
 	"common": {
 		"delete_dialog": {
-			"title": "Permenantly delete {entity}?",
+			"title": "Permanently delete {entity}?",
 			"description": "Once you delete this note, you will not be able to access it again"
 		},
 		"edit_book_dialog": {
@@ -913,7 +913,7 @@
 		"error_dialog": {
 			"demo_db_not_initialised": {
 				"title": "Load the DB with data",
-				"call_to_action": "Click on the button below to load the DB prepupulated with demo data",
+				"call_to_action": "Click on the button below to load the DB prepopulated with demo data",
 				"description": "This will download the demo DB .sqlite3 file and store it to browser's OPFS (for in app usage)",
 				"button": "Load DB"
 			},

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -233,7 +233,7 @@ const purchase_note = {
 	},
 	placeholder: {
 		scan_title: "Scan to add books",
-		scan_description: "Plugin your barcode scanner and pull the trigger"
+		scan_description: "Plug in your barcode scanner and pull the trigger"
 	}
 };
 
@@ -272,7 +272,7 @@ const customer_orders_page = {
 			description: "Create a new customer order to get started"
 		},
 		scan_title: "Scan to add books",
-		scan_description: "Plugin your barcode scanner and pull the trigger"
+		scan_description: "Plug in your barcode scanner and pull the trigger"
 	},
 	new_customer_dialog: {
 		title: "new customer form dialog",
@@ -611,7 +611,7 @@ const books_page = {
 
 const common = {
 	delete_dialog: {
-		title: `Permenantly delete {entity}?`,
+		title: `Permanently delete {entity}?`,
 		description: "Once you delete this note, you will not be able to access it again"
 	},
 	edit_book_dialog: {
@@ -705,7 +705,7 @@ const sale_note = {
 		any_warehouse: "Any warehouse",
 		no_warehouses: "No available warehouses",
 		scan_title: "Scan to select books from...",
-		scan_description: "Plugin your barcode scanner and pull the trigger"
+		scan_description: "Plug in your barcode scanner and pull the trigger"
 	},
 	alerts: {
 		insufficient_quantity:
@@ -980,7 +980,7 @@ const layout = {
 	error_dialog: {
 		demo_db_not_initialised: {
 			title: "Load the DB with data",
-			call_to_action: "Click on the button below to load the DB prepupulated with demo data",
+			call_to_action: "Click on the button below to load the DB prepopulated with demo data",
 			description: "This will download the demo DB .sqlite3 file and store it to browser's OPFS (for in app usage)",
 			button: "Load DB"
 		},

--- a/pkg/shared/src/i18n/export-json.ts
+++ b/pkg/shared/src/i18n/export-json.ts
@@ -9,10 +9,14 @@ function syncLocaleWithBase(base: any, target: any): any {
 	const result: any = {}
 
 	for (const key in base) {
+		const targetVal = target?.[key]
 		if (typeof base[key] === 'object' && base[key] !== null && !Array.isArray(base[key])) {
-			result[key] = syncLocaleWithBase(base[key], target?.[key] || {})
+			const targetObj = typeof targetVal === 'object' && targetVal !== null && !Array.isArray(targetVal) ? targetVal : {}
+			result[key] = syncLocaleWithBase(base[key], targetObj)
 		} else {
-			result[key] = key in target ? target[key] : ''
+			// Keep the existing value only if its type matches the base value - prunes stale structures
+			// (e.g. an object left shadowing a base string after a key was flattened)
+			result[key] = typeof targetVal === typeof base[key] ? targetVal : ''
 		}
 	}
 

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -618,7 +618,7 @@ type RootTranslation = {
 			 */
 			scan_title: string
 			/**
-			 * P​l​u​g​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
+			 * P​l​u​g​ ​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
 			 */
 			scan_description: string
 		}
@@ -1085,7 +1085,7 @@ type RootTranslation = {
 			 */
 			scan_title: string
 			/**
-			 * P​l​u​g​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
+			 * P​l​u​g​ ​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
 			 */
 			scan_description: string
 		}
@@ -1211,7 +1211,7 @@ type RootTranslation = {
 			 */
 			scan_title: string
 			/**
-			 * P​l​u​g​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
+			 * P​l​u​g​ ​i​n​ ​y​o​u​r​ ​b​a​r​c​o​d​e​ ​s​c​a​n​n​e​r​ ​a​n​d​ ​p​u​l​l​ ​t​h​e​ ​t​r​i​g​g​e​r
 			 */
 			scan_description: string
 		}
@@ -1329,7 +1329,7 @@ type RootTranslation = {
 	common: {
 		delete_dialog: {
 			/**
-			 * P​e​r​m​e​n​a​n​t​l​y​ ​d​e​l​e​t​e​ ​{​e​n​t​i​t​y​}​?
+			 * P​e​r​m​a​n​e​n​t​l​y​ ​d​e​l​e​t​e​ ​{​e​n​t​i​t​y​}​?
 			 * @param {unknown} entity
 			 */
 			title: RequiredParams<'entity'>
@@ -2605,7 +2605,7 @@ type RootTranslation = {
 				 */
 				title: string
 				/**
-				 * C​l​i​c​k​ ​o​n​ ​t​h​e​ ​b​u​t​t​o​n​ ​b​e​l​o​w​ ​t​o​ ​l​o​a​d​ ​t​h​e​ ​D​B​ ​p​r​e​p​u​p​u​l​a​t​e​d​ ​w​i​t​h​ ​d​e​m​o​ ​d​a​t​a
+				 * C​l​i​c​k​ ​o​n​ ​t​h​e​ ​b​u​t​t​o​n​ ​b​e​l​o​w​ ​t​o​ ​l​o​a​d​ ​t​h​e​ ​D​B​ ​p​r​e​p​o​p​u​l​a​t​e​d​ ​w​i​t​h​ ​d​e​m​o​ ​d​a​t​a
 				 */
 				call_to_action: string
 				/**
@@ -3798,7 +3798,7 @@ export type TranslationFunctions = {
 			 */
 			scan_title: () => LocalizedString
 			/**
-			 * Plugin your barcode scanner and pull the trigger
+			 * Plug in your barcode scanner and pull the trigger
 			 */
 			scan_description: () => LocalizedString
 		}
@@ -4250,7 +4250,7 @@ export type TranslationFunctions = {
 			 */
 			scan_title: () => LocalizedString
 			/**
-			 * Plugin your barcode scanner and pull the trigger
+			 * Plug in your barcode scanner and pull the trigger
 			 */
 			scan_description: () => LocalizedString
 		}
@@ -4372,7 +4372,7 @@ export type TranslationFunctions = {
 			 */
 			scan_title: () => LocalizedString
 			/**
-			 * Plugin your barcode scanner and pull the trigger
+			 * Plug in your barcode scanner and pull the trigger
 			 */
 			scan_description: () => LocalizedString
 		}
@@ -4490,7 +4490,7 @@ export type TranslationFunctions = {
 	common: {
 		delete_dialog: {
 			/**
-			 * Permenantly delete {entity}?
+			 * Permanently delete {entity}?
 			 */
 			title: (arg: { entity: unknown }) => LocalizedString
 			/**
@@ -5741,7 +5741,7 @@ export type TranslationFunctions = {
 				 */
 				title: () => LocalizedString
 				/**
-				 * Click on the button below to load the DB prepupulated with demo data
+				 * Click on the button below to load the DB prepopulated with demo data
 				 */
 				call_to_action: () => LocalizedString
 				/**

--- a/pkg/shared/src/i18n/it/index.json
+++ b/pkg/shared/src/i18n/it/index.json
@@ -405,7 +405,7 @@
 	"purchase_note": {
 		"commit_dialog": {
 			"title": "Confermare acquisto \"{entity}\"?",
-			"description": "{ bookCount } libr{{o|i}} verr{{à|anno}} aggiunti a { warehouseName }"
+			"description": "{ bookCount } libr{{o|i}} verr{{à|anno}} aggiunt{{o|i}} a { warehouseName }"
 		},
 		"stats": {
 			"last_updated": "Ultimo aggiornamento"


### PR DESCRIPTION
Batch of confirmed user-visible string bugs, plus the i18n sync-script fix that lets one of them stay fixed. All renders runtime-verified against the built dictionaries (singular/plural, all three locales).

## What changed

- **en** ([index.ts](https://github.com/librocco/librocco/blob/c22d216b164ccde116189fe482355e808849e7ee/pkg/shared/src/i18n/en/index.ts)): "Permenantly" → "Permanently" (every delete dialog), "prepupulated" → "prepopulated" (demo first-run dialog), "Plugin your barcode scanner" → "Plug in…" (three scan placeholders).
- **it**: purchase commit dialog pluralizes the participle — was "1 libro verrà **aggiunti**", now "aggiunt{{o|i}}" (the sale string already did this).
- **de**: "{count} Buch{{er}}" rendered "2 Bucher"; umlaut plurals can't be suffixes, now "{{Buch|Bücher}}". Also the German Suppliers page h1 rendered **empty**: a stale nested object under `suppliers_page.title` defeated the English fallback — flattened so the fallback applies ("Suppliers").
- **[export-json.ts](https://github.com/librocco/librocco/blob/c22d216b164ccde116189fe482355e808849e7ee/pkg/shared/src/i18n/export-json.ts#L9-L24)** (the load-bearing piece): `syncLocaleWithBase` kept any existing locale value whose key existed, including stale structures whose *shape* no longer matches the base — which is exactly how the de h1 bug survived every sync. Values are now kept only when their type matches the base, so structural drift gets pruned to the fallback instead of perpetuated.
- **web-client**: hardcoded misspelled "Unkonwn Title" → existing translated placeholder (warehouse history); discounted-price stat badge reused the cover-price label → existing discounted key (history/date); reconcile summary's two columns were both labeled "Quantity" → existing ordered/delivered keys.

## Tests

Runtime-verified: `de 1→"1 Buch" / 2→"2 Bücher"`, `it 1→"verrà aggiunto" / 3→"verranno aggiunti"`, de suppliers h1 → "Suppliers", en → "Permanently delete…". pkg/shared tests: same single pre-existing failure as main (StockMap ordering, unrelated). e2e delete-dialog assertions use the translation functions, so they follow the fix. Locale JSON + i18n-types regenerated via `typesafe-i18n-sync` + format in the same commit (type files change in JSDoc comments only).

Closes D-332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)