### PR TITLE
fix(sync-server): validate the :dbname route param (D-336)

### DIFF
--- a/apps/sync-server/src/index.ts
+++ b/apps/sync-server/src/index.ts
@@ -100,6 +100,14 @@ const dbProvider = {
 app.use(cors());
 app.use(express.json());
 
+// Validate the db name for every route with a :dbname param
+app.param("dbname", (_req, res, next, dbname: string) => {
+	if (!isValidDbname(dbname)) {
+		return res.status(400).json({ message: "Invalid database name" });
+	}
+	return next();
+});
+
 app.get("/", (_, res) => {
 	res.send("Ok");
 });
@@ -338,6 +346,12 @@ async function useReadonlyDb<T>(dbname: string, cb: (db: any) => T): Promise<T> 
 	}
 
 	return result;
+}
+
+// A database name must be a plain file name within the DB folder.
+// Same rule as getDbPath in @vlcn.io/ws-server, plus a null-byte check.
+function isValidDbname(dbname: string): boolean {
+	return dbname.length > 0 && !dbname.includes("..") && !dbname.includes("/") && !dbname.includes("\\") && !dbname.includes("\0");
 }
 
 function parsePositiveInteger(rawValue: string | undefined): number | undefined {


### PR DESCRIPTION
The HTTP routes (`/:dbname/health`, `/:dbname/file`, dev-gated `/:dbname/reset`, …) resolved the URL-decoded `:dbname` straight into a filesystem path with no validation, unlike the websocket sync path which already enforces plain-file-name semantics via ws-server's `getDbPath`. This brings the HTTP side in line.

## What changed

- An [`app.param("dbname", …)` hook](https://github.com/librocco/librocco/blob/2886850816093bb6403133f5edb4e2cf66df7a00/apps/sync-server/src/index.ts#L97-L104) rejects names containing path separators, `..`, or null bytes with a 400, before any route handler runs — covering every current and future `:dbname` route in one place.

## Why it's correct

- Centralized: `app.param` fires for all routes using the param, so no handler can forget the check.
- Legitimate names are unaffected: db file names (e.g. `dev.sqlite3`) contain dots but never separators; the rule matches what the ws path already enforces.

## Tests

Verified against a running server: `/test.sqlite3/health` → 200; names with encoded separators → 400 on /health and /file. Unit tests: same single pre-existing failure as main (`ws-server-reject-recovery`, unrelated); tsc error set unchanged from main.

Closes D-336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)