### PR TITLE
feat(web-client): workstation-based default note names (D-608)

### DIFF
--- a/apps/e2e/integration/inbound_flow.spec.ts
+++ b/apps/e2e/integration/inbound_flow.spec.ts
@@ -27,9 +27,9 @@ test('should create a new inbound note, under the particular warehouse, on wareh
 	// Create a new note under "Warehouse 1"
 	await content.entityList("warehouse-list").item(0).getByRole("button", { name: "New Purchase" }).click();
 
-	// Check that we've been redirected to the new note's page
+	// Check that we've been redirected to the new note's page (named after the workstation)
 	await dashboard.view("inbound-note").waitFor();
-	await page.getByRole("main").getByRole("heading", { name: "New Purchase" }).first().waitFor();
+	await page.getByRole("main").getByRole("heading", { name: "Purchase Alpha" }).first().waitFor();
 });
 
 test("should display notes, namespaced to warehouses, in the inbound note list", async ({ page }) => {
@@ -169,7 +169,7 @@ test("note heading should display note name, 'updated at' timestamp", async ({ p
 	await dashboard.content().entityList("warehouse-list").item(0).createNote();
 
 	// Check the title
-	await page.getByRole("heading", { name: "New Purchase" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha" }).first().waitFor();
 
 	// Check the 'updated at' timestamp
 	const updatedAt = new Date();
@@ -184,7 +184,7 @@ test("note should display breadcrumbs leading back to inbound page, or the paren
 	await dashboard.content().entityList("warehouse-list").item(0).createNote();
 
 	await header.breadcrumbs().waitFor();
-	await header.breadcrumbs().assert(["Inbound", "Warehouse 1", "New Purchase"]);
+	await header.breadcrumbs().assert(["Inbound", "Warehouse 1", "Purchase Alpha"]);
 
 	await header.breadcrumbs().getByText("Inbound").click();
 
@@ -216,21 +216,21 @@ test("should assign default name to notes in sequential order (regardless of war
 
 	// First note (Warehouse 1)
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Purchase" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha", exact: true }).first().waitFor();
 	const note1UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
 	// Second note (Warehouse 1)
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Purchase (2)" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha (2)" }).first().waitFor();
 	const note2UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
 	// Third note (Warehouse 2)
 	await warehouseList.item(1).createNote();
-	await page.getByRole("heading", { name: "New Purchase (3)" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha (3)" }).first().waitFor();
 	const note3UpdatedAt = await header.updatedAt().value();
 
 	// Should display created notes in the inbound list
@@ -240,15 +240,13 @@ test("should assign default name to notes in sequential order (regardless of war
 	const entityList = content.entityList("inbound-list");
 
 	await entityList.assertElements([
-		{ name: "Warehouse 2 / New Purchase (3)", numBooks: 0, updatedAt: note3UpdatedAt },
-		{ name: "Warehouse 1 / New Purchase (2)", numBooks: 0, updatedAt: note2UpdatedAt },
-		{ name: "Warehouse 1 / New Purchase", numBooks: 0, updatedAt: note1UpdatedAt }
+		{ name: "Warehouse 2 / Purchase Alpha (3)", numBooks: 0, updatedAt: note3UpdatedAt },
+		{ name: "Warehouse 1 / Purchase Alpha (2)", numBooks: 0, updatedAt: note2UpdatedAt },
+		{ name: "Warehouse 1 / Purchase Alpha", numBooks: 0, updatedAt: note1UpdatedAt }
 	]);
 });
 
-test("should continue the naming sequence from the highest sequenced note name (even if lower sequenced notes have been renamed)", async ({
-	page
-}) => {
+test("should restart the workstation naming sequence once no active note carries the base name", async ({ page }) => {
 	const dashboard = getDashboard(page);
 
 	const content = dashboard.content();
@@ -256,22 +254,26 @@ test("should continue the naming sequence from the highest sequenced note name (
 
 	const dbHandle = await getDbHandle(page);
 
-	// TODO: Create two notes with default names
-	await dbHandle.evaluate(createInboundNote, { id: 1, warehouseId: 1, displayName: "New Purchase" });
-	await dbHandle.evaluate(createInboundNote, { id: 2, warehouseId: 1, displayName: "New Purchase (2)" });
-
-	// Create a new note, continuning the naming sequence
+	// Create two notes through the UI: "Purchase Alpha", "Purchase Alpha (2)"
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Purchase (3)" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha", exact: true }).first().waitFor();
 
 	await page.getByRole("link", { name: "Manage inventory" }).click();
 
-	// Rename the first two notes (leaving us with only "New Purchase (3)", having the default name)
-	await dbHandle.evaluate(updateNote, { id: 1, displayName: "Purchase 1" });
-	await dbHandle.evaluate(updateNote, { id: 2, displayName: "Purchase 2" });
+	await warehouseList.item(0).createNote();
+	await page.getByRole("heading", { name: "Purchase Alpha (2)" }).first().waitFor();
+
+	await page.getByRole("link", { name: "Manage inventory" }).click();
+
+	// Rename the first note: the highest active suffix still wins
+	// (notes created through the UI get site-scoped ids, so look the ids up by name)
+	const [{ id: note1Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Purchase Alpha'")
+	);
+	await dbHandle.evaluate(updateNote, { id: note1Id, displayName: "Purchase 1" });
 
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Purchase (4)" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha (3)" }).first().waitFor();
 
 	// Check names
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -280,28 +282,26 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await content
 		.entityList("inbound-list")
 		.assertElements([
-			{ name: "Warehouse 1 / New Purchase (4)" },
-			{ name: "Warehouse 1 / Purchase 2" },
+			{ name: "Warehouse 1 / Purchase Alpha (3)" },
 			{ name: "Warehouse 1 / Purchase 1" },
-			{ name: "Warehouse 1 / New Purchase (3)" }
+			{ name: "Warehouse 1 / Purchase Alpha (2)" }
 		]);
 
-	// Rename the remaining notes to restart the sequence
-	// (notes created through the UI get site-scoped ids, so look the ids up by name)
+	// Rename the remaining workstation-named notes: the sequence restarts
+	const [{ id: note2Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Purchase Alpha (2)'")
+	);
 	const [{ id: note3Id }] = await dbHandle.evaluate((db) =>
-		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Purchase (3)'")
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Purchase Alpha (3)'")
 	);
-	const [{ id: note4Id }] = await dbHandle.evaluate((db) =>
-		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Purchase (4)'")
-	);
+	await dbHandle.evaluate(updateNote, { id: note2Id, displayName: "Purchase 2" });
 	await dbHandle.evaluate(updateNote, { id: note3Id, displayName: "Purchase 3" });
-	await dbHandle.evaluate(updateNote, { id: note4Id, displayName: "Purchase 4" });
 
 	// Create a final note (with reset sequence)
 	await page.getByRole("link", { name: "Warehouses" }).click();
 
 	await warehouseList.item(0).createNote();
-	await page.getByRole("heading", { name: "New Purchase" }).first().waitFor();
+	await page.getByRole("heading", { name: "Purchase Alpha", exact: true }).first().waitFor();
 
 	// Check names
 	await page.getByRole("link", { name: "Manage inventory" }).click();
@@ -310,8 +310,7 @@ test("should continue the naming sequence from the highest sequenced note name (
 	await content
 		.entityList("inbound-list")
 		.assertElements([
-			{ name: "Warehouse 1 / New Purchase" },
-			{ name: "Warehouse 1 / Purchase 4" },
+			{ name: "Warehouse 1 / Purchase Alpha" },
 			{ name: "Warehouse 1 / Purchase 3" },
 			{ name: "Warehouse 1 / Purchase 2" },
 			{ name: "Warehouse 1 / Purchase 1" }

--- a/apps/e2e/integration/outbound_flow.spec.ts
+++ b/apps/e2e/integration/outbound_flow.spec.ts
@@ -36,8 +36,8 @@ test('should create a new outbound note, on "New sale" and redirect to it', asyn
 	// Create a new note
 	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
 
-	// Check that we've been redirected to the new note's page
-	await page.getByRole("heading", { name: "New Sale" }).first().waitFor();
+	// Check that we've been redirected to the new note's page (named after the workstation)
+	await page.getByRole("heading", { name: "Sale Alpha" }).first().waitFor();
 });
 
 test("should delete the note on delete button click (after confirming the prompt) then make sure a newly created note has an empty state", async ({
@@ -84,7 +84,7 @@ test("note heading should display note name, 'updated at' timestamp", async ({ p
 	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
 
 	// Check the title
-	await page.getByRole("heading", { name: "New Sale" }).first().waitFor();
+	await page.getByRole("heading", { name: "Sale Alpha" }).first().waitFor();
 
 	// Check the 'updated at' timestamp
 	const updatedAt = new Date();
@@ -101,14 +101,14 @@ test("note should display breadcrumbs leading back to outbound page", async ({ p
 
 	await header.breadcrumbs().waitFor();
 
-	await header.breadcrumbs().assert(["Outbound", "New Sale"]);
+	await header.breadcrumbs().assert(["Outbound", "Sale Alpha"]);
 
 	await header.breadcrumbs().getByText("Outbound").click();
 
 	await dashboard.view("outbound").waitFor();
 });
 
-test("should assign default name to notes in sequential order", async ({ page }) => {
+test("should assign workstation-based default names, suffixing concurrent drafts in sequential order", async ({ page }) => {
 	const dashboard = getDashboard(page);
 	await page.getByRole("link", { name: "Sale" }).click();
 
@@ -118,7 +118,7 @@ test("should assign default name to notes in sequential order", async ({ page })
 	// First note
 	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
 
-	await page.getByRole("heading", { name: "New Sale" }).first().waitFor();
+	await page.getByRole("heading", { name: "Sale Alpha", exact: true }).first().waitFor();
 	const note1UpdatedAt = await header.updatedAt().value();
 
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
@@ -126,7 +126,7 @@ test("should assign default name to notes in sequential order", async ({ page })
 	// Second note
 	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
 
-	await page.getByRole("heading", { name: "New Sale (2)" }).first().waitFor();
+	await page.getByRole("heading", { name: "Sale Alpha (2)" }).first().waitFor();
 	const note2UpdatedAt = await header.updatedAt().value();
 
 	// Should display created notes in the outbound note list
@@ -137,86 +137,74 @@ test("should assign default name to notes in sequential order", async ({ page })
 	await entityList.waitFor();
 
 	await entityList.assertElements([
-		{ name: "New Sale (2)", numBooks: 0, updatedAt: note2UpdatedAt },
-		{ name: "New Sale", numBooks: 0, updatedAt: note1UpdatedAt }
+		{ name: "Sale Alpha (2)", numBooks: 0, updatedAt: note2UpdatedAt },
+		{ name: "Sale Alpha", numBooks: 0, updatedAt: note1UpdatedAt }
 	]);
 
-	// assert for note sequence > 10
+	// A note with a different (explicit) name doesn't disturb the workstation sequence
 	const dbHandle = await getDbHandle(page);
 
-	await dbHandle.evaluate(createOutboundNote, { id: 10, displayName: "New Sale (10)" });
+	await dbHandle.evaluate(createOutboundNote, { id: 10, displayName: "Some other note" });
 	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
 
 	await entityList.assertElements([
-		{ name: "New Sale (11)", numBooks: 0 },
-		{ name: "New Sale (10)", numBooks: 0 },
-		{ name: "New Sale (2)", numBooks: 0, updatedAt: note2UpdatedAt },
-		{ name: "New Sale", numBooks: 0, updatedAt: note1UpdatedAt }
+		{ name: "Sale Alpha (3)", numBooks: 0 },
+		{ name: "Some other note", numBooks: 0 },
+		{ name: "Sale Alpha (2)", numBooks: 0, updatedAt: note2UpdatedAt },
+		{ name: "Sale Alpha", numBooks: 0, updatedAt: note1UpdatedAt }
 	]);
 });
 
-test("should continue the naming sequence from the highest sequenced note name (even if lower sequenced notes have been renamed)", async ({
-	page
-}) => {
+test("should restart the workstation naming sequence once no active note carries the base name", async ({ page }) => {
 	const dashboard = getDashboard(page);
 	await page.getByRole("link", { name: "Sale" }).click();
 
 	const content = dashboard.content();
 	const dbHandle = await getDbHandle(page);
 
-	// Create notes with default names
-	await dbHandle.evaluate(createOutboundNote, { id: 1, displayName: "New Sale" });
-	await dbHandle.evaluate(createOutboundNote, { id: 2, displayName: "New Sale (2)" });
-
-	// Create a new note, continuing the naming sequence
-	await page.getByRole("button", { name: "New Sale", exact: true }).click();
-	await page.getByRole("heading", { name: "New Sale (3)" }).first().waitFor();
-
-	// Verify names
+	// Create two drafts through the UI: "Sale Alpha", "Sale Alpha (2)"
+	await page.getByRole("button", { name: "New Sale", exact: true }).first().click();
+	await page.getByRole("heading", { name: "Sale Alpha", exact: true }).first().waitFor();
 	await page.getByRole("link", { name: "Sale" }).first().click(); // In the main nav, not the breadcrumb nav
-	await content.entityList("outbound-list").assertElements([{ name: "New Sale (3)" }, { name: "New Sale (2)" }, { name: "New Sale" }]);
 
-	// Rename the first two notes
-	await dbHandle.evaluate(updateNote, { id: 1, displayName: "Sale 1" });
-	await dbHandle.evaluate(updateNote, { id: 2, displayName: "Sale 2" });
+	await page.getByRole("button", { name: "New Sale", exact: true }).first().click();
+	await page.getByRole("heading", { name: "Sale Alpha (2)" }).first().waitFor();
+	await page.getByRole("link", { name: "Sale" }).first().click(); // In the main nav, not the breadcrumb nav
 
-	// Verify names
-	await content.entityList("outbound-list").assertElements([{ name: "Sale 2" }, { name: "Sale 1" }, { name: "New Sale (3)" }]);
+	await content.entityList("outbound-list").assertElements([{ name: "Sale Alpha (2)" }, { name: "Sale Alpha" }]);
 
-	// Create another note, continuing the sequence
-	await page.getByRole("button", { name: "New Sale", exact: true }).click();
-	await page.getByRole("heading", { name: "New Sale (4)" }).first().waitFor();
-
-	// Verify names
-	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
-	await content
-		.entityList("outbound-list")
-		.assertElements([{ name: "New Sale (4)" }, { name: "Sale 2" }, { name: "Sale 1" }, { name: "New Sale (3)" }]);
-
-	// Rename remaining notes to reset the sequence
+	// Rename the first draft: the highest active suffix still wins
 	// (notes created through the UI get site-scoped ids, so look the ids up by name)
-	const [{ id: note3Id }] = await dbHandle.evaluate((db) =>
-		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Sale (3)'")
+	const [{ id: note1Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Sale Alpha'")
 	);
-	const [{ id: note4Id }] = await dbHandle.evaluate((db) =>
-		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'New Sale (4)'")
-	);
-	await dbHandle.evaluate(updateNote, { id: note3Id, displayName: "Sale 3" });
-	await dbHandle.evaluate(updateNote, { id: note4Id, displayName: "Sale 4" });
-	await content
-		.entityList("outbound-list")
-		.assertElements([{ name: "Sale 4" }, { name: "Sale 3" }, { name: "Sale 2" }, { name: "Sale 1" }]);
+	await dbHandle.evaluate(updateNote, { id: note1Id, displayName: "Sale 1" });
+	await content.entityList("outbound-list").assertElements([{ name: "Sale 1" }, { name: "Sale Alpha (2)" }]);
 
-	// Create a final note with reset sequence
-	await page.getByRole("button", { name: "New Sale", exact: true }).click();
-	await page.getByRole("heading", { name: "New Sale" }).first().waitFor();
+	await page.getByRole("button", { name: "New Sale", exact: true }).first().click();
+	await page.getByRole("heading", { name: "Sale Alpha (3)" }).first().waitFor();
+	await page.getByRole("link", { name: "Sale" }).first().click(); // In the main nav, not the breadcrumb nav
+
+	// Rename the remaining workstation-named drafts: the sequence restarts
+	const [{ id: note2Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Sale Alpha (2)'")
+	);
+	const [{ id: note3Id }] = await dbHandle.evaluate((db) =>
+		db.execO<{ id: number }>("SELECT id FROM note WHERE display_name = 'Sale Alpha (3)'")
+	);
+	await dbHandle.evaluate(updateNote, { id: note2Id, displayName: "Sale 2" });
+	await dbHandle.evaluate(updateNote, { id: note3Id, displayName: "Sale 3" });
+	await content.entityList("outbound-list").assertElements([{ name: "Sale 3" }, { name: "Sale 2" }, { name: "Sale 1" }]);
+
+	await page.getByRole("button", { name: "New Sale", exact: true }).first().click();
+	await page.getByRole("heading", { name: "Sale Alpha", exact: true }).first().waitFor();
 
 	// Verify names
 	await page.getByRole("link", { name: "Outbound" }).first().click(); // In the main nav, not the breadcrumb nav
 	await content
 		.entityList("outbound-list")
-		.assertElements([{ name: "New Sale" }, { name: "Sale 4" }, { name: "Sale 3" }, { name: "Sale 2" }, { name: "Sale 1" }]);
+		.assertElements([{ name: "Sale Alpha" }, { name: "Sale 3" }, { name: "Sale 2" }, { name: "Sale 1" }]);
 });
 
 test("should navigate to note page on 'edit' button click", async ({ page }) => {

--- a/apps/e2e/integration/scan_flow.spec.ts
+++ b/apps/e2e/integration/scan_flow.spec.ts
@@ -19,7 +19,7 @@ test.beforeEach(async ({ page }) => {
 
 	// Create new outbound note (and navigate to it)
 	await page.getByRole("button", { name: "New Sale" }).first().click();
-	await page.getByRole("heading", { name: "New Sale" }).first().waitFor();
+	await page.getByRole("heading", { name: "Sale Alpha" }).first().waitFor();
 });
 
 test("should allow for continous scanning by auto focusing the scan field after the previous scanning operation is submitted", async ({

--- a/apps/e2e/integration/workstation_name.spec.ts
+++ b/apps/e2e/integration/workstation_name.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from "@playwright/test";
+
+import { baseURL } from "@/constants";
+
+import { testBase as test } from "@/helpers/fixtures";
+import { getDashboard } from "@/helpers/dashboard";
+
+test.beforeEach(async ({ page }) => {
+	// Load the app
+	await page.goto(baseURL);
+	await getDashboard(page).waitFor();
+});
+
+test("uses the workstation name set in settings for new note names", async ({ page }) => {
+	const dashboard = getDashboard(page);
+
+	// Change the workstation name on the settings page
+	await page.getByRole("link", { name: "Settings" }).click();
+
+	const workstationInput = page.locator("input[name='workstationName']");
+	await workstationInput.waitFor();
+	// Seeded by the e2e storage state (see playwright.config.ts)
+	await expect(workstationInput).toHaveValue("Alpha");
+
+	await workstationInput.fill("Front desk");
+	const deviceSettingsForm = page.locator("form", { has: page.locator("input[name='workstationName']") });
+	await deviceSettingsForm.getByRole("button", { name: "Save and Reload" }).click();
+
+	// A new sale is named after the updated workstation name
+	await page.getByRole("link", { name: "Sale" }).click();
+	await dashboard.content().header().getByRole("button", { name: "New sale" }).first().click();
+	await page.getByRole("heading", { name: "Sale Front desk", exact: true }).first().waitFor();
+});

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -65,7 +65,22 @@ const baseConfig: Config = {
 		/* Collect trace for failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: "retain-on-failure",
 		/** Record video for all test runs and retain for failed tests. See https://playwright.dev/docs/videos */
-		video: "retain-on-failure"
+		video: "retain-on-failure",
+		/**
+		 * Seed a deterministic workstation name: notes created through the UI are named
+		 * "<Sale|Purchase> <workstation name>" (the name is otherwise randomly generated on first use)
+		 */
+		storageState: {
+			origins: [
+				{
+					origin: new URL(baseURL).origin,
+					localStorage: [
+						{ name: "librocco:settings", value: JSON.stringify({ workstationName: "Alpha", labelPrinterUrl: "", receiptPrinterUrl: "" }) }
+					]
+				}
+			],
+			cookies: [] as any[]
+		}
 	}
 };
 
@@ -118,7 +133,21 @@ const vfsTestConfig: Config = {
 			use: {
 				...device,
 				locale: locales[0],
-				storageState: { origins: [{ origin: new URL(baseURL).origin, localStorage: [{ name: "vfs", value: vfs }] }], cookies: [] as any[] }
+				storageState: {
+					origins: [
+						{
+							origin: new URL(baseURL).origin,
+							localStorage: [
+								{ name: "vfs", value: vfs },
+								{
+									name: "librocco:settings",
+									value: JSON.stringify({ workstationName: "Alpha", labelPrinterUrl: "", receiptPrinterUrl: "" })
+								}
+							]
+						}
+					],
+					cookies: [] as any[]
+				}
 			}
 		}))
 };

--- a/apps/web-client/src/lib/controllers/Page.svelte
+++ b/apps/web-client/src/lib/controllers/Page.svelte
@@ -9,6 +9,7 @@
 	import { goto } from "$lib/utils/navigation";
 
 	import { createOutboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { newSaleNoteName } from "$lib/utils/note-names";
 
 	import { PageLayout, ExtensionStatusBanner } from "$lib/components";
 
@@ -24,7 +25,7 @@
 	 */
 	const handleCreateOutboundNote = async () => {
 		const db = await getDb(app);
-		const id = await createOutboundNote(db, await getNoteIdSeq(db));
+		const id = await createOutboundNote(db, await getNoteIdSeq(db), newSaleNoteName());
 		await goto(appPath("outbound", id));
 	};
 

--- a/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts
@@ -1841,3 +1841,42 @@ describe("Misc note tests", () => {
 		expect(await getActiveOutboundNotes(db)).toEqual([expect.objectContaining({ id: base + 3 })]);
 	});
 });
+
+describe("Workstation-based note names", () => {
+	it("names notes after the provided base, suffixing only among active notes", async () => {
+		const db = await getRandomDb();
+
+		const id1 = await createOutboundNote(db, await getNoteIdSeq(db), "Sale Front desk");
+		const id2 = await createOutboundNote(db, await getNoteIdSeq(db), "Sale Front desk");
+		expect(await getNoteById(db, id1)).toEqual(expect.objectContaining({ displayName: "Sale Front desk" }));
+		expect(await getNoteById(db, id2)).toEqual(expect.objectContaining({ displayName: "Sale Front desk (2)" }));
+
+		// Committed notes drop out of the sequence: a fresh draft starts over
+		await commitNote(db, id1);
+		await commitNote(db, id2);
+		const id3 = await createOutboundNote(db, await getNoteIdSeq(db), "Sale Front desk");
+		expect(await getNoteById(db, id3)).toEqual(expect.objectContaining({ displayName: "Sale Front desk" }));
+	});
+
+	it("keeps inbound and outbound name sequences separate", async () => {
+		const db = await getRandomDb();
+		await upsertWarehouse(db, { id: 1, displayName: "Warehouse 1" });
+
+		const saleId = await createOutboundNote(db, await getNoteIdSeq(db), "Cassa");
+		const purchaseId = await createInboundNote(db, 1, await getNoteIdSeq(db), "Cassa");
+		expect(await getNoteById(db, saleId)).toEqual(expect.objectContaining({ displayName: "Cassa" }));
+		expect(await getNoteById(db, purchaseId)).toEqual(expect.objectContaining({ displayName: "Cassa" }));
+	});
+
+	it("treats LIKE wildcards in the workstation name literally", async () => {
+		const db = await getRandomDb();
+
+		// A name that would match "Sale 100%" as a LIKE pattern, but isn't a suffixed variant of it
+		await createOutboundNote(db, await getNoteIdSeq(db), "Sale 100234 (2)");
+
+		const id1 = await createOutboundNote(db, await getNoteIdSeq(db), "Sale 100%");
+		const id2 = await createOutboundNote(db, await getNoteIdSeq(db), "Sale 100%");
+		expect(await getNoteById(db, id1)).toEqual(expect.objectContaining({ displayName: "Sale 100%" }));
+		expect(await getNoteById(db, id2)).toEqual(expect.objectContaining({ displayName: "Sale 100% (2)" }));
+	});
+});

--- a/apps/web-client/src/lib/db/cr-sqlite/note.ts
+++ b/apps/web-client/src/lib/db/cr-sqlite/note.ts
@@ -105,6 +105,42 @@ const getSeqName = async (db: TXAsync, kind: "inbound" | "outbound"): Promise<st
 	return kind === "inbound" ? `New Purchase (${maxSequence})` : `New Sale (${maxSequence})`;
 };
 
+const escapeLike = (str: string) => str.replace(/[\\%_]/g, (c) => `\\${c}`);
+
+/**
+ * Returns a display name for a new note based on `base` (the workstation-derived
+ * default, e.g. "Sale Front desk"): `base` itself if free, otherwise "base (n)".
+ *
+ * Unlike the legacy `getSeqName`, the sequence only considers ACTIVE (uncommitted)
+ * notes: it exists to tell concurrent drafts apart, and committed notes in history
+ * are already distinguished by their timestamps. This keeps the suffix from growing
+ * unboundedly over the life of the database.
+ */
+const getSeqNameForBase = async (db: TXAsync, kind: "inbound" | "outbound", base: string): Promise<string> => {
+	const query = `
+		SELECT display_name AS displayName FROM note
+		WHERE (displayName = ? OR displayName LIKE ? ESCAPE '\\')
+		AND warehouse_id ${kind === "outbound" ? "IS NULL" : "IS NOT NULL"}
+		AND COALESCE(committed, 0) = 0
+		ORDER BY LENGTH(displayName) DESC, displayName DESC
+		LIMIT 1;
+	`;
+	const [result] = await db.execO<{ displayName?: string }>(query, [base, `${escapeLike(base)} (%`]);
+	const displayName = result?.displayName;
+
+	if (!displayName) {
+		return base;
+	}
+
+	const suffix = displayName.slice(base.length).match(/^ \((\d+)\)$/);
+	// A note named exactly `base` exists, or one with an unparsable suffix: start at (2)
+	if (!suffix) {
+		return `${base} (2)`;
+	}
+
+	return `${base} (${Number(suffix[1]) + 1})`;
+};
+
 /**
  * Creates a new inbound note associated with a specific warehouse.
  * Generates a default sequential display name automatically.
@@ -112,16 +148,17 @@ const getSeqName = async (db: TXAsync, kind: "inbound" | "outbound"): Promise<st
  * @param {DB} db - Database connection
  * @param {number} warehouseId - ID of warehouse receiving books
  * @param {number} noteId - Requested id for the new note (re-allocated in-transaction if already taken)
+ * @param {string} [displayNameBase] - Base for the display name (e.g. the workstation-derived default); suffixed with "(n)" if an active note already carries it. Falls back to the legacy "New Purchase (n)" sequence when omitted.
  * @returns {Promise<number>} The id the note was actually created with
  */
-export async function createInboundNote(db: DBAsync, warehouseId: number, noteId: number): Promise<number> {
+export async function createInboundNote(db: DBAsync, warehouseId: number, noteId: number, displayNameBase?: string): Promise<number> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, warehouse_id, updated_at, created_at) VALUES (?, ?, ?, ?, ?)";
 
 	let id = noteId;
 	await db.tx(async (txDb) => {
 		id = await resolveFreeNoteId(txDb, noteId);
-		const displayName = await getSeqName(txDb, "inbound");
+		const displayName = displayNameBase ? await getSeqNameForBase(txDb, "inbound", displayNameBase) : await getSeqName(txDb, "inbound");
 		await txDb.exec(stmt, [id, displayName, warehouseId, timestamp, timestamp]);
 	});
 	return id;
@@ -133,16 +170,17 @@ export async function createInboundNote(db: DBAsync, warehouseId: number, noteId
  *
  * @param {DB} db - Database connection
  * @param {number} noteId - Requested id for the new note (re-allocated in-transaction if already taken)
+ * @param {string} [displayNameBase] - Base for the display name (e.g. the workstation-derived default); suffixed with "(n)" if an active note already carries it. Falls back to the legacy "New Sale (n)" sequence when omitted.
  * @returns {Promise<number>} The id the note was actually created with
  */
-export async function createOutboundNote(db: DBAsync, noteId: number): Promise<number> {
+export async function createOutboundNote(db: DBAsync, noteId: number, displayNameBase?: string): Promise<number> {
 	const timestamp = Date.now();
 	const stmt = "INSERT INTO note (id, display_name, updated_at, created_at) VALUES (?, ?, ?, ?)";
 
 	let id = noteId;
 	await db.tx(async (txDb) => {
 		id = await resolveFreeNoteId(txDb, noteId);
-		const displayName = await getSeqName(txDb, "outbound");
+		const displayName = displayNameBase ? await getSeqNameForBase(txDb, "outbound", displayNameBase) : await getSeqName(txDb, "outbound");
 		await txDb.exec(stmt, [id, displayName, timestamp, timestamp]);
 	});
 	return id;

--- a/apps/web-client/src/lib/forms/DeviceSettingsForm.svelte
+++ b/apps/web-client/src/lib/forms/DeviceSettingsForm.svelte
@@ -29,7 +29,13 @@
 				<div class="label">
 					<span class="label-text">{$LL.forms.device_settings.labels.workstation_name()}</span>
 				</div>
-				<input id="workstationName" name="workstationName" bind:value={$formStore.workstationName} class="input-bordered input w-full" />
+				<input
+					id="workstationName"
+					name="workstationName"
+					maxlength="60"
+					bind:value={$formStore.workstationName}
+					class="input-bordered input w-full"
+				/>
 				<div class="label">
 					<span class="label-text-alt">{$LL.forms.device_settings.labels.workstation_name_description()}</span>
 				</div>

--- a/apps/web-client/src/lib/forms/DeviceSettingsForm.svelte
+++ b/apps/web-client/src/lib/forms/DeviceSettingsForm.svelte
@@ -27,6 +27,16 @@
 		<div class="flex grow flex-col flex-wrap gap-y-4 lg:flex-row">
 			<label class="form-control basis-full">
 				<div class="label">
+					<span class="label-text">{$LL.forms.device_settings.labels.workstation_name()}</span>
+				</div>
+				<input id="workstationName" name="workstationName" bind:value={$formStore.workstationName} class="input-bordered input w-full" />
+				<div class="label">
+					<span class="label-text-alt">{$LL.forms.device_settings.labels.workstation_name_description()}</span>
+				</div>
+			</label>
+
+			<label class="form-control basis-full">
+				<div class="label">
 					<span class="label-text">{$LL.forms.device_settings.labels.label_printer_url()}</span>
 				</div>
 				<input id="url" name="labelPrinterUrl" bind:value={$formStore.labelPrinterUrl} class="input-bordered input w-full" />

--- a/apps/web-client/src/lib/forms/schemas.ts
+++ b/apps/web-client/src/lib/forms/schemas.ts
@@ -6,6 +6,7 @@ import type { CustomerDisplayIdInfo } from "$lib/db/cr-sqlite/customers";
 
 export type DeviceSettingsSchema = Infer<typeof deviceSettingsSchema>;
 export const deviceSettingsSchema = z.object({
+	workstationName: z.string(),
 	labelPrinterUrl: z.string(),
 	receiptPrinterUrl: z.string()
 });

--- a/apps/web-client/src/lib/forms/schemas.ts
+++ b/apps/web-client/src/lib/forms/schemas.ts
@@ -6,7 +6,8 @@ import type { CustomerDisplayIdInfo } from "$lib/db/cr-sqlite/customers";
 
 export type DeviceSettingsSchema = Infer<typeof deviceSettingsSchema>;
 export const deviceSettingsSchema = z.object({
-	workstationName: z.string(),
+	// The name is copied into every note's display name and synced with it - keep it short
+	workstationName: z.string().max(60),
 	labelPrinterUrl: z.string(),
 	receiptPrinterUrl: z.string()
 });

--- a/apps/web-client/src/lib/stores/app.ts
+++ b/apps/web-client/src/lib/stores/app.ts
@@ -2,7 +2,7 @@ import { persisted } from "svelte-local-storage-store";
 import { of } from "rxjs";
 import { defaults } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
-import { type Writable, type Readable, writable } from "svelte/store";
+import { type Writable, type Readable, writable, get } from "svelte/store";
 import { browser } from "$app/environment";
 
 import type { PluginsInterface } from "$lib/plugins";
@@ -37,6 +37,20 @@ export const removeAutoPrintLabelsSetting = (noteId: number) => {
 
 const { data: defaultSettings } = defaults(zod(deviceSettingsSchema));
 export const deviceSettingsStore = persisted<typeof defaultSettings>(LOCAL_STORAGE_SETTINGS, defaultSettings);
+
+/**
+ * Returns this device's workstation name (used in default note names). If none was ever set
+ * (fresh device, or settings predating the field), generates one via `generateDefault` and
+ * persists it so the device keeps the same name until changed in settings.
+ */
+export const ensureWorkstationName = (generateDefault: () => string): string => {
+	const settings = get(deviceSettingsStore);
+	if (settings.workstationName) return settings.workstationName;
+
+	const workstationName = generateDefault();
+	deviceSettingsStore.update((s) => ({ ...s, workstationName }));
+	return workstationName;
+};
 
 const createDBConnectivityStream = () => {
 	// TODO: this is updated in a different PR, remove when merged

--- a/apps/web-client/src/lib/stores/app.ts
+++ b/apps/web-client/src/lib/stores/app.ts
@@ -48,7 +48,13 @@ export const ensureWorkstationName = (generateDefault: () => string): string => 
 	if (settings.workstationName) return settings.workstationName;
 
 	const workstationName = generateDefault();
-	deviceSettingsStore.update((s) => ({ ...s, workstationName }));
+	// A failed persist (storage quota, disabled storage) must not block note creation:
+	// fall back to using the generated name for this session only
+	try {
+		deviceSettingsStore.update((s) => ({ ...s, workstationName }));
+	} catch (err) {
+		console.warn("[workstation-name] failed to persist the generated name; using it for this session only", err);
+	}
 	return workstationName;
 };
 

--- a/apps/web-client/src/lib/utils/note-names.ts
+++ b/apps/web-client/src/lib/utils/note-names.ts
@@ -15,9 +15,10 @@ import { ensureWorkstationName } from "$lib/stores/app";
  */
 
 const workstationName = (): string => {
-	// The generated default is localized ("Workstation 374" / "Postazione 374") and stored
-	// as-is: it's just an initial value for a user-editable name, not a live translation
-	return ensureWorkstationName(() => get(LL).common.workstation_default_name({ n: Math.floor(Math.random() * 900) + 100 }));
+	// The generated default is localized ("Workstation 3741" / "Postazione 3741") and stored
+	// as-is: it's just an initial value for a user-editable name, not a live translation.
+	// 9000 values keep the chance of two devices drawing the same default negligible
+	return ensureWorkstationName(() => get(LL).common.workstation_default_name({ n: Math.floor(Math.random() * 9000) + 1000 }));
 };
 
 /** Default display name (base) for a new sale note created on this device */

--- a/apps/web-client/src/lib/utils/note-names.ts
+++ b/apps/web-client/src/lib/utils/note-names.ts
@@ -1,0 +1,27 @@
+import { get } from "svelte/store";
+
+import { LL } from "@librocco/shared/i18n-svelte";
+
+import { ensureWorkstationName } from "$lib/stores/app";
+
+/**
+ * @fileoverview Default display names for new notes
+ *
+ * New notes are named after the workstation they're created on ("Sale Front desk",
+ * "Vendita Cassa", ...) so that, with several devices working concurrently, it is
+ * always visible where a note originated. The workstation name is device-local
+ * (localStorage, never synced), randomly generated on first use and editable on the
+ * settings page.
+ */
+
+const workstationName = (): string => {
+	// The generated default is localized ("Workstation 374" / "Postazione 374") and stored
+	// as-is: it's just an initial value for a user-editable name, not a live translation
+	return ensureWorkstationName(() => get(LL).common.workstation_default_name({ n: Math.floor(Math.random() * 900) + 100 }));
+};
+
+/** Default display name (base) for a new sale note created on this device */
+export const newSaleNoteName = (): string => get(LL).common.new_note_names.sale({ workstation: workstationName() });
+
+/** Default display name (base) for a new purchase note created on this device */
+export const newPurchaseNoteName = (): string => get(LL).common.new_note_names.purchase({ workstation: workstationName() });

--- a/apps/web-client/src/routes/inventory/warehouses/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/+page.svelte
@@ -35,6 +35,7 @@
 
 	import { removeAutoPrintLabelsSetting } from "$lib/stores/app";
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { newPurchaseNoteName } from "$lib/utils/note-names";
 	import { getStock } from "$lib/db/cr-sqlite/stock";
 	import { deleteWarehouse, getWarehouseIdSeq, upsertWarehouse } from "$lib/db/cr-sqlite/warehouse";
 	import LL from "@librocco/shared/i18n-svelte";
@@ -118,7 +119,7 @@
 	 */
 	const handleCreateInboundNote = (warehouseId: number) => async () => {
 		const db = await getDb(app);
-		const id = await createInboundNote(db, warehouseId, await getNoteIdSeq(db));
+		const id = await createInboundNote(db, warehouseId, await getNoteIdSeq(db), newPurchaseNoteName());
 		// Note ids get recycled (id seq = MAX(id) + 1, deletes are hard deletes): clear any stale auto-print
 		// flag left behind by a previous note with the same id (e.g. one deleted from another workstation -
 		// cleanup there can't reach this workstation's localStorage)

--- a/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
+++ b/apps/web-client/src/routes/inventory/warehouses/[id]/+page.svelte
@@ -34,6 +34,7 @@
 
 	import { appPath } from "$lib/paths";
 	import { createInboundNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { newPurchaseNoteName } from "$lib/utils/note-names";
 	import { upsertBook } from "$lib/db/cr-sqlite/books";
 	import * as stockCache from "$lib/db/cr-sqlite/stock_cache";
 	import LL from "@librocco/shared/i18n-svelte";
@@ -109,7 +110,7 @@
 	 */
 	const handleCreateInboundNote = async () => {
 		const db = await getDb(app);
-		const noteId = await createInboundNote(db, id, await getNoteIdSeq(db)); // Id here is warehouseId ^^^
+		const noteId = await createInboundNote(db, id, await getNoteIdSeq(db), newPurchaseNoteName()); // Id here is warehouseId ^^^
 		// Note ids get recycled (id seq = MAX(id) + 1, deletes are hard deletes): clear any stale auto-print
 		// flag left behind by a previous note with the same id (e.g. one deleted from another workstation -
 		// cleanup there can't reach this workstation's localStorage)

--- a/apps/web-client/src/routes/outbound/+page.svelte
+++ b/apps/web-client/src/routes/outbound/+page.svelte
@@ -24,6 +24,7 @@
 
 	import { appPath } from "$lib/paths";
 	import { createOutboundNote, deleteNote, getNoteIdSeq } from "$lib/db/cr-sqlite/note";
+	import { newSaleNoteName } from "$lib/utils/note-names";
 	import LL from "@librocco/shared/i18n-svelte";
 	import ConfirmDialog from "$lib/components/Dialogs/ConfirmDialog.svelte";
 
@@ -65,7 +66,7 @@
 	 */
 	const handleCreateNote = async () => {
 		const db = await getDb(app);
-		const id = await createOutboundNote(db, await getNoteIdSeq(db));
+		const id = await createOutboundNote(db, await getNoteIdSeq(db), newSaleNoteName());
 		await goto(appPath("outbound", id));
 	};
 

--- a/apps/web-client/src/routes/outbound/[id]/+page.svelte
+++ b/apps/web-client/src/routes/outbound/[id]/+page.svelte
@@ -174,22 +174,32 @@
 		openReconciliationDialog([]);
 	};
 
+	// Guards against double-activation of the commit confirm: a second concurrent run
+	// would mint a second reconciliation note from the same stale shortage list
+	// (id re-allocation makes both inserts succeed), leaving phantom positive stock
+	let committing = false;
 	const handleReconcileAndCommitSelf = (invalidTransactions?: OutOfStockTransaction[]) => async (closeDialog: () => void) => {
-		const db = await getDb(app);
+		if (committing) return;
+		committing = true;
+		try {
+			const db = await getDb(app);
 
-		if (invalidTransactions?.length) {
-			// The id fetched here is only a candidate: createAndCommitReconciliationNote re-checks it
-			// inside its transaction and re-allocates if it was taken in the meantime
-			const id = await getNoteIdSeq(db);
-			await createAndCommitReconciliationNote(
-				db,
-				id,
-				invalidTransactions.map(({ quantity, available, ...txn }) => ({ ...txn, quantity: quantity - available }))
-			);
+			if (invalidTransactions?.length) {
+				// The id fetched here is only a candidate: createAndCommitReconciliationNote re-checks it
+				// inside its transaction and re-allocates if it was taken in the meantime
+				const id = await getNoteIdSeq(db);
+				await createAndCommitReconciliationNote(
+					db,
+					id,
+					invalidTransactions.map(({ quantity, available, ...txn }) => ({ ...txn, quantity: quantity - available }))
+				);
+			}
+			await commitNote(db, noteId);
+			closeDialog();
+			confirmDialogOpen.set(false);
+		} finally {
+			committing = false;
 		}
-		await commitNote(db, noteId);
-		closeDialog();
-		confirmDialogOpen.set(false);
 	};
 
 	const handleDeleteSelf = async (closeDialog: () => void) => {

--- a/pkg/shared/src/i18n/de/index.json
+++ b/pkg/shared/src/i18n/de/index.json
@@ -516,6 +516,11 @@
 			"purchase_notes": "{count:number} Einkaufsnoti{{z|zen}}",
 			"sale_notes": "{count:number} Verkaufsnoti{{z|zen}}"
 		},
+		"new_note_names": {
+			"sale": "Verkauf {workstation}",
+			"purchase": "Einkauf {workstation}"
+		},
+		"workstation_default_name": "Arbeitsplatz {n:number}",
 		"loading": ""
 	},
 	"supplier_orders_page": {
@@ -982,6 +987,8 @@
 		},
 		"device_settings": {
 			"labels": {
+				"workstation_name": "Name des Arbeitsplatzes",
+				"workstation_name_description": "Wird im Standardnamen der auf diesem Gerät erstellten Notizen verwendet",
 				"label_printer_url": "",
 				"receipt_printer_url": "",
 				"save_reload": ""

--- a/pkg/shared/src/i18n/en/index.json
+++ b/pkg/shared/src/i18n/en/index.json
@@ -514,6 +514,11 @@
 			"purchase_notes": "{count:number} purchase note{{s}}",
 			"sale_notes": "{count:number} sale note{{s}}"
 		},
+		"new_note_names": {
+			"sale": "Sale {workstation}",
+			"purchase": "Purchase {workstation}"
+		},
+		"workstation_default_name": "Workstation {n:number}",
 		"loading": "Loading"
 	},
 	"supplier_orders_page": {
@@ -980,6 +985,8 @@
 		},
 		"device_settings": {
 			"labels": {
+				"workstation_name": "Workstation name",
+				"workstation_name_description": "Used in the default name of notes created on this device",
 				"label_printer_url": "Label Printer URL",
 				"receipt_printer_url": "Receipt Printer URL",
 				"save_reload": "Save and Reload"

--- a/pkg/shared/src/i18n/en/index.ts
+++ b/pkg/shared/src/i18n/en/index.ts
@@ -653,6 +653,11 @@ const common = {
 		purchase_notes: "{count:number} purchase note{{s}}",
 		sale_notes: "{count:number} sale note{{s}}"
 	},
+	new_note_names: {
+		sale: "Sale {workstation}",
+		purchase: "Purchase {workstation}"
+	},
+	workstation_default_name: "Workstation {n:number}",
 	loading: "Loading"
 };
 const sale_note = {
@@ -1021,6 +1026,8 @@ const forms = {
 	},
 	device_settings: {
 		labels: {
+			workstation_name: "Workstation name",
+			workstation_name_description: "Used in the default name of notes created on this device",
 			label_printer_url: "Label Printer URL",
 			receipt_printer_url: "Receipt Printer URL",
 			save_reload: "Save and Reload"

--- a/pkg/shared/src/i18n/i18n-types.ts
+++ b/pkg/shared/src/i18n/i18n-types.ts
@@ -1443,6 +1443,23 @@ type RootTranslation = {
 			 */
 			sale_notes: RequiredParams<'count'>
 		}
+		new_note_names: {
+			/**
+			 * S​a​l​e​ ​{​w​o​r​k​s​t​a​t​i​o​n​}
+			 * @param {unknown} workstation
+			 */
+			sale: RequiredParams<'workstation'>
+			/**
+			 * P​u​r​c​h​a​s​e​ ​{​w​o​r​k​s​t​a​t​i​o​n​}
+			 * @param {unknown} workstation
+			 */
+			purchase: RequiredParams<'workstation'>
+		}
+		/**
+		 * W​o​r​k​s​t​a​t​i​o​n​ ​{​n​}
+		 * @param {number} n
+		 */
+		workstation_default_name: RequiredParams<'n'>
 		/**
 		 * L​o​a​d​i​n​g
 		 */
@@ -2772,6 +2789,14 @@ type RootTranslation = {
 		}
 		device_settings: {
 			labels: {
+				/**
+				 * W​o​r​k​s​t​a​t​i​o​n​ ​n​a​m​e
+				 */
+				workstation_name: string
+				/**
+				 * U​s​e​d​ ​i​n​ ​t​h​e​ ​d​e​f​a​u​l​t​ ​n​a​m​e​ ​o​f​ ​n​o​t​e​s​ ​c​r​e​a​t​e​d​ ​o​n​ ​t​h​i​s​ ​d​e​v​i​c​e
+				 */
+				workstation_name_description: string
 				/**
 				 * L​a​b​e​l​ ​P​r​i​n​t​e​r​ ​U​R​L
 				 */
@@ -4600,6 +4625,20 @@ export type TranslationFunctions = {
 			 */
 			sale_notes: (arg: { count: number }) => LocalizedString
 		}
+		new_note_names: {
+			/**
+			 * Sale {workstation}
+			 */
+			sale: (arg: { workstation: unknown }) => LocalizedString
+			/**
+			 * Purchase {workstation}
+			 */
+			purchase: (arg: { workstation: unknown }) => LocalizedString
+		}
+		/**
+		 * Workstation {n}
+		 */
+		workstation_default_name: (arg: { n: number }) => LocalizedString
 		/**
 		 * Loading
 		 */
@@ -5906,6 +5945,14 @@ export type TranslationFunctions = {
 		}
 		device_settings: {
 			labels: {
+				/**
+				 * Workstation name
+				 */
+				workstation_name: () => LocalizedString
+				/**
+				 * Used in the default name of notes created on this device
+				 */
+				workstation_name_description: () => LocalizedString
 				/**
 				 * Label Printer URL
 				 */

--- a/pkg/shared/src/i18n/it/index.json
+++ b/pkg/shared/src/i18n/it/index.json
@@ -514,6 +514,11 @@
 			"purchase_notes": "{count:number} not{{a|e}} di acquisto",
 			"sale_notes": "{count:number} not{{a|e}} di vendita"
 		},
+		"new_note_names": {
+			"sale": "Vendita {workstation}",
+			"purchase": "Acquisto {workstation}"
+		},
+		"workstation_default_name": "Postazione {n:number}",
 		"loading": "Caricamento"
 	},
 	"supplier_orders_page": {
@@ -980,6 +985,8 @@
 		},
 		"device_settings": {
 			"labels": {
+				"workstation_name": "Nome postazione",
+				"workstation_name_description": "Usato nel nome predefinito delle note create su questo dispositivo",
 				"label_printer_url": "URL Stampante Etichette",
 				"receipt_printer_url": "URL Stampante Ricevute",
 				"save_reload": "Salva e Ricarica"


### PR DESCRIPTION
New notes are now named after the workstation they're created on ("Sale Front desk", "Vendita Cassa") instead of the global "New Sale (2870)" counter. Each device gets a name: randomly generated on first use, stored in localStorage (never synced), editable on the settings page. Together with the per-site id blocks of #1273 this makes concurrent multi-device work legible: ids keep documents distinct, names make the origin readable at a glance. **One deliberate behavior change: the "(n)" suffix now counts only active (uncommitted) drafts**, so the counter restarts once same-named drafts are committed/renamed; committed notes in history are told apart by their timestamps, and the unbounded "(2870)"-style growth is gone.

## What changed

- New [`site workstation name`](https://github.com/librocco/librocco/blob/86d353658a3053df32642f83913a0330e94a45cd/apps/web-client/src/lib/utils/note-names.ts) flow: `deviceSettingsStore` gains `workstationName` (new field on the settings page, seeded lazily with a localized random default like "Workstation 374" / "Postazione 374").
- UI note creation passes a workstation-derived base name; [`getSeqNameForBase`](https://github.com/librocco/librocco/blob/86d353658a3053df32642f83913a0330e94a45cd/apps/web-client/src/lib/db/cr-sqlite/note.ts#L106-L131) suffixes it against active same-kind notes (LIKE-escaped, so names with `%`/`_` behave).
- i18n: `common.new_note_names.{sale,purchase}` and workstation settings labels in en/it/de.
- e2e seeds a deterministic workstation name ("Alpha") via `storageState`; naming-sequence specs rewritten to the new semantics; new `workstation_name.spec.ts` covers renaming via settings.

## Why it's correct

- The db-level create functions keep the legacy "New Sale (n)" naming when no base is passed, so API-level callers and existing tests are untouched; only UI creation paths opt in.
- Names are pure display data: no schema change, no sync impact (the workstation name itself never syncs; only the resulting note names do, like any display name).

## What this does NOT do

- Reconciliation notes keep their timestamp names; warehouse default names keep the legacy "New Warehouse (n)" sequence.
- Two devices left on the same default-random name would produce same-named (never same-id) notes; the settings field is the remedy.

## Tests

Unit: suffix scoping, active-only restart, inbound/outbound separation, LIKE-escaping ([note.test.ts](https://github.com/librocco/librocco/blob/86d353658a3053df32642f83913a0330e94a45cd/apps/web-client/src/lib/db/cr-sqlite/__tests__/note.test.ts)). E2E: rewritten naming-sequence specs + settings-rename flow, all passing locally (chromium).

---
Closes D-608

---
Stacked on #1273 (D-595 per-site id blocks); merges after it.
