### PR TITLE
fix(web-client): allocate note/warehouse ids from per-site blocks (D-595)

### DIFF
--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -287,8 +287,15 @@ test("should continue the naming sequence from the highest sequenced note name (
 		]);
 
 	// Rename the remaining notes to restart the sequence
-	await dbHandle.evaluate(updateNote, { id: 3, displayName: "Purchase 3" });
-	await dbHandle.evaluate(updateNote, { id: 4, displayName: "Purchase 4" });
+	// (notes created through the UI get site-scoped ids, so look the ids up by name)
+	const [{ id: note3Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Purchase (3)'")
+	);
+	const [{ id: note4Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Purchase (4)'")
+	);
+	await dbHandle.evaluate(updateNote, { id: note3Id, displayName: "Purchase 3" });
+	await dbHandle.evaluate(updateNote, { id: note4Id, displayName: "Purchase 4" });
 
 	// Create a final note (with reset sequence)
 	await page.getByRole("link", { name: "Warehouses" }).click();

--- a/apps/e2e/integration/outbound_flow.spec.ts
+++ b/apps/e2e/integration/outbound_flow.spec.ts
@@ -195,8 +195,15 @@ test("should continue the naming sequence from the highest sequenced note name (
 		.assertElements([{ name: "New Sale (4)" }, { name: "Sale 2" }, { name: "Sale 1" }, { name: "New Sale (3)" }]);
 
 	// Rename remaining notes to reset the sequence
-	await dbHandle.evaluate(updateNote, { id: 3, displayName: "Sale 3" });
-	await dbHandle.evaluate(updateNote, { id: 4, displayName: "Sale 4" });
+	// (notes created through the UI get site-scoped ids, so look the ids up by name)
+	const [{ id: note3Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Sale (3)'")
+	);
+	const [{ id: note4Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Sale (4)'")
+	);
+	await dbHandle.evaluate(updateNote, { id: note3Id, displayName: "Sale 3" });
+	await dbHandle.evaluate(updateNote, { id: note4Id, displayName: "Sale 4" });
 	await content
 		.entityList("outbound-list")
 		.assertElements([{ name: "Sale 4" }, { name: "Sale 3" }, { name: "Sale 2" }, { name: "Sale 1" }]);

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -212,8 +212,15 @@ test("should continue the naming sequence from the highest sequenced warehouse n
 	]);
 
 	// Rename remaining warehouses to restart the sequence
-	await dbHandle.evaluate(upsertWarehouse, { id: 3, displayName: "Warehouse 3" });
-	await dbHandle.evaluate(upsertWarehouse, { id: 4, displayName: "Warehouse 4" });
+	// (warehouses created through the UI get site-scoped ids, so look the ids up by name)
+	const [{ id: warehouse3Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM warehouse WHERE display_name = 'New Warehouse (3)'")
+	);
+	const [{ id: warehouse4Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM warehouse WHERE display_name = 'New Warehouse (4)'")
+	);
+	await dbHandle.evaluate(upsertWarehouse, { id: warehouse3Id, displayName: "Warehouse 3" });
+	await dbHandle.evaluate(upsertWarehouse, { id: warehouse4Id, displayName: "Warehouse 4" });
 
 	// Create a final warehouse with reset sequence
 	await page.getByRole("link", { name: "Manage inventory" }).click();

--- a/apps/e2e/integration/warehouse_flow.spec.ts
+++ b/apps/e2e/integration/warehouse_flow.spec.ts
@@ -236,13 +236,15 @@ test("should continue the naming sequence from the highest sequenced warehouse n
 	await header.title().assert("New Warehouse (11)");
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
+	// The list has no explicit ordering, so rows come back in id order: the explicitly-seeded
+	// ids (1, 2, 10) precede the UI-created warehouses, whose site-scoped ids are far larger
 	await warehouseList.assertElements([
 		{ name: "Warehouse 1" },
 		{ name: "Warehouse 2" },
+		{ name: "New Warehouse (10)" },
 		{ name: "Warehouse 3" },
 		{ name: "Warehouse 4" },
 		{ name: "New Warehouse" },
-		{ name: "New Warehouse (10)" },
 		{ name: "New Warehouse (11)" }
 	]);
 });

--- a/apps/web-client/src/lib/controllers/Page.svelte
+++ b/apps/web-client/src/lib/controllers/Page.svelte
@@ -24,8 +24,7 @@
 	 */
 	const handleCreateOutboundNote = async () => {
 		const db = await getDb(app);
-		const id = await getNoteIdSeq(db);
-		await createOutboundNote(db, id);
+		const id = await createOutboundNote(db, await getNoteIdSeq(db));
 		await goto(appPath("outbound", id));
 	};
 

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -30,6 +30,7 @@ import {
 import { upsertWarehouse } from "../warehouse";
 import { upsertBook } from "../books";
 import { getStock } from "../stock";
+import { siteIdBlockBase } from "../site-id-block";
 
 describe("Inbound note tests", () => {
 	it("creates a new inbound note, using id and warehouseId, with default fields", async () => {
@@ -1820,20 +1821,23 @@ describe("Reconciliation note", () => {
 });
 
 describe("Misc note tests", () => {
-	it("returns a note id seq", async () => {
+	it("returns a note id seq (scoped to this site's id block)", async () => {
 		const db = await getRandomDb();
 		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
 		await upsertWarehouse(db, { id: 2, displayName: "Warehouse 2" });
+
+		const [[siteId]] = await db.execA<[Uint8Array]>("SELECT crsql_site_id()");
+		const base = siteIdBlockBase(siteId);
 
 		await createInboundNote(db, 1, await getNoteIdSeq(db));
 		await createInboundNote(db, 2, await getNoteIdSeq(db));
 		await createOutboundNote(db, await getNoteIdSeq(db));
 
 		expect(await getActiveInboundNotes(db)).toEqual([
-			expect.objectContaining({ id: 2, warehouseName: "Warehouse 2" }),
-			expect.objectContaining({ id: 1, warehouseName: "Warehouse 1" })
+			expect.objectContaining({ id: base + 2, warehouseName: "Warehouse 2" }),
+			expect.objectContaining({ id: base + 1, warehouseName: "Warehouse 1" })
 		]);
 
-		expect(await getActiveOutboundNotes(db)).toEqual([expect.objectContaining({ id: 3 })]);
+		expect(await getActiveOutboundNotes(db)).toEqual([expect.objectContaining({ id: base + 3 })]);
 	});
 });

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/site-id-block.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/site-id-block.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+
+import type { DBAsync } from "../types";
+
+import { getRandomDb, getRandomDbs, syncDBs } from "./lib";
+
+import { siteIdBlockBase, SITE_ID_BLOCK_SIZE } from "../site-id-block";
+import { createInboundNote, createOutboundNote, createAndCommitReconciliationNote, getNoteIdSeq } from "../note";
+import { getWarehouseIdSeq, upsertWarehouse } from "../warehouse";
+
+const getBlockBase = async (db: DBAsync): Promise<number> => {
+	const [[siteId]] = await db.execA<[Uint8Array]>("SELECT crsql_site_id()");
+	return siteIdBlockBase(siteId);
+};
+
+describe("siteIdBlockBase", () => {
+	it("maps any site id to a block clear of legacy ids and within safe integer range", () => {
+		const zeros = new Uint8Array(16);
+		expect(siteIdBlockBase(zeros)).toBe(SITE_ID_BLOCK_SIZE);
+
+		const ones = new Uint8Array(16).fill(0xff);
+		const maxBase = siteIdBlockBase(ones);
+		expect(maxBase).toBe(((0xffffffff % 2 ** 20) + 1) * SITE_ID_BLOCK_SIZE);
+
+		// The highest possible allocation stays a safe JS integer
+		expect(2 ** 20 * SITE_ID_BLOCK_SIZE + SITE_ID_BLOCK_SIZE).toBeLessThan(Number.MAX_SAFE_INTEGER);
+	});
+
+	it("derives different blocks from different site id prefixes", () => {
+		const a = new Uint8Array(16);
+		const b = new Uint8Array(16);
+		b[3] = 1;
+		expect(siteIdBlockBase(a)).not.toBe(siteIdBlockBase(b));
+	});
+});
+
+describe("per-site id allocation", () => {
+	it("allocates note ids from the site block, ignoring legacy ids", async () => {
+		const db = await getRandomDb();
+		const base = await getBlockBase(db);
+
+		expect(await getNoteIdSeq(db)).toBe(base + 1);
+
+		// A legacy (pre-block) id doesn't shift the block-scoped sequence
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+		await createInboundNote(db, 1, 123);
+		expect(await getNoteIdSeq(db)).toBe(base + 1);
+
+		await createInboundNote(db, 1, await getNoteIdSeq(db));
+		expect(await getNoteIdSeq(db)).toBe(base + 2);
+	});
+
+	it("re-allocates in-transaction when the requested note id is already taken", async () => {
+		const db = await getRandomDb();
+		const base = await getBlockBase(db);
+
+		const first = await createOutboundNote(db, base + 1);
+		expect(first).toBe(base + 1);
+
+		// Same (stale) candidate id: the second create must not clobber the first note
+		const second = await createOutboundNote(db, base + 1);
+		expect(second).toBe(base + 2);
+
+		const ids = await db.execO<{ id: number }>("SELECT id FROM note ORDER BY id");
+		expect(ids).toEqual([{ id: base + 1 }, { id: base + 2 }]);
+	});
+
+	it("re-allocates a taken reconciliation note id and keeps its transactions attached", async () => {
+		const db = await getRandomDb();
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+
+		const taken = await createOutboundNote(db, await getNoteIdSeq(db));
+		await createAndCommitReconciliationNote(db, taken, [{ isbn: "1111111111", quantity: 2, warehouseId: 1 }]);
+
+		const notes = await db.execO<{ id: number; is_reconciliation_note: number }>("SELECT id, is_reconciliation_note FROM note ORDER BY id");
+		expect(notes.length).toBe(2);
+
+		const reconciliation = notes.find(({ is_reconciliation_note }) => is_reconciliation_note === 1);
+		expect(reconciliation.id).not.toBe(taken);
+
+		const [txn] = await db.execO<{ note_id: number }>("SELECT note_id FROM book_transaction");
+		expect(txn.note_id).toBe(reconciliation.id);
+	});
+
+	it("allocates warehouse ids from the site block", async () => {
+		const db = await getRandomDb();
+		const base = await getBlockBase(db);
+
+		expect(await getWarehouseIdSeq(db)).toBe(base + 1);
+		await upsertWarehouse(db, { id: await getWarehouseIdSeq(db), displayName: "Warehouse 1" });
+		expect(await getWarehouseIdSeq(db)).toBe(base + 2);
+	});
+
+	it("prevents cross-device note-id collisions: two out-of-sync devices minting 'the next id' stay distinct", async () => {
+		const [db1, db2] = await getRandomDbs();
+
+		// Both devices allocate their "next id" without having seen each other's writes -
+		// with the old MAX(id) + 1 allocator both would mint the same id and cr-sqlite
+		// would merge the two notes into one row on sync
+		const id1 = await createOutboundNote(db1, await getNoteIdSeq(db1));
+		const id2 = await createOutboundNote(db2, await getNoteIdSeq(db2));
+		expect(id1).not.toBe(id2);
+
+		await syncDBs(db1, db2);
+		await syncDBs(db2, db1);
+
+		const expected = [id1, id2].sort((a, b) => a - b).map((id) => ({ id }));
+		expect(await db1.execO<{ id: number }>("SELECT id FROM note ORDER BY id")).toEqual(expected);
+		expect(await db2.execO<{ id: number }>("SELECT id FROM note ORDER BY id")).toEqual(expected);
+	});
+});

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/warehouse.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import { getRandomDb } from "./lib";
 
 import { upsertWarehouse, getAllWarehouses, getWarehouseById, getWarehouseIdSeq, deleteWarehouse } from "../warehouse";
+import { siteIdBlockBase } from "../site-id-block";
 import {
 	addVolumesToNote,
 	createAndCommitReconciliationNote,
@@ -247,13 +248,16 @@ describe("Warehouse tests", () => {
 		expect(await getAllWarehouses(db)).toEqual([expect.objectContaining({ id: 1 })]);
 	});
 
-	it("retrieves a warehouse id seq", async () => {
+	it("retrieves a warehouse id seq (scoped to this site's id block)", async () => {
 		const db = await getRandomDb();
 
+		const [[siteId]] = await db.execA<[Uint8Array]>("SELECT crsql_site_id()");
+		const base = siteIdBlockBase(siteId);
+
 		await upsertWarehouse(db, { id: await getWarehouseIdSeq(db) });
 		await upsertWarehouse(db, { id: await getWarehouseIdSeq(db) });
 
-		expect(await getAllWarehouses(db)).toEqual([expect.objectContaining({ id: 1 }), expect.objectContaining({ id: 2 })]);
+		expect(await getAllWarehouses(db)).toEqual([expect.objectContaining({ id: base + 1 }), expect.objectContaining({ id: base + 2 })]);
 	});
 
 	it("excludes orphan legs (leg whose note row is absent) from warehouse totals, agreeing with the stock page", async () => {

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -54,10 +54,22 @@ import { NoWarehouseSelectedError, OutOfStockError } from "./errors";
 
 import { getStock } from "./stock";
 
+import { nextSiteScopedId } from "./site-id-block";
+
 async function _getNoteIdSeq(db: TXAsync) {
-	const query = `SELECT COALESCE(MAX(id), 0) + 1 AS nextId FROM note;`;
-	const [result] = await db.execO<{ nextId: number }>(query);
-	return result.nextId;
+	return nextSiteScopedId(db, "note");
+}
+
+/**
+ * Returns `candidate` if no note with that id exists, otherwise allocates a
+ * fresh id from this site's block. Run inside the same transaction as the
+ * INSERT using the id: there the check-and-insert is atomic with respect to
+ * other writers, closing the race left open by fetching an id in one await
+ * and inserting in another (two tabs, double-click).
+ */
+async function resolveFreeNoteId(txDb: TXAsync, candidate: number): Promise<number> {
+	const [taken] = await txDb.execO<{ id: number }>("SELECT id FROM note WHERE id = ?", [candidate]);
+	return taken ? nextSiteScopedId(txDb, "note") : candidate;
 }
 
 /**
@@ -99,17 +111,20 @@ const getSeqName = async (db: TXAsync, kind: "inbound" | "outbound"): Promise<st
  *
  * @param {DB} db - Database connection
  * @param {number} warehouseId - ID of warehouse receiving books
- * @param {number} noteId - Unique identifier for the new note
- * @returns {Promise<void>} Resolves when note is created
+ * @param {number} noteId - Requested id for the new note (re-allocated in-transaction if already taken)
+ * @returns {Promise<number>} The id the note was actually created with
  */
-export function createInboundNote(db: DBAsync, warehouseId: number, noteId: number): Promise<void> {
+export async function createInboundNote(db: DBAsync, warehouseId: number, noteId: number): Promise<number> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, warehouse_id, updated_at, created_at) VALUES (?, ?, ?, ?, ?)";
 
-	return db.tx(async (txDb) => {
+	let id = noteId;
+	await db.tx(async (txDb) => {
+		id = await resolveFreeNoteId(txDb, noteId);
 		const displayName = await getSeqName(txDb, "inbound");
-		await txDb.exec(stmt, [noteId, displayName, warehouseId, timestamp, timestamp]);
+		await txDb.exec(stmt, [id, displayName, warehouseId, timestamp, timestamp]);
 	});
+	return id;
 }
 
 /**
@@ -117,17 +132,20 @@ export function createInboundNote(db: DBAsync, warehouseId: number, noteId: numb
  * Generates a default sequential display name automatically.
  *
  * @param {DB} db - Database connection
- * @param {number} noteId - Unique identifier for the new note
- * @returns {Promise<void>} Resolves when note is created
+ * @param {number} noteId - Requested id for the new note (re-allocated in-transaction if already taken)
+ * @returns {Promise<number>} The id the note was actually created with
  */
-export function createOutboundNote(db: DBAsync, noteId: number): Promise<void> {
+export async function createOutboundNote(db: DBAsync, noteId: number): Promise<number> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, updated_at, created_at) VALUES (?, ?, ?, ?)";
 
-	return db.tx(async (txDb) => {
+	let id = noteId;
+	await db.tx(async (txDb) => {
+		id = await resolveFreeNoteId(txDb, noteId);
 		const displayName = await getSeqName(txDb, "outbound");
-		await txDb.exec(stmt, [noteId, displayName, timestamp, timestamp]);
+		await txDb.exec(stmt, [id, displayName, timestamp, timestamp]);
 	});
+	return id;
 }
 
 /**
@@ -885,13 +903,15 @@ async function _createAndCommitReconciliationNote(db: DBAsync, id: number, volum
 	const displayName = `Reconciliation note: ${new Date(timestamp).toISOString()}`;
 
 	await db.tx(async (txDb) => {
+		const noteId = await resolveFreeNoteId(txDb, id);
+
 		// Insert book transactions
 		for (const volume of volumes) {
 			// TODO: This isn't terribly efficient and should probably be run as a prepared statement, but having done so (with the exact same statement and args)
 			// made the tests fail. Should investigate further
 			await txDb.exec(
 				"INSERT INTO book_transaction (isbn, quantity, warehouse_id, note_id, updated_at, committed_at) VALUES (?, ?, ?, ?, ?, ?)",
-				[volume.isbn, volume.quantity, volume.warehouseId, id, timestamp, timestamp]
+				[volume.isbn, volume.quantity, volume.warehouseId, noteId, timestamp, timestamp]
 			);
 		}
 
@@ -899,7 +919,7 @@ async function _createAndCommitReconciliationNote(db: DBAsync, id: number, volum
 		await txDb.exec(
 			`INSERT INTO note (id, display_name, is_reconciliation_note, updated_at, created_at, committed, committed_at)
 			VALUES (?, ?, 1, ?, ?, 1, ?)`,
-			[id, displayName, timestamp, timestamp, timestamp]
+			[noteId, displayName, timestamp, timestamp, timestamp]
 		);
 	});
 }

--- a/apps/web-client/src/lib/db/cr-sqlite/site-id-block.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/site-id-block.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Per-site id blocks for locally-allocated integer ids
+ *
+ * Note and warehouse ids used to be allocated as a device-local `MAX(id) + 1`.
+ * `note`/`warehouse` are CRRs keyed on that plain integer, so whenever two
+ * devices minted the same "next id" (sync lag, offline work), cr-sqlite merged
+ * two different business documents into one row, column by column.
+ *
+ * Instead, each site now allocates ids from its own block of the integer
+ * space, derived from the local `crsql_site_id`. Blocks are `2^32` wide and
+ * start at `2^32` or above, so:
+ * - two sites with different blocks can never mint the same id
+ * - legacy ids (all far below `2^32`) can never fall inside any block
+ * - the highest possible id (`(2^20 + 1) * 2^32`) stays well below
+ *   `Number.MAX_SAFE_INTEGER` (`2^53 - 1`)
+ *
+ * Two sites can still end up sharing a block if the leading 4 bytes of their
+ * (random) site ids collide modulo 2^20 (~1-in-a-million per pair) - in that
+ * case behavior degrades to the old status quo rather than breaking.
+ */
+
+import type { TXAsync } from "./types";
+
+/** Width of each per-site id block */
+export const SITE_ID_BLOCK_SIZE = 2 ** 32;
+
+/** Number of distinct blocks the site id hashes into */
+const SITE_ID_BLOCK_COUNT = 2 ** 20;
+
+/**
+ * Derives the base of a site's id block from the raw `crsql_site_id` bytes.
+ * The block spans `(base, base + SITE_ID_BLOCK_SIZE]` - allocation starts at
+ * `base + 1`.
+ */
+export function siteIdBlockBase(siteId: Uint8Array): number {
+	const hash = new DataView(siteId.buffer, siteId.byteOffset, siteId.byteLength).getUint32(0);
+	return ((hash % SITE_ID_BLOCK_COUNT) + 1) * SITE_ID_BLOCK_SIZE;
+}
+
+/**
+ * Allocates the next id for `table` from this site's block: block-scoped
+ * `MAX(id) + 1`, starting at the block base + 1 when the block is empty.
+ *
+ * NOTE: the read is only atomic with the subsequent INSERT when both run
+ * inside the same transaction - callers creating rows should re-check the id
+ * in-transaction (see `createInboundNote`/`createOutboundNote` in `note.ts`).
+ */
+export async function nextSiteScopedId(db: TXAsync, table: "note" | "warehouse"): Promise<number> {
+	const [[siteId]] = await db.execA<[Uint8Array]>("SELECT crsql_site_id()");
+	const base = siteIdBlockBase(siteId);
+	const [result] = await db.execO<{ nextId: number }>(`SELECT COALESCE(MAX(id), ?) + 1 AS nextId FROM ${table} WHERE id > ? AND id <= ?`, [
+		base,
+		base,
+		base + SITE_ID_BLOCK_SIZE
+	]);
+	return result.nextId;
+}

--- a/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/warehouse.ts
@@ -19,10 +19,10 @@ import type { DBAsync, TXAsync, PickPartial, Warehouse } from "./types";
 
 import { timed } from "$lib/utils/timer";
 
+import { nextSiteScopedId } from "./site-id-block";
+
 async function _getWarehouseIdSeq(db: TXAsync) {
-	const query = `SELECT COALESCE(MAX(id), 0) + 1 AS nextId FROM warehouse;`;
-	const [result] = await db.execO<{ nextId: number }>(query);
-	return result.nextId;
+	return nextSiteScopedId(db, "warehouse");
 }
 
 /**

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -118,12 +118,11 @@
 	 */
 	const handleCreateInboundNote = (warehouseId: number) => async () => {
 		const db = await getDb(app);
-		const id = await getNoteIdSeq(db);
-		// Note ids get recycled (id seq = MAX(id) + 1): clear any stale auto-print flag left behind by a
-		// previous note with the same id (e.g. one deleted from another workstation - cleanup there can't reach
-		// this workstation's localStorage)
+		const id = await createInboundNote(db, warehouseId, await getNoteIdSeq(db));
+		// Note ids get recycled (id seq = MAX(id) + 1, deletes are hard deletes): clear any stale auto-print
+		// flag left behind by a previous note with the same id (e.g. one deleted from another workstation -
+		// cleanup there can't reach this workstation's localStorage)
 		removeAutoPrintLabelsSetting(id);
-		await createInboundNote(db, warehouseId, id);
 		await goto(appPath("inbound", id));
 	};
 

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -109,12 +109,11 @@
 	 */
 	const handleCreateInboundNote = async () => {
 		const db = await getDb(app);
-		const noteId = await getNoteIdSeq(db);
-		// Note ids get recycled (id seq = MAX(id) + 1): clear any stale auto-print flag left behind by a
-		// previous note with the same id (e.g. one deleted from another workstation - cleanup there can't reach
-		// this workstation's localStorage)
+		const noteId = await createInboundNote(db, id, await getNoteIdSeq(db)); // Id here is warehouseId ^^^
+		// Note ids get recycled (id seq = MAX(id) + 1, deletes are hard deletes): clear any stale auto-print
+		// flag left behind by a previous note with the same id (e.g. one deleted from another workstation -
+		// cleanup there can't reach this workstation's localStorage)
 		removeAutoPrintLabelsSetting(noteId);
-		await createInboundNote(db, id, noteId); // Id here is warehouseId ^^^
 		await goto(appPath("inbound", noteId));
 	};
 	// #endregion warehouse-actions

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -65,8 +65,7 @@
 	 */
 	const handleCreateNote = async () => {
 		const db = await getDb(app);
-		const id = await getNoteIdSeq(db);
-		await createOutboundNote(db, id);
+		const id = await createOutboundNote(db, await getNoteIdSeq(db));
 		await goto(appPath("outbound", id));
 	};
 

--- a/apps/web-client/src/routes/outbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[id]/+page.svelte
@@ -178,7 +178,8 @@
 		const db = await getDb(app);
 
 		if (invalidTransactions?.length) {
-			// TODO: this should probably be wrapped in a txn, but doing so resulted in app freezing at this point
+			// The id fetched here is only a candidate: createAndCommitReconciliationNote re-checks it
+			// inside its transaction and re-allocates if it was taken in the meantime
 			const id = await getNoteIdSeq(db);
 			await createAndCommitReconciliationNote(
 				db,


### PR DESCRIPTION
Note and warehouse ids were allocated as a device-local `MAX(id) + 1` on a CRR keyed on that plain integer, so any sync lag let two devices mint the same "next id" and cr-sqlite merged two different business documents into one row, column by column (a sale merged with a reconciliation note diverges stock on every ISBN they share). Ids now come from a per-site block of the integer space derived from the local `crsql_site_id`: no schema change, no PK migration, **but the guarantee only holds between upgraded devices, so all workstations must be updated together** (an un-upgraded device still allocates from the legacy low range).

## What changed

- New [`site-id-block.ts`](https://github.com/librocco/librocco/blob/8423f454bcd94a9524645551ffea1beac2027b91/apps/web-client/src/lib/db/cr-sqlite/site-id-block.ts): each site allocates from a 2^32-wide block at `((first 4 site-id bytes as uint32) % 2^20 + 1) * 2^32`. `getNoteIdSeq`/`getWarehouseIdSeq` now do block-scoped `MAX + 1`.
- [`createInboundNote`/`createOutboundNote`/`createAndCommitReconciliationNote`](https://github.com/librocco/librocco/blob/8423f454bcd94a9524645551ffea1beac2027b91/apps/web-client/src/lib/db/cr-sqlite/note.ts#L63-L74) re-check the candidate id inside their write transaction and re-allocate if taken, then return the id actually used; callers navigate to the returned id. This closes the local race (two tabs, double-click) that block scoping alone doesn't, and resolves the old "should be wrapped in a txn" TODO in the outbound commit handler.
- The auto-print stale-flag cleanup on the inbound pages now runs after creation, against the actual id.

## Why it's correct

- Two sites with different blocks cannot mint the same id; blocks start at 2^32 or above, so legacy ids (all below ~100k) can never fall inside any block, and the highest possible id (~2^52) stays below `Number.MAX_SAFE_INTEGER`. Route params parse via `Number(params.id)`, exact in that range.
- Ids stay plain INTEGERs: no CRR schema change, no PK rewrite (a June lesson: cr-sqlite PK updates are delete+insert), URLs and joins untouched.
- `MAX(id)` elsewhere in `note.ts` is only used when `COUNT(*) = 1`, so nothing assumes ids are small or chronological.

## What this does NOT do

- Two site-id prefixes can still hash to the same block (~1-in-a-million per pair); that pair degrades to the old status quo rather than breaking.
- Warehouse creation still goes through `upsertWarehouse` with a prefetched id, so its local race window remains (warehouses are created rarely; cross-device collision is what block scoping fixes).
- Customer display-id allocation (`customers.ts`, capped below 10000) is untouched: different id space, customer-orders territory, out of scope for now.

## Tests

New [`site-id-block.test.ts`](https://github.com/librocco/librocco/blob/8423f454bcd94a9524645551ffea1beac2027b91/apps/web-client/src/lib/db/cr-sqlite/__tests__/site-id-block.test.ts): block math bounds, legacy-id interplay, in-transaction re-allocation (plain and reconciliation), and a two-device sync test reproducing the incident shape (both devices mint "the next id" while out of sync, then sync both ways; the notes stay distinct). Existing id-seq tests updated to block-scoped expectations; full note/warehouse/stock/history suites pass locally.

Closes D-595

---
Stacked on #1272 (D-597); merges after it.
