### PR TITLE
fix(web-client): stop minting an empty reconciliation note on every sale commit (D-597)

### DIFF
--- a/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
+++ b/apps/e2e/integration/note-transactions/outbound_note_transactions.spec.ts
@@ -826,6 +826,35 @@ test("should check validity of the transactions and commit the note on 'commit' 
 		.assertRows([{ isbn: "22222222", quantity: 2 }]);
 });
 
+test("should not create a reconciliation note when committing a note with all transactions in stock", async ({ page }) => {
+	const dbHandle = await getDbHandle(page);
+
+	// Setup - add some stock
+	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1 });
+	await dbHandle.evaluate(addVolumesToNote, [2, { isbn: "11111111", quantity: 4, warehouseId: 1 }] as const);
+	await dbHandle.evaluate(commitNote, 2);
+
+	// Add a fully-in-stock transaction to the outbound note
+	await dbHandle.evaluate(addVolumesToNote, [1, { isbn: "11111111", quantity: 2, warehouseId: 1 }] as const);
+
+	const dashboard = getDashboard(page);
+	const entries = dashboard.content().table("outbound-note");
+	await entries.assertRows([{ isbn: "11111111", quantity: 2, warehouseName: "Warehouse 1" }]);
+
+	await page.getByRole("button", { name: "Commit" }).click();
+
+	const dialog = dashboard.dialog();
+	await dialog.confirm();
+	await expect(dialog).not.toBeVisible();
+
+	// The note should be committed, we're redirected to '/outbound' page
+	await dashboard.view("outbound").waitFor();
+
+	// Regression (D-597): a clean commit used to mint an empty reconciliation note
+	const reconciliationNotes = await dbHandle.evaluate((db) => db.execO("SELECT id FROM note WHERE is_reconciliation_note = 1", []));
+	expect(reconciliationNotes).toEqual([]);
+});
+
 // TODO: Should not allow committing of an empty note ??
 
 test("should create a new (forced) row for the same isbn/warehouse when quantity is increased beyond available stock in specified warehouse", async ({

--- a/apps/web-client/src/routes/outbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[id]/+page.svelte
@@ -177,9 +177,9 @@
 	const handleReconcileAndCommitSelf = (invalidTransactions?: OutOfStockTransaction[]) => async (closeDialog: () => void) => {
 		const db = await getDb(app);
 
-		// TODO: this should probably be wrapped in a txn, but doing so resulted in app freezing at this point
-		const id = await getNoteIdSeq(db);
-		if (invalidTransactions) {
+		if (invalidTransactions?.length) {
+			// TODO: this should probably be wrapped in a txn, but doing so resulted in app freezing at this point
+			const id = await getNoteIdSeq(db);
 			await createAndCommitReconciliationNote(
 				db,
 				id,


### PR DESCRIPTION
Every clean sale commit was minting a zero-transaction reconciliation note: the commit handler guards with `if (invalidTransactions)`, and the clean path passes `[]`, which is truthy. Beyond the junk notes, this doubled note-id burn at peak commit rate, which directly widens the cross-device id-collision window tracked in D-595.

## What changed

- [`handleReconcileAndCommitSelf`](https://github.com/librocco/librocco/blob/edaa9ff5992a10817a6be2508528571b135d1b78/apps/web-client/src/routes/outbound/%5Bid%5D/%2Bpage.svelte#L177-L192) now guards on `invalidTransactions?.length`, and the note-id allocation (`getNoteIdSeq`) moved inside that guard, so a clean commit allocates no id at all.
- e2e regression test: commit a fully-in-stock sale through the dialog, then assert the `note` table contains no `is_reconciliation_note = 1` row.

## Why it's correct

- The dialog UI already branches on `confirmDialogData.length` (empty list renders the plain confirm dialog); only the handler treated `[]` as "reconcile". Out-of-stock commits still pass a non-empty list and reconcile exactly as before, covered by the existing commit e2e.

## What this does NOT do

- The id fetch is still outside the write transaction (the line-180 TODO). That, plus the collision fix itself, is D-595 and stacks on this branch.

Closes D-597
